### PR TITLE
fix: restore coin control Qt build

### DIFF
--- a/src/qt/coincontroltreewidget.cpp
+++ b/src/qt/coincontroltreewidget.cpp
@@ -49,26 +49,26 @@ static bool isLeafItem(QTreeWidgetItem* item)
     return item && item->data(COLUMN_ADDRESS, Qt::UserRole).toString().length() == 64;
 }
 
-static bool isCheckboxClick(QTreeWidget* tree, QTreeWidgetItem* item, const QPoint& pos)
+bool CoinControlTreeWidget::isCheckboxClick(QTreeWidgetItem* item, const QPoint& pos) const
 {
     int COLUMN_CHECKBOX = 0;
 
-    if (!tree || !item || tree->columnAt(pos.x()) != COLUMN_CHECKBOX) {
+    if (!item || columnAt(pos.x()) != COLUMN_CHECKBOX) {
         return false;
     }
 
-    const QModelIndex index = tree->indexFromItem(item, COLUMN_CHECKBOX);
+    const QModelIndex index = indexFromItem(item, COLUMN_CHECKBOX);
     if (!index.isValid()) {
         return false;
     }
 
     QStyleOptionViewItem option;
-    option.initFrom(tree);
-    option.rect = tree->visualRect(index);
+    option.initFrom(this);
+    option.rect = visualRect(index);
     option.features = QStyleOptionViewItem::HasCheckIndicator;
     option.checkState = item->checkState(COLUMN_CHECKBOX);
 
-    return tree->style()->subElementRect(QStyle::SE_ItemViewItemCheckIndicator, &option, tree).contains(pos);
+    return style()->subElementRect(QStyle::SE_ItemViewItemCheckIndicator, &option, this).contains(pos);
 }
 
 void CoinControlTreeWidget::mouseReleaseEvent(QMouseEvent *event)
@@ -76,7 +76,7 @@ void CoinControlTreeWidget::mouseReleaseEvent(QMouseEvent *event)
     int COLUMN_CHECKBOX = 0;
 
     QTreeWidgetItem* clickedItem = itemAt(event->pos());
-    const bool isCheckboxInteraction = isCheckboxClick(this, clickedItem, event->pos());
+    const bool isCheckboxInteraction = isCheckboxClick(clickedItem, event->pos());
 
     bool isShiftClick = (event->button() == Qt::LeftButton)
                         && (event->modifiers() & Qt::ShiftModifier)

--- a/src/qt/coincontroltreewidget.h
+++ b/src/qt/coincontroltreewidget.h
@@ -22,6 +22,8 @@ protected:
     void mouseReleaseEvent(QMouseEvent *event) override;
 
 private:
+    bool isCheckboxClick(QTreeWidgetItem* item, const QPoint& pos) const;
+
     QTreeWidgetItem* m_lastClickedItem{nullptr};
 };
 


### PR DESCRIPTION
# Restore coin-control Qt build

## Summary

- Move the coin-control checkbox hit-test helper into
  `CoinControlTreeWidget`.
- Keep the same checkbox-column and check-indicator hit testing while allowing
  access to protected `QTreeWidget::indexFromItem`.
- Leave the conflict-prediction workflow alone; the relevant upstream workflow
  fix is already on `develop`.

## Validation

- Reproduced the original Qt build failure against the pre-fix code path:
  protected `QTreeWidget::indexFromItem` access from a free helper.
- Ran a targeted `-fsyntax-only` compile of
  `src/qt/coincontroltreewidget.cpp` after the fix with local Qt5 headers:
  passed.
- Ran the pre-PR `code-review` gate for
  `6b5a5553bf6fb3e60acb734ec86d3c2def06166c..fcb84c34345c76c1b6325f0e3bf3e13a69a03b23`:
  `ship`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements to the coin control tree widget implementation with no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PastaPastaPasta/dash/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->