### PR TITLE
test: keep asset lock batch mempool sync

### DIFF
--- a/test/functional/feature_asset_locks.py
+++ b/test/functional/feature_asset_locks.py
@@ -253,14 +253,14 @@ class AssetLocksTest(DashTestFramework):
         except JSONRPCException as e:
             assert expected_error in e.error['message']
 
-    def generate_batch(self, count, sync_fun=None):
+    def generate_batch(self, count):
         self.log.info(f"Generate {count} blocks")
         while count > 0:
             self.log.info(f"Generating batch of blocks {count} left")
             batch = min(50, count)
             count -= batch
             self.bump_mocktime(10 * 60 + 1)
-            self.generate(self.nodes[1], batch, sync_fun=sync_fun)
+            self.generate(self.nodes[1], batch)
 
     # This functional test intentionally setup only 2 MN and only 2 Evo nodes
     # to ensure that corner case of quorum with minimum amount of nodes as possible
@@ -474,7 +474,7 @@ class AssetLocksTest(DashTestFramework):
         for inode in self.nodes:
             inode.invalidateblock(block_asset_unlock)
         self.validate_credit_pool_balance(locked)
-        self.generate_batch(25, sync_fun=lambda: self.sync_blocks())
+        self.generate_batch(25)
         self.validate_credit_pool_balance(locked)
         for inode in self.nodes:
             inode.reconsiderblock(block_to_reconsider)


### PR DESCRIPTION
# PR 7411 Review Follow-Up

## Issue Being Fixed Or Feature Implemented

Follow-up for knst's review feedback on dashpay/dash#7411:
<https://github.com/dashpay/dash/pull/7411#discussion_r3539014464>

## What Was Done

Reverted the asset-lock reorg padding change back to `generate_batch(25)` and
removed the now-unused `generate_batch(sync_fun=...)` plumbing.

## How Has This Been Tested

- `git diff --check`
- `python3 -m py_compile test/functional/feature_asset_locks.py`

```text
python3 test/functional/feature_asset_locks.py \
  --configfile=/Users/claw/Projects/dash/test/config.ini \
  --tmpdir=/private/tmp/dash_pr7411_knst_sync \
  --portseed=7411 \
  --timeout-factor=4
```

## Breaking Changes

None.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
