### PR TITLE
Merge Udjin's splash screen improvements

### DIFF
--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -400,6 +400,11 @@ public:
     using LoadWalletFn = std::function<void(std::unique_ptr<Wallet> wallet)>;
     virtual std::unique_ptr<Handler> handleLoadWallet(LoadWalletFn fn) = 0;
 
+    //! Register handler for wallet-loading messages. This callback is triggered
+    //! after a wallet object exists and can emit progress, but before startup
+    //! load work like AttachChain()/rescan necessarily completes.
+    virtual std::unique_ptr<Handler> handleLoadWalletLoading(LoadWalletFn fn) = 0;
+
     //! Return pointer to internal context, useful for testing.
     virtual wallet::WalletContext* context() { return nullptr; }
 };

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -265,16 +265,14 @@ bool SplashScreen::eventFilter(QObject * obj, QEvent * ev) {
 qreal SplashScreen::calcOverallProgress() const
 {
     if (curProgress >= 0) {
-        // Phase with real sub-progress: interpolate linearly within phase range
+        // When a phase reports real sub-progress, map that 0-100 value into the
+        // phase's assigned range directly.
         return phaseStart + (phaseEnd - phaseStart) * (curProgress / 100.0);
     }
-    // Phase without sub-progress: exponential approach toward phaseEnd
+    // Otherwise fall back to a time-based curve so phases driven only by
+    // initMessage() still show movement without claiming exact progress.
     qreal elapsed = phaseTimer.elapsed() / 1000.0;
-    // Long phases (rescan, wallet load) can take minutes/hours — use a very slow curve
-    // Normal phases: reaches ~90% of range in ~15s
-    // Long phases: reaches ~50% in ~2min, ~75% in ~5min
-    qreal tau = phaseIsLong ? 120.0 : 5.0;
-    qreal fraction = 1.0 - std::exp(-elapsed / tau);
+    qreal fraction = 1.0 - std::exp(-elapsed / 5.0);
     return phaseStart + (phaseEnd - phaseStart) * fraction * EXPONENTIAL_FILL_CAP;
 }
 
@@ -365,6 +363,9 @@ void SplashScreen::showMessage(const QString &message, int alignment, const QCol
     if (phase_changed) {
         m_current_phase = phase;
         m_current_phase_message = message;
+        // Progress values are phase-local; drop any numeric progress from the
+        // previous phase until a new ShowProgress update arrives.
+        curProgress = -1;
         if (phase->snapsToEnd) {
             // Final phase: snap to 100% immediately since the splash
             // will be destroyed moments after "Done loading" arrives
@@ -377,11 +378,9 @@ void SplashScreen::showMessage(const QString &message, int alignment, const QCol
             displayProgress = 0.0;
             phaseStart = phase->start;
             phaseEnd = phase->end;
-            phaseIsLong = true;
             animTimer.start(30);
         } else {
             // Normal phase: ensure we never jump backwards
-            phaseIsLong = false;
             phaseStart = std::max(phase->start, displayProgress);
             phaseEnd = std::max(phase->end, phaseStart);
         }

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -69,10 +69,17 @@ static const PhaseInfo PHASE_TABLE[] = {
  *  Uses contains() because ShowProgress may prepend the wallet name. */
 static const PhaseInfo* LookupPhase(const QString& message)
 {
-    for (const auto& phase : PHASE_TABLE) {
-        QString translated = QString::fromStdString(_(phase.msg_key).translated);
+    static const auto cache = [] {
+        std::vector<std::pair<const PhaseInfo*, QString>> phases_with_translations;
+        for (const auto& phase : PHASE_TABLE) {
+            phases_with_translations.push_back({&phase, QString::fromStdString(_(phase.msg_key).translated)});
+        }
+        return phases_with_translations;
+    }();
+
+    for (const auto& [phase, translated] : cache) {
         if (message.contains(translated, Qt::CaseInsensitive)) {
-            return &phase;
+            return phase;
         }
     }
     return nullptr;

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -307,15 +307,15 @@ void SplashScreen::subscribeToCoreSignals()
     m_handler_show_progress = m_node->handleShowProgress([this, color](const std::string& title, int nProgress, bool /*resume_possible*/) {
         PostMessageAndProgress(this, color, title, nProgress);
     });
-    m_handler_init_wallet = m_node->handleInitWallet([this]() { handleLoadWallet(); });
+    m_handler_init_wallet = m_node->handleInitWallet([this]() { handleLoadingWallet(); });
 }
 
-void SplashScreen::handleLoadWallet()
+void SplashScreen::handleLoadingWallet()
 {
 #ifdef ENABLE_WALLET
     if (!WalletModel::isWalletEnabled()) return;
     const QColor color = messageColor;
-    m_handler_load_wallet = m_node->walletLoader().handleLoadWallet([this, color](std::unique_ptr<interfaces::Wallet> wallet) {
+    m_handler_loading_wallet = m_node->walletLoader().handleLoadWalletLoading([this, color](std::unique_ptr<interfaces::Wallet> wallet) {
         m_connected_wallet_handlers.emplace_back(wallet->handleShowProgress([this, color](const std::string& title, int nProgress) {
             PostMessageAndProgress(this, color, title, nProgress);
         }));
@@ -331,8 +331,8 @@ void SplashScreen::unsubscribeFromCoreSignals()
     m_handler_show_progress->disconnect();
     m_handler_init_wallet->disconnect();
 #ifdef ENABLE_WALLET
-    if (m_handler_load_wallet != nullptr) {
-        m_handler_load_wallet->disconnect();
+    if (m_handler_loading_wallet != nullptr) {
+        m_handler_loading_wallet->disconnect();
     }
 #endif // ENABLE_WALLET
     for (const auto& handler : m_connected_wallet_handlers) {

--- a/src/qt/splashscreen.h
+++ b/src/qt/splashscreen.h
@@ -73,7 +73,6 @@ private:
     // Phase-based progress tracking
     qreal phaseStart{0.0};      // Overall progress at start of current phase
     qreal phaseEnd{0.0};        // Overall progress at end of current phase
-    bool phaseIsLong{false};    // True for long independent phases (rescan, wallet load)
     QElapsedTimer phaseTimer;    // Time since current phase started
     const struct PhaseInfo* m_current_phase{nullptr}; // Current phase (defined in splashscreen.cpp)
     QString m_current_phase_message;                   // Message that triggered current phase

--- a/src/qt/splashscreen.h
+++ b/src/qt/splashscreen.h
@@ -45,8 +45,8 @@ public Q_SLOTS:
     /** Set progress bar value (-1 = no sub-progress, 0-100 = phase sub-progress) */
     void setProgress(int value);
 
-    /** Handle wallet load notifications. */
-    void handleLoadWallet();
+    /** Handle early wallet-loading notifications so startup progress can be observed. */
+    void handleLoadingWallet();
 
 protected:
     bool eventFilter(QObject * obj, QEvent * ev) override;
@@ -85,7 +85,7 @@ private:
     std::unique_ptr<interfaces::Handler> m_handler_init_message;
     std::unique_ptr<interfaces::Handler> m_handler_show_progress;
     std::unique_ptr<interfaces::Handler> m_handler_init_wallet;
-    std::unique_ptr<interfaces::Handler> m_handler_load_wallet;
+    std::unique_ptr<interfaces::Handler> m_handler_loading_wallet;
     std::list<std::unique_ptr<interfaces::Wallet>> m_connected_wallets;
     std::list<std::unique_ptr<interfaces::Handler>> m_connected_wallet_handlers;
 };

--- a/src/wallet/context.h
+++ b/src/wallet/context.h
@@ -46,6 +46,7 @@ struct WalletContext {
     // this could introduce inconsistent lock ordering and cause deadlocks.
     Mutex wallets_mutex;
     std::vector<std::shared_ptr<CWallet>> wallets GUARDED_BY(wallets_mutex);
+    std::list<LoadWalletFn> wallet_loading_fns GUARDED_BY(wallets_mutex);
     std::list<LoadWalletFn> wallet_load_fns GUARDED_BY(wallets_mutex);
     interfaces::CoinJoin::Loader* coinjoin_loader{nullptr};
     // Some Dash RPCs rely on WalletContext yet access NodeContext members

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -792,6 +792,10 @@ public:
     {
         return HandleLoadWallet(m_context, std::move(fn));
     }
+    std::unique_ptr<Handler> handleLoadWalletLoading(LoadWalletFn fn) override
+    {
+        return HandleLoadWalletLoading(m_context, std::move(fn));
+    }
     WalletContext* context() override  { return &m_context; }
 
     WalletContext m_context;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -193,6 +193,21 @@ std::unique_ptr<interfaces::Handler> HandleLoadWallet(WalletContext& context, Lo
     return interfaces::MakeHandler([&context, it] { LOCK(context.wallets_mutex); context.wallet_load_fns.erase(it); });
 }
 
+std::unique_ptr<interfaces::Handler> HandleLoadWalletLoading(WalletContext& context, LoadWalletFn load_wallet)
+{
+    LOCK(context.wallets_mutex);
+    auto it = context.wallet_loading_fns.emplace(context.wallet_loading_fns.end(), std::move(load_wallet));
+    return interfaces::MakeHandler([&context, it] { LOCK(context.wallets_mutex); context.wallet_loading_fns.erase(it); });
+}
+
+void NotifyWalletLoading(WalletContext& context, const std::shared_ptr<CWallet>& wallet)
+{
+    LOCK(context.wallets_mutex);
+    for (auto& load_wallet : context.wallet_loading_fns) {
+        load_wallet(interfaces::MakeWallet(context, wallet));
+    }
+}
+
 void NotifyWalletLoaded(WalletContext& context, const std::shared_ptr<CWallet>& wallet)
 {
     LOCK(context.wallets_mutex);
@@ -3281,6 +3296,8 @@ std::shared_ptr<CWallet> CWallet::Create(WalletContext& context, const std::stri
 
     // Try to top up keypool. No-op if the wallet is locked.
     walletInstance->TopUpKeyPool();
+
+    NotifyWalletLoading(context, walletInstance);
 
     if (chain && !AttachChain(walletInstance, *chain, error, warnings)) {
         walletInstance->m_chain_notifications_handler.reset(); // Reset this pointer so that the wallet will actually be unloaded

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -76,7 +76,9 @@ std::shared_ptr<CWallet> GetWallet(WalletContext& context, const std::string& na
 std::shared_ptr<CWallet> LoadWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error, std::vector<bilingual_str>& warnings);
 std::shared_ptr<CWallet> CreateWallet(WalletContext& context, const std::string& name, std::optional<bool> load_on_start, DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error, std::vector<bilingual_str>& warnings);
 std::shared_ptr<CWallet> RestoreWallet(WalletContext& context, const fs::path& backup_file, const std::string& wallet_name, std::optional<bool> load_on_start, DatabaseStatus& status, bilingual_str& error, std::vector<bilingual_str>& warnings);
+std::unique_ptr<interfaces::Handler> HandleLoadWalletLoading(WalletContext& context, LoadWalletFn load_wallet);
 std::unique_ptr<interfaces::Handler> HandleLoadWallet(WalletContext& context, LoadWalletFn load_wallet);
+void NotifyWalletLoading(WalletContext& context, const std::shared_ptr<CWallet>& wallet);
 void NotifyWalletLoaded(WalletContext& context, const std::shared_ptr<CWallet>& wallet);
 std::unique_ptr<WalletDatabase> MakeWalletDatabase(const std::string& name, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error);
 


### PR DESCRIPTION
Merges UdjinM6's 3 commits from [pr-7210-attempt1](https://github.com/UdjinM6/dash/commits/pr-7210-attempt1/) on top of the existing splash screen work:

1. **`qt: show real wallet rescan progress on startup`** — Adds `NotifyWalletLoading` callback that fires before `AttachChain()`, allowing the splash to receive real rescan `ShowProgress` values instead of falling back to the fake exponential curve.
2. **`qt: simplify splash fallback progress state`** — Removes the now-unnecessary `phaseIsLong` flag and slow 120s tau curve; resets `curProgress = -1` on phase transitions.
3. **`qt: cache translated splash phase labels`** — Caches translated strings in a static lambda-initialized vector for minor perf improvement.

cc @UdjinM6