### PR TITLE
chore: drop unrelated typo fixes per review feedback

### DIFF
--- a/contrib/linearize/example-linearize-testnet.cfg
+++ b/contrib/linearize/example-linearize-testnet.cfg
@@ -16,5 +16,5 @@ hashlist=hashlist.txt
 split_year=1
 genesis=00000bafbc94add76cb75e2ec92894837288a481e5c005f6563d91623bf8bc2c
 
-# Maximum size in bytes of out-of-order blocks cache in memory
+# Maxmimum size in bytes of out-of-order blocks cache in memory
 out_of_order_cache_sz = 10000000

--- a/src/evo/mnhftx.h
+++ b/src/evo/mnhftx.h
@@ -89,7 +89,7 @@ class CMNHFManager : public AbstractEHFManager
 {
 private:
     CEvoDB& m_evoDb;
-    // TODO: move its functionality of ProcessBlock, UndoBlock to specialtxman;
+    // TODO: move its functionallity of ProcessBlock, UndoBlock to specialtxman;
     // it will help to drop dependency on m_chainman, m_qman here (and validation.h)
     // Secondly, store in database active EHF signals not for each block;
     // but quite opposite: keep only hash of block where signal is added.


### PR DESCRIPTION
Drops the incidental typo corrections in `contrib/linearize/example-linearize-testnet.cfg` and `src/evo/mnhftx.h` that are outside the scope of this PR, per [knst's review](https://github.com/dashpay/dash/pull/7206#pullrequestreview-3927316280).