### PR TITLE
backport: bitcoin#25494 index interface decoupling

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1286,6 +1286,7 @@ libdashkernel_la_SOURCES = \
   init/common.cpp \
   instantsend/db.cpp \
   instantsend/instantsend.cpp \
+  kernel/chain.cpp \
   kernel/checks.cpp \
   kernel/coinstats.cpp \
   kernel/context.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -279,6 +279,7 @@ BITCOIN_CORE_H = \
   interfaces/node.h \
   interfaces/wallet.h \
   kernel/blockmanager_opts.h \
+  kernel/chain.h \
   kernel/chainstatemanager_opts.h \
   kernel/checks.h \
   kernel/coinstats.h \
@@ -562,6 +563,7 @@ libbitcoin_node_a_SOURCES = \
   instantsend/lock.cpp \
   instantsend/net_instantsend.cpp \
   instantsend/signing.cpp \
+  kernel/chain.cpp \
   kernel/checks.cpp \
   kernel/coinstats.cpp \
   kernel/context.cpp \

--- a/src/index/addressindex.cpp
+++ b/src/index/addressindex.cpp
@@ -13,6 +13,7 @@
 #include <tinyformat.h>
 #include <undo.h>
 #include <util/system.h>
+#include <validation.h>
 
 constexpr uint8_t DB_ADDRESSINDEX{'a'};
 constexpr uint8_t DB_ADDRESSUNSPENTINDEX{'u'};
@@ -170,7 +171,7 @@ AddressIndex::~AddressIndex() = default;
 bool AddressIndex::CustomAppend(const interfaces::BlockInfo& block)
 {
     assert(block.data);
-    const CBlockIndex* pindex = m_chainstate->m_blockman.LookupBlockIndex(block.hash);
+    const CBlockIndex* pindex = WITH_LOCK(cs_main, return m_chainstate->m_blockman.LookupBlockIndex(block.hash));
     assert(pindex);
     // Skip genesis block (no inputs to index)
     if (pindex->nHeight == 0) {
@@ -273,6 +274,7 @@ bool AddressIndex::CustomAppend(const interfaces::BlockInfo& block)
 
 bool AddressIndex::CustomRewind(const interfaces::BlockKey& current_tip_key, const interfaces::BlockKey& new_tip_key)
 {
+    LOCK(cs_main);
     const CBlockIndex* current_tip = m_chainstate->m_blockman.LookupBlockIndex(current_tip_key.hash);
     const CBlockIndex* new_tip = m_chainstate->m_blockman.LookupBlockIndex(new_tip_key.hash);
     assert(current_tip && new_tip);

--- a/src/index/addressindex.cpp
+++ b/src/index/addressindex.cpp
@@ -167,8 +167,11 @@ AddressIndex::AddressIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_ca
 
 AddressIndex::~AddressIndex() = default;
 
-bool AddressIndex::WriteBlock(const CBlock& block, const CBlockIndex* pindex)
+bool AddressIndex::CustomAppend(const interfaces::BlockInfo& block)
 {
+    assert(block.data);
+    const CBlockIndex* pindex = m_chainstate->m_blockman.LookupBlockIndex(block.hash);
+    assert(pindex);
     // Skip genesis block (no inputs to index)
     if (pindex->nHeight == 0) {
         return true;
@@ -186,13 +189,13 @@ bool AddressIndex::WriteBlock(const CBlock& block, const CBlockIndex* pindex)
 
     // Process each non-coinbase transaction
     // blockundo.vtxundo[i] corresponds to block.vtx[i+1] (coinbase is skipped in undo data)
-    if (blockundo.vtxundo.size() != block.vtx.size() - 1) {
+    if (blockundo.vtxundo.size() != block.data->vtx.size() - 1) {
         return error("%s: Undo data size mismatch for block %s (expected %zu, got %zu)", __func__,
-                     pindex->GetBlockHash().ToString(), block.vtx.size() - 1, blockundo.vtxundo.size());
+                     pindex->GetBlockHash().ToString(), block.data->vtx.size() - 1, blockundo.vtxundo.size());
     }
 
     for (size_t i = 0; i < blockundo.vtxundo.size(); i++) {
-        const CTransactionRef& tx = block.vtx[i + 1]; // +1 to skip coinbase
+        const CTransactionRef& tx = block.data->vtx[i + 1]; // +1 to skip coinbase
         const CTxUndo& txundo = blockundo.vtxundo[i];
         const uint256 txhash = tx->GetHash();
 
@@ -245,7 +248,7 @@ bool AddressIndex::WriteBlock(const CBlock& block, const CBlockIndex* pindex)
     }
 
     // Also process coinbase outputs (receiving activity only)
-    const CTransactionRef& coinbase = block.vtx[0];
+    const CTransactionRef& coinbase = block.data->vtx[0];
     const uint256 coinbase_hash = coinbase->GetHash();
     for (size_t k = 0; k < coinbase->vout.size(); k++) {
         const CTxOut& out = coinbase->vout[k];

--- a/src/index/addressindex.cpp
+++ b/src/index/addressindex.cpp
@@ -159,7 +159,8 @@ bool AddressIndex::DB::RewindBatch(const std::vector<CAddressIndexEntry>& addres
     return CDBWrapper::WriteBatch(batch);
 }
 
-AddressIndex::AddressIndex(size_t n_cache_size, bool f_memory, bool f_wipe) :
+AddressIndex::AddressIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory, bool f_wipe) :
+    BaseIndex(std::move(chain)),
     m_db(std::make_unique<AddressIndex::DB>(n_cache_size, f_memory, f_wipe))
 {
 }

--- a/src/index/addressindex.cpp
+++ b/src/index/addressindex.cpp
@@ -271,8 +271,11 @@ bool AddressIndex::CustomAppend(const interfaces::BlockInfo& block)
     return m_db->WriteBatch(addressIndex, addressUnspentIndex);
 }
 
-bool AddressIndex::Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip)
+bool AddressIndex::CustomRewind(const interfaces::BlockKey& current_tip_key, const interfaces::BlockKey& new_tip_key)
 {
+    const CBlockIndex* current_tip = m_chainstate->m_blockman.LookupBlockIndex(current_tip_key.hash);
+    const CBlockIndex* new_tip = m_chainstate->m_blockman.LookupBlockIndex(new_tip_key.hash);
+    assert(current_tip && new_tip);
     assert(current_tip->GetAncestor(new_tip->nHeight) == new_tip);
 
     // Rewind the unspent index by processing blocks in reverse
@@ -392,7 +395,7 @@ bool AddressIndex::Rewind(const CBlockIndex* current_tip, const CBlockIndex* new
     }
 
     // Call base class Rewind to update the best block pointer
-    return BaseIndex::Rewind(current_tip, new_tip);
+    return true;
 }
 
 BaseIndex::DB& AddressIndex::GetDB() const { return *m_db; }

--- a/src/index/addressindex.h
+++ b/src/index/addressindex.h
@@ -73,7 +73,7 @@ protected:
 
 public:
     /// Constructs the index, which becomes available to be queried
-    explicit AddressIndex(size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+    explicit AddressIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
 
     /// Destructor
     virtual ~AddressIndex() override;

--- a/src/index/addressindex.h
+++ b/src/index/addressindex.h
@@ -65,7 +65,7 @@ protected:
     bool CustomAppend(const interfaces::BlockInfo& block) override;
 
     /// Custom rewind to handle both transaction history and unspent index
-    bool Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip) override;
+    bool CustomRewind(const interfaces::BlockKey& current_tip, const interfaces::BlockKey& new_tip) override;
 
     BaseIndex::DB& GetDB() const override;
 

--- a/src/index/addressindex.h
+++ b/src/index/addressindex.h
@@ -62,7 +62,7 @@ protected:
     bool AllowPrune() const override { return false; }
 
     /// Write block data to the index databases
-    bool WriteBlock(const CBlock& block, const CBlockIndex* pindex) override;
+    bool CustomAppend(const interfaces::BlockInfo& block) override;
 
     /// Custom rewind to handle both transaction history and unspent index
     bool Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip) override;

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -5,6 +5,7 @@
 #include <chainparams.h>
 #include <index/base.h>
 #include <interfaces/chain.h>
+#include <kernel/chain.h>
 #include <node/blockstorage.h>
 #include <node/context.h>
 #include <node/interface_ui.h>
@@ -169,12 +170,15 @@ void BaseIndex::ThreadSync()
             }
 
             CBlock block;
+            interfaces::BlockInfo block_info = kernel::MakeBlockInfo(pindex);
             if (!ReadBlockFromDisk(block, pindex, consensus_params)) {
                 FatalError("%s: Failed to read block %s from disk",
                            __func__, pindex->GetBlockHash().ToString());
                 return;
+            } else {
+                block_info.data = &block;
             }
-            if (!WriteBlock(block, pindex)) {
+            if (!CustomAppend(block_info)) {
                 FatalError("%s: Failed to write block %s to index database",
                            __func__, pindex->GetBlockHash().ToString());
                 return;
@@ -276,8 +280,8 @@ void BaseIndex::BlockConnected(const std::shared_ptr<const CBlock>& block, const
             return;
         }
     }
-
-    if (WriteBlock(*block, pindex)) {
+    interfaces::BlockInfo block_info = kernel::MakeBlockInfo(pindex, block.get());
+    if (CustomAppend(block_info)) {
         // Setting the best block index is intentionally the last step of this
         // function, so BlockUntilSyncedToCurrentChain callers waiting for the
         // best block index to be updated can rely on the block being fully

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -233,6 +233,10 @@ bool BaseIndex::Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_ti
     assert(current_tip == m_best_block_index);
     assert(current_tip->GetAncestor(new_tip->nHeight) == new_tip);
 
+    if (!CustomRewind({current_tip->GetBlockHash(), current_tip->nHeight}, {new_tip->GetBlockHash(), new_tip->nHeight})) {
+        return false;
+    }
+
     // In the case of a reorg, ensure persisted block locator is not stale.
     // Pruning has a minimum of 288 blocks-to-keep and getting the index
     // out of sync may be possible but a users fault.

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -4,7 +4,9 @@
 
 #include <chainparams.h>
 #include <index/base.h>
+#include <interfaces/chain.h>
 #include <node/blockstorage.h>
+#include <node/context.h>
 #include <node/interface_ui.h>
 #include <shutdown.h>
 #include <tinyformat.h>
@@ -48,6 +50,9 @@ void BaseIndex::DB::WriteBestBlock(CDBBatch& batch, const CBlockLocator& locator
 {
     batch.Write(DB_BEST_BLOCK, locator);
 }
+
+BaseIndex::BaseIndex(std::unique_ptr<interfaces::Chain> chain)
+    : m_chain{std::move(chain)} {}
 
 BaseIndex::~BaseIndex()
 {
@@ -377,9 +382,11 @@ void BaseIndex::Interrupt()
     m_interrupt();
 }
 
-bool BaseIndex::Start(CChainState& active_chainstate)
+bool BaseIndex::Start()
 {
-    m_chainstate = &active_chainstate;
+    // m_chainstate member gives indexing code access to node internals. It is
+    // removed in followup https://github.com/bitcoin/bitcoin/pull/24230
+    m_chainstate = &m_chain->context()->chainman->ActiveChainstate();
     // Need to register this ValidationInterface before running Init(), so that
     // callbacks are not missed if Init sets m_synced to true.
     RegisterValidationInterface(this);

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -34,6 +34,15 @@ void BaseIndex::FatalErrorImpl(const std::string& message)
     StartShutdown();
 }
 
+CBlockLocator GetLocator(interfaces::Chain& chain, const uint256& block_hash)
+{
+    CBlockLocator locator;
+    bool found = chain.findBlock(block_hash, interfaces::FoundBlock().locator(locator));
+    assert(found);
+    assert(!locator.IsNull());
+    return locator;
+}
+
 BaseIndex::DB::DB(const fs::path& path, size_t n_cache_size, bool f_memory, bool f_wipe, bool f_obfuscate) :
     CDBWrapper(path, n_cache_size, f_memory, f_wipe, f_obfuscate)
 {}
@@ -209,22 +218,20 @@ void BaseIndex::ThreadSync()
 
 bool BaseIndex::Commit()
 {
-    CDBBatch batch(GetDB());
-    if (!CommitInternal(batch) || !GetDB().WriteBatch(batch)) {
-        return error("%s: Failed to commit latest %s state", __func__, GetName());
-    }
-    return true;
-}
-
-bool BaseIndex::CommitInternal(CDBBatch& batch)
-{
-    LOCK(cs_main);
     // Don't commit anything if we haven't indexed any block yet
     // (this could happen if init is interrupted).
-    if (m_best_block_index == nullptr) {
-        return false;
+    bool ok = m_best_block_index != nullptr;
+    if (ok) {
+        CDBBatch batch(GetDB());
+        ok = CustomCommit(batch);
+        if (ok) {
+            GetDB().WriteBestBlock(batch, GetLocator(*m_chain, m_best_block_index.load()->GetBlockHash()));
+            ok = GetDB().WriteBatch(batch);
+        }
     }
-    GetDB().WriteBestBlock(batch, m_chainstate->m_chain.GetLocator(m_best_block_index));
+    if (!ok) {
+        return error("%s: Failed to commit latest %s state", __func__, GetName());
+    }
     return true;
 }
 

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -390,7 +390,10 @@ bool BaseIndex::Start()
     // Need to register this ValidationInterface before running Init(), so that
     // callbacks are not missed if Init sets m_synced to true.
     RegisterValidationInterface(this);
-    if (!Init()) {
+    if (!Init()) return false;
+
+    const CBlockIndex* index = m_best_block_index.load();
+    if (!CustomInit(index ? std::make_optional(interfaces::BlockKey{index->GetBlockHash(), index->nHeight}) : std::nullopt)) {
         return false;
     }
 

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -90,6 +90,9 @@ private:
     /// getting corrupted.
     bool Commit();
 
+    /// Loop over disconnected blocks and call CustomRewind.
+    bool Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip);
+
     virtual bool AllowPrune() const = 0;
 
 protected:
@@ -114,7 +117,7 @@ protected:
 
     /// Rewind index to an earlier chain tip during a chain reorg. The tip must
     /// be an ancestor of the current best block.
-    virtual bool Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip);
+    [[nodiscard]] virtual bool CustomRewind(const interfaces::BlockKey& current_tip, const interfaces::BlockKey& new_tip) { return true; }
 
     virtual DB& GetDB() const = 0;
 

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -8,6 +8,7 @@
 #include <dbwrapper.h>
 #include <tinyformat.h>
 #include <util/threadinterrupt.h>
+#include <interfaces/chain.h>
 #include <validationinterface.h>
 
 #include <atomic>
@@ -15,6 +16,9 @@
 class CBlock;
 class CBlockIndex;
 class CChainState;
+namespace interfaces {
+class Chain;
+} // namespace interfaces
 
 struct IndexSummary {
     std::string name;
@@ -86,6 +90,7 @@ private:
     virtual bool AllowPrune() const = 0;
 
 protected:
+    std::unique_ptr<interfaces::Chain> m_chain;
     CChainState* m_chainstate{nullptr};
 
     void BlockConnected(const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindex) override;
@@ -128,6 +133,7 @@ protected:
     void SetBestBlockIndex(const CBlockIndex* block);
 
 public:
+    BaseIndex(std::unique_ptr<interfaces::Chain> chain);
     /// Destructor interrupts sync thread if running and blocks until it exits.
     virtual ~BaseIndex();
 
@@ -142,7 +148,7 @@ public:
 
     /// Start initializes the sync state and registers the instance as a
     /// ValidationInterface so that it stays in sync with blockchain updates.
-    [[nodiscard]] bool Start(CChainState& active_chainstate);
+    [[nodiscard]] bool Start();
 
     /// Stops the instance from staying in sync with blockchain updates.
     void Stop();

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -70,6 +70,9 @@ private:
     std::thread m_thread_sync;
     CThreadInterrupt m_interrupt;
 
+    /// Read best block locator and check that data needed to sync has not been pruned.
+    bool Init();
+
     /// Sync the index with the block index starting from the current best block.
     /// Intended to be run in its own thread, m_thread_sync, and can be
     /// interrupted with m_interrupt. Once the index gets in sync, the m_synced
@@ -99,10 +102,8 @@ protected:
 
     void ChainStateFlushed(const CBlockLocator& locator) override;
 
-    const CBlockIndex* CurrentIndex() { return m_best_block_index.load(); };
-
     /// Initialize internal state from the database and block index.
-    [[nodiscard]] virtual bool Init();
+    [[nodiscard]] virtual bool CustomInit(const std::optional<interfaces::BlockKey>& block) { return true; }
 
     /// Write update index entries for a newly connected block.
     virtual bool WriteBlock(const CBlock& block, const CBlockIndex* pindex) { return true; }

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -106,7 +106,7 @@ protected:
     [[nodiscard]] virtual bool CustomInit(const std::optional<interfaces::BlockKey>& block) { return true; }
 
     /// Write update index entries for a newly connected block.
-    virtual bool WriteBlock(const CBlock& block, const CBlockIndex* pindex) { return true; }
+    [[nodiscard]] virtual bool CustomAppend(const interfaces::BlockInfo& block) { return true; }
 
     /// Virtual method called internally by Commit that can be overridden to atomically
     /// commit more index state.

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -113,7 +113,7 @@ protected:
 
     /// Virtual method called internally by Commit that can be overridden to atomically
     /// commit more index state.
-    virtual bool CommitInternal(CDBBatch& batch);
+    virtual bool CustomCommit(CDBBatch& batch) { return true; }
 
     /// Rewind index to an earlier chain tip during a chain reorg. The tip must
     /// be an ancestor of the current best block.

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -101,9 +101,9 @@ struct DBHashKey {
 
 static std::map<BlockFilterType, BlockFilterIndex> g_filter_indexes;
 
-BlockFilterIndex::BlockFilterIndex(BlockFilterType filter_type,
+BlockFilterIndex::BlockFilterIndex(std::unique_ptr<interfaces::Chain> chain, BlockFilterType filter_type,
                                    size_t n_cache_size, bool f_memory, bool f_wipe)
-    : m_filter_type(filter_type)
+    : BaseIndex(std::move(chain)), m_filter_type(filter_type)
 {
     const std::string& filter_name = BlockFilterTypeName(filter_type);
     if (filter_name.empty()) throw std::invalid_argument("unknown filter_type");
@@ -500,12 +500,12 @@ void ForEachBlockFilterIndex(std::function<void (BlockFilterIndex&)> fn)
     for (auto& entry : g_filter_indexes) fn(entry.second);
 }
 
-bool InitBlockFilterIndex(BlockFilterType filter_type,
+bool InitBlockFilterIndex(std::function<std::unique_ptr<interfaces::Chain>()> make_chain, BlockFilterType filter_type,
                           size_t n_cache_size, bool f_memory, bool f_wipe)
 {
     auto result = g_filter_indexes.emplace(std::piecewise_construct,
                                            std::forward_as_tuple(filter_type),
-                                           std::forward_as_tuple(filter_type,
+                                           std::forward_as_tuple(make_chain(), filter_type,
                                                                  n_cache_size, f_memory, f_wipe));
     return result.second;
 }

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -10,6 +10,7 @@
 #include <node/blockstorage.h>
 #include <serialize.h>
 #include <util/system.h>
+#include <validation.h>
 
 using node::UndoReadFromDisk;
 
@@ -247,22 +248,25 @@ size_t BlockFilterIndex::WriteFilterToDisk(FlatFilePos& pos, const BlockFilter& 
     return data_size;
 }
 
-bool BlockFilterIndex::WriteBlock(const CBlock& block, const CBlockIndex* pindex)
+bool BlockFilterIndex::CustomAppend(const interfaces::BlockInfo& block)
 {
     CBlockUndo block_undo;
     uint256 prev_header;
 
-    if (pindex->nHeight > 0) {
+    if (block.height > 0) {
+        // pindex variable gives indexing code access to node internals. It
+        // will be removed in upcoming commit
+        const CBlockIndex* pindex = WITH_LOCK(cs_main, return m_chainstate->m_blockman.LookupBlockIndex(block.hash));
         if (!UndoReadFromDisk(block_undo, pindex)) {
             return false;
         }
 
         std::pair<uint256, DBVal> read_out;
-        if (!m_db->Read(DBHeightKey(pindex->nHeight - 1), read_out)) {
+        if (!m_db->Read(DBHeightKey(block.height - 1), read_out)) {
             return false;
         }
 
-        uint256 expected_block_hash = pindex->pprev->GetBlockHash();
+        uint256 expected_block_hash = *Assert(block.prev_hash);
         if (read_out.first != expected_block_hash) {
             return error("%s: previous block header belongs to unexpected block %s; expected %s",
                          __func__, read_out.first.ToString(), expected_block_hash.ToString());
@@ -271,18 +275,18 @@ bool BlockFilterIndex::WriteBlock(const CBlock& block, const CBlockIndex* pindex
         prev_header = read_out.second.header;
     }
 
-    BlockFilter filter(m_filter_type, block, block_undo);
+    BlockFilter filter(m_filter_type, *Assert(block.data), block_undo);
 
     size_t bytes_written = WriteFilterToDisk(m_next_filter_pos, filter);
     if (bytes_written == 0) return false;
 
     std::pair<uint256, DBVal> value;
-    value.first = pindex->GetBlockHash();
+    value.first = block.hash;
     value.second.hash = filter.GetHash();
     value.second.header = filter.ComputeHeader(prev_header);
     value.second.pos = m_next_filter_pos;
 
-    if (!m_db->Write(DBHeightKey(pindex->nHeight), value)) {
+    if (!m_db->Write(DBHeightKey(block.height), value)) {
         return false;
     }
 

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -158,7 +158,7 @@ bool BlockFilterIndex::CustomInit(const std::optional<interfaces::BlockKey>& blo
     return true;
 }
 
-bool BlockFilterIndex::CommitInternal(CDBBatch& batch)
+bool BlockFilterIndex::CustomCommit(CDBBatch& batch)
 {
     const FlatFilePos& pos = m_next_filter_pos;
 
@@ -177,7 +177,7 @@ bool BlockFilterIndex::CommitInternal(CDBBatch& batch)
     }
 
     batch.Write(DB_FILTER_POS, pos);
-    return BaseIndex::CommitInternal(batch);
+    return true;
 }
 
 bool BlockFilterIndex::ReadFilterFromDisk(const FlatFilePos& pos, const uint256& hash, BlockFilter& filter) const

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -320,17 +320,15 @@ bool BlockFilterIndex::CustomAppend(const interfaces::BlockInfo& block)
     return true;
 }
 
-bool BlockFilterIndex::Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip)
+bool BlockFilterIndex::CustomRewind(const interfaces::BlockKey& current_tip, const interfaces::BlockKey& new_tip)
 {
-    assert(current_tip->GetAncestor(new_tip->nHeight) == new_tip);
-
     CDBBatch batch(*m_db);
     std::unique_ptr<CDBIterator> db_it(m_db->NewIterator());
 
     // During a reorg, we need to copy all filters for blocks that are getting disconnected from the
     // height index to the hash index so we can still find them when the height index entries are
     // overwritten.
-    if (!CopyHeightIndexToHashIndex(*db_it, batch, m_name, new_tip->nHeight, current_tip->nHeight)) {
+    if (!CopyHeightIndexToHashIndex(*db_it, batch, m_name, new_tip.height, current_tip.height)) {
         return false;
     }
 
@@ -340,7 +338,7 @@ bool BlockFilterIndex::Rewind(const CBlockIndex* current_tip, const CBlockIndex*
     batch.Write(DB_FILTER_POS, m_next_filter_pos);
     if (!m_db->WriteBatch(batch)) return false;
 
-    return BaseIndex::Rewind(current_tip, new_tip);
+    return true;
 }
 
 static bool LookupOne(const CDBWrapper& db, const CBlockIndex* block_index, DBVal& result)

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -127,7 +127,7 @@ BlockFilterIndex::BlockFilterIndex(std::unique_ptr<interfaces::Chain> chain, Blo
     m_filter_fileseq = std::make_unique<FlatFileSeq>(std::move(path), "fltr", FLTR_FILE_CHUNK_SIZE);
 }
 
-bool BlockFilterIndex::Init()
+bool BlockFilterIndex::CustomInit(const std::optional<interfaces::BlockKey>& block)
 {
     // Check version compatibility first
     int version = 0;
@@ -154,7 +154,7 @@ bool BlockFilterIndex::Init()
         m_next_filter_pos.nFile = 0;
         m_next_filter_pos.nPos = 0;
     }
-    return BaseIndex::Init();
+    return true;
 }
 
 bool BlockFilterIndex::CommitInternal(CDBBatch& batch)

--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -47,7 +47,7 @@ private:
     bool AllowPrune() const override { return true; }
 
 protected:
-    bool Init() override;
+    bool CustomInit(const std::optional<interfaces::BlockKey>& block) override;
 
     bool CommitInternal(CDBBatch& batch) override;
 

--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -61,7 +61,7 @@ protected:
 
 public:
     /** Constructs the index, which becomes available to be queried. */
-    explicit BlockFilterIndex(BlockFilterType filter_type,
+    explicit BlockFilterIndex(std::unique_ptr<interfaces::Chain> chain, BlockFilterType filter_type,
                               size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
 
     BlockFilterType GetFilterType() const { return m_filter_type; }
@@ -94,7 +94,7 @@ void ForEachBlockFilterIndex(std::function<void (BlockFilterIndex&)> fn);
  * Initialize a block filter index for the given type if one does not already exist. Returns true if
  * a new index is created and false if one has already been initialized.
  */
-bool InitBlockFilterIndex(BlockFilterType filter_type,
+bool InitBlockFilterIndex(std::function<std::unique_ptr<interfaces::Chain>()> make_chain, BlockFilterType filter_type,
                           size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
 
 /**

--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -49,7 +49,7 @@ private:
 protected:
     bool CustomInit(const std::optional<interfaces::BlockKey>& block) override;
 
-    bool CommitInternal(CDBBatch& batch) override;
+    bool CustomCommit(CDBBatch& batch) override;
 
     bool CustomAppend(const interfaces::BlockInfo& block) override;
 

--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -51,7 +51,7 @@ protected:
 
     bool CommitInternal(CDBBatch& batch) override;
 
-    bool WriteBlock(const CBlock& block, const CBlockIndex* pindex) override;
+    bool CustomAppend(const interfaces::BlockInfo& block) override;
 
     bool Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip) override;
 

--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -53,7 +53,7 @@ protected:
 
     bool CustomAppend(const interfaces::BlockInfo& block) override;
 
-    bool Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip) override;
+    bool CustomRewind(const interfaces::BlockKey& current_tip, const interfaces::BlockKey& new_tip) override;
 
     BaseIndex::DB& GetDB() const LIFETIMEBOUND override { return *m_db; }
 

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -391,12 +391,12 @@ bool CoinStatsIndex::CustomInit(const std::optional<interfaces::BlockKey>& block
     return true;
 }
 
-bool CoinStatsIndex::CommitInternal(CDBBatch& batch)
+bool CoinStatsIndex::CustomCommit(CDBBatch& batch)
 {
     // DB_MUHASH should always be committed in a batch together with DB_BEST_BLOCK
     // to prevent an inconsistent state of the DB.
     batch.Write(DB_MUHASH, m_muhash);
-    return BaseIndex::CommitInternal(batch);
+    return true;
 }
 
 // Reverse a single block as part of a reorg

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -104,7 +104,8 @@ struct DBHashKey {
 
 std::unique_ptr<CoinStatsIndex> g_coin_stats_index;
 
-CoinStatsIndex::CoinStatsIndex(size_t n_cache_size, bool f_memory, bool f_wipe)
+CoinStatsIndex::CoinStatsIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory, bool f_wipe)
+    : BaseIndex(std::move(chain))
 {
     fs::path path{gArgs.GetDataDirNet() / "indexes" / "coinstats"};
     fs::create_directories(path);

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -299,23 +299,23 @@ bool CoinStatsIndex::Rewind(const CBlockIndex* current_tip, const CBlockIndex* n
     return BaseIndex::Rewind(current_tip, new_tip);
 }
 
-static bool LookUpOne(const CDBWrapper& db, const CBlockIndex* block_index, DBVal& result)
+static bool LookUpOne(const CDBWrapper& db, const interfaces::BlockKey& block, DBVal& result)
 {
     // First check if the result is stored under the height index and the value
     // there matches the block hash. This should be the case if the block is on
     // the active chain.
     std::pair<uint256, DBVal> read_out;
-    if (!db.Read(DBHeightKey(block_index->nHeight), read_out)) {
+    if (!db.Read(DBHeightKey(block.height), read_out)) {
         return false;
     }
-    if (read_out.first == block_index->GetBlockHash()) {
+    if (read_out.first == block.hash) {
         result = std::move(read_out.second);
         return true;
     }
 
     // If value at the height index corresponds to an different block, the
     // result will be stored in the hash index.
-    return db.Read(DBHashKey(block_index->GetBlockHash()), result);
+    return db.Read(DBHashKey(block.hash), result);
 }
 
 std::optional<CCoinsStats> CoinStatsIndex::LookUpStats(const CBlockIndex* block_index) const
@@ -324,7 +324,7 @@ std::optional<CCoinsStats> CoinStatsIndex::LookUpStats(const CBlockIndex* block_
     stats.index_used = true;
 
     DBVal entry;
-    if (!LookUpOne(*m_db, block_index, entry)) {
+    if (!LookUpOne(*m_db, {block_index->GetBlockHash(), block_index->nHeight}, entry)) {
         return std::nullopt;
     }
 
@@ -363,7 +363,7 @@ bool CoinStatsIndex::Init()
 
     if (pindex) {
         DBVal entry;
-        if (!LookUpOne(*m_db, pindex, entry)) {
+        if (!LookUpOne(*m_db, {pindex->GetBlockHash(), pindex->nHeight}, entry)) {
             return error("%s: Cannot read current %s state; index may be corrupted",
                             __func__, GetName());
         }

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -345,7 +345,7 @@ std::optional<CCoinsStats> CoinStatsIndex::LookUpStats(const CBlockIndex* block_
     return stats;
 }
 
-bool CoinStatsIndex::Init()
+bool CoinStatsIndex::CustomInit(const std::optional<interfaces::BlockKey>& block)
 {
     if (!m_db->Read(DB_MUHASH, m_muhash)) {
         // Check that the cause of the read failure is that the key does not
@@ -357,13 +357,9 @@ bool CoinStatsIndex::Init()
         }
     }
 
-    if (!BaseIndex::Init()) return false;
-
-    const CBlockIndex* pindex{CurrentIndex()};
-
-    if (pindex) {
+    if (block) {
         DBVal entry;
-        if (!LookUpOne(*m_db, {pindex->GetBlockHash(), pindex->nHeight}, entry)) {
+        if (!LookUpOne(*m_db, *block, entry)) {
             return error("%s: Cannot read current %s state; index may be corrupted",
                             __func__, GetName());
         }

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -115,7 +115,7 @@ CoinStatsIndex::CoinStatsIndex(std::unique_ptr<interfaces::Chain> chain, size_t 
 
 bool CoinStatsIndex::CustomAppend(const interfaces::BlockInfo& block)
 {
-    const CBlockIndex* pindex = m_chainstate->m_blockman.LookupBlockIndex(block.hash);
+    const CBlockIndex* pindex = WITH_LOCK(cs_main, return m_chainstate->m_blockman.LookupBlockIndex(block.hash));
     assert(pindex);
     CBlockUndo block_undo;
     const CAmount block_subsidy{GetBlockSubsidy(pindex, Params().GetConsensus())};

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -265,17 +265,15 @@ bool CoinStatsIndex::CustomAppend(const interfaces::BlockInfo& block)
     return true;
 }
 
-bool CoinStatsIndex::Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip)
+bool CoinStatsIndex::CustomRewind(const interfaces::BlockKey& current_tip, const interfaces::BlockKey& new_tip)
 {
-    assert(current_tip->GetAncestor(new_tip->nHeight) == new_tip);
-
     CDBBatch batch(*m_db);
     std::unique_ptr<CDBIterator> db_it(m_db->NewIterator());
 
     // During a reorg, we need to copy all hash digests for blocks that are
     // getting disconnected from the height index to the hash index so we can
     // still find them when the height index entries are overwritten.
-    if (!CopyHeightIndexToHashIndex(*db_it, batch, m_name, new_tip->nHeight, current_tip->nHeight)) {
+    if (!CopyHeightIndexToHashIndex(*db_it, batch, m_name, new_tip.height, current_tip.height)) {
         return false;
     }
 
@@ -283,7 +281,8 @@ bool CoinStatsIndex::Rewind(const CBlockIndex* current_tip, const CBlockIndex* n
 
     {
         LOCK(cs_main);
-        const CBlockIndex* iter_tip{m_chainstate->m_blockman.LookupBlockIndex(current_tip->GetBlockHash())};
+        const CBlockIndex* iter_tip{m_chainstate->m_blockman.LookupBlockIndex(current_tip.hash)};
+        const CBlockIndex* new_tip_index{m_chainstate->m_blockman.LookupBlockIndex(new_tip.hash)};
         const auto& consensus_params{Params().GetConsensus()};
 
         do {
@@ -299,10 +298,10 @@ bool CoinStatsIndex::Rewind(const CBlockIndex* current_tip, const CBlockIndex* n
             }
 
             iter_tip = iter_tip->GetAncestor(iter_tip->nHeight - 1);
-        } while (new_tip != iter_tip);
+        } while (new_tip_index != iter_tip);
     }
 
-    return BaseIndex::Rewind(current_tip, new_tip);
+    return true;
 }
 
 static bool LookUpOne(const CDBWrapper& db, const interfaces::BlockKey& block, DBVal& result)

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -113,24 +113,29 @@ CoinStatsIndex::CoinStatsIndex(std::unique_ptr<interfaces::Chain> chain, size_t 
     m_db = std::make_unique<CoinStatsIndex::DB>(path / "db", n_cache_size, f_memory, f_wipe);
 }
 
-bool CoinStatsIndex::WriteBlock(const CBlock& block, const CBlockIndex* pindex)
+bool CoinStatsIndex::CustomAppend(const interfaces::BlockInfo& block)
 {
+    const CBlockIndex* pindex = m_chainstate->m_blockman.LookupBlockIndex(block.hash);
+    assert(pindex);
     CBlockUndo block_undo;
     const CAmount block_subsidy{GetBlockSubsidy(pindex, Params().GetConsensus())};
     m_total_subsidy += block_subsidy;
 
     // Ignore genesis block
-    if (pindex->nHeight > 0) {
+    if (block.height > 0) {
+        // pindex variable gives indexing code access to node internals. It
+        // will be removed in upcoming commit
+        const CBlockIndex* pindex = WITH_LOCK(cs_main, return m_chainstate->m_blockman.LookupBlockIndex(block.hash));
         if (!UndoReadFromDisk(block_undo, pindex)) {
             return false;
         }
 
         std::pair<uint256, DBVal> read_out;
-        if (!m_db->Read(DBHeightKey(pindex->nHeight - 1), read_out)) {
+        if (!m_db->Read(DBHeightKey(block.height - 1), read_out)) {
             return false;
         }
 
-        uint256 expected_block_hash{pindex->pprev->GetBlockHash()};
+        uint256 expected_block_hash{*Assert(block.prev_hash)};
         if (read_out.first != expected_block_hash) {
             LogPrintf("WARNING: previous block header belongs to unexpected block %s; expected %s\n",
                       read_out.first.ToString(), expected_block_hash.ToString());
@@ -142,8 +147,9 @@ bool CoinStatsIndex::WriteBlock(const CBlock& block, const CBlockIndex* pindex)
         }
 
         // Add the new utxos created from the block
-        for (size_t i = 0; i < block.vtx.size(); ++i) {
-            const auto& tx{block.vtx.at(i)};
+        assert(block.data);
+        for (size_t i = 0; i < block.data->vtx.size(); ++i) {
+            const auto& tx{block.data->vtx.at(i)};
 
             // Skip duplicate txid coinbase transactions (BIP30).
             if (IsBIP30Unspendable(*pindex) && tx->IsCoinBase()) {
@@ -154,7 +160,7 @@ bool CoinStatsIndex::WriteBlock(const CBlock& block, const CBlockIndex* pindex)
 
             for (uint32_t j = 0; j < tx->vout.size(); ++j) {
                 const CTxOut& out{tx->vout[j]};
-                Coin coin{out, pindex->nHeight, tx->IsCoinBase()};
+                Coin coin{out, block.height, tx->IsCoinBase()};
                 COutPoint outpoint{tx->GetHash(), j};
 
                 // Skip unspendable coins
@@ -210,7 +216,7 @@ bool CoinStatsIndex::WriteBlock(const CBlock& block, const CBlockIndex* pindex)
     m_total_unspendables_unclaimed_rewards += unclaimed_rewards;
 
     std::pair<uint256, DBVal> value;
-    value.first = pindex->GetBlockHash();
+    value.first = block.hash;
     value.second.transaction_output_count = m_transaction_output_count;
     value.second.bogo_size = m_bogo_size;
     value.second.total_amount = m_total_amount;
@@ -230,7 +236,7 @@ bool CoinStatsIndex::WriteBlock(const CBlock& block, const CBlockIndex* pindex)
 
     // Intentionally do not update DB_MUHASH here so it stays in sync with
     // DB_BEST_BLOCK, and the index is not corrupted if there is an unclean shutdown.
-    return m_db->Write(DBHeightKey(pindex->nHeight), value);
+    return m_db->Write(DBHeightKey(block.height), value);
 }
 
 [[nodiscard]] static bool CopyHeightIndexToHashIndex(CDBIterator& db_it, CDBBatch& batch,

--- a/src/index/coinstatsindex.h
+++ b/src/index/coinstatsindex.h
@@ -45,7 +45,7 @@ protected:
 
     bool CommitInternal(CDBBatch& batch) override;
 
-    bool WriteBlock(const CBlock& block, const CBlockIndex* pindex) override;
+    bool CustomAppend(const interfaces::BlockInfo& block) override;
 
     bool Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip) override;
 

--- a/src/index/coinstatsindex.h
+++ b/src/index/coinstatsindex.h
@@ -43,7 +43,7 @@ private:
 protected:
     bool CustomInit(const std::optional<interfaces::BlockKey>& block) override;
 
-    bool CommitInternal(CDBBatch& batch) override;
+    bool CustomCommit(CDBBatch& batch) override;
 
     bool CustomAppend(const interfaces::BlockInfo& block) override;
 

--- a/src/index/coinstatsindex.h
+++ b/src/index/coinstatsindex.h
@@ -47,7 +47,7 @@ protected:
 
     bool CustomAppend(const interfaces::BlockInfo& block) override;
 
-    bool Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip) override;
+    bool CustomRewind(const interfaces::BlockKey& current_tip, const interfaces::BlockKey& new_tip) override;
 
     BaseIndex::DB& GetDB() const override { return *m_db; }
 

--- a/src/index/coinstatsindex.h
+++ b/src/index/coinstatsindex.h
@@ -41,7 +41,7 @@ private:
     bool AllowPrune() const override { return true; }
 
 protected:
-    bool Init() override;
+    bool CustomInit(const std::optional<interfaces::BlockKey>& block) override;
 
     bool CommitInternal(CDBBatch& batch) override;
 

--- a/src/index/coinstatsindex.h
+++ b/src/index/coinstatsindex.h
@@ -55,7 +55,7 @@ protected:
 
 public:
     // Constructs the index, which becomes available to be queried.
-    explicit CoinStatsIndex(size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+    explicit CoinStatsIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
 
     // Look up stats for a specific block using CBlockIndex
     std::optional<kernel::CCoinsStats> LookUpStats(const CBlockIndex* block_index) const;

--- a/src/index/spentindex.cpp
+++ b/src/index/spentindex.cpp
@@ -53,7 +53,8 @@ bool SpentIndex::DB::EraseSpentIndex(const std::vector<CSpentIndexKey>& keys)
     return CDBWrapper::WriteBatch(batch);
 }
 
-SpentIndex::SpentIndex(size_t n_cache_size, bool f_memory, bool f_wipe) :
+SpentIndex::SpentIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory, bool f_wipe) :
+    BaseIndex(std::move(chain)),
     m_db(std::make_unique<SpentIndex::DB>(n_cache_size, f_memory, f_wipe))
 {
 }

--- a/src/index/spentindex.cpp
+++ b/src/index/spentindex.cpp
@@ -117,8 +117,11 @@ bool SpentIndex::CustomAppend(const interfaces::BlockInfo& block)
     return m_db->WriteBatch(entries);
 }
 
-bool SpentIndex::Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip)
+bool SpentIndex::CustomRewind(const interfaces::BlockKey& current_tip_key, const interfaces::BlockKey& new_tip_key)
 {
+    const CBlockIndex* current_tip = m_chainstate->m_blockman.LookupBlockIndex(current_tip_key.hash);
+    const CBlockIndex* new_tip = m_chainstate->m_blockman.LookupBlockIndex(new_tip_key.hash);
+    assert(current_tip && new_tip);
     assert(current_tip->GetAncestor(new_tip->nHeight) == new_tip);
 
     // Erase spent index entries for blocks being rewound
@@ -152,7 +155,7 @@ bool SpentIndex::Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_t
     }
 
     // Call base class Rewind to update the best block pointer
-    return BaseIndex::Rewind(current_tip, new_tip);
+    return true;
 }
 
 BaseIndex::DB& SpentIndex::GetDB() const { return *m_db; }

--- a/src/index/spentindex.cpp
+++ b/src/index/spentindex.cpp
@@ -61,8 +61,11 @@ SpentIndex::SpentIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_
 
 SpentIndex::~SpentIndex() = default;
 
-bool SpentIndex::WriteBlock(const CBlock& block, const CBlockIndex* pindex)
+bool SpentIndex::CustomAppend(const interfaces::BlockInfo& block)
 {
+    assert(block.data);
+    const CBlockIndex* pindex = m_chainstate->m_blockman.LookupBlockIndex(block.hash);
+    assert(pindex);
     // Skip genesis block (no inputs to index)
     if (pindex->nHeight == 0) {
         return true;
@@ -79,13 +82,13 @@ bool SpentIndex::WriteBlock(const CBlock& block, const CBlockIndex* pindex)
 
     // Process each non-coinbase transaction
     // blockundo.vtxundo[i] corresponds to block.vtx[i+1] (coinbase is skipped in undo data)
-    if (blockundo.vtxundo.size() != block.vtx.size() - 1) {
+    if (blockundo.vtxundo.size() != block.data->vtx.size() - 1) {
         return error("%s: Undo data size mismatch for block %s (expected %zu, got %zu)", __func__,
-                     pindex->GetBlockHash().ToString(), block.vtx.size() - 1, blockundo.vtxundo.size());
+                     pindex->GetBlockHash().ToString(), block.data->vtx.size() - 1, blockundo.vtxundo.size());
     }
 
     for (size_t i = 0; i < blockundo.vtxundo.size(); i++) {
-        const CTransactionRef& tx = block.vtx[i + 1]; // +1 to skip coinbase
+        const CTransactionRef& tx = block.data->vtx[i + 1]; // +1 to skip coinbase
         const CTxUndo& txundo = blockundo.vtxundo[i];
         const uint256 txhash = tx->GetHash();
 

--- a/src/index/spentindex.cpp
+++ b/src/index/spentindex.cpp
@@ -15,6 +15,7 @@
 #include <tinyformat.h>
 #include <undo.h>
 #include <util/system.h>
+#include <validation.h>
 
 constexpr uint8_t DB_SPENTINDEX{'p'};
 
@@ -64,7 +65,7 @@ SpentIndex::~SpentIndex() = default;
 bool SpentIndex::CustomAppend(const interfaces::BlockInfo& block)
 {
     assert(block.data);
-    const CBlockIndex* pindex = m_chainstate->m_blockman.LookupBlockIndex(block.hash);
+    const CBlockIndex* pindex = WITH_LOCK(cs_main, return m_chainstate->m_blockman.LookupBlockIndex(block.hash));
     assert(pindex);
     // Skip genesis block (no inputs to index)
     if (pindex->nHeight == 0) {
@@ -119,6 +120,7 @@ bool SpentIndex::CustomAppend(const interfaces::BlockInfo& block)
 
 bool SpentIndex::CustomRewind(const interfaces::BlockKey& current_tip_key, const interfaces::BlockKey& new_tip_key)
 {
+    LOCK(cs_main);
     const CBlockIndex* current_tip = m_chainstate->m_blockman.LookupBlockIndex(current_tip_key.hash);
     const CBlockIndex* new_tip = m_chainstate->m_blockman.LookupBlockIndex(new_tip_key.hash);
     assert(current_tip && new_tip);

--- a/src/index/spentindex.h
+++ b/src/index/spentindex.h
@@ -54,7 +54,7 @@ protected:
     bool CustomAppend(const interfaces::BlockInfo& block) override;
 
     /// Custom rewind to handle spent index cleanup
-    bool Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip) override;
+    bool CustomRewind(const interfaces::BlockKey& current_tip, const interfaces::BlockKey& new_tip) override;
 
     BaseIndex::DB& GetDB() const override;
     const char* GetName() const override { return "spentindex"; }

--- a/src/index/spentindex.h
+++ b/src/index/spentindex.h
@@ -51,7 +51,7 @@ protected:
         bool EraseSpentIndex(const std::vector<CSpentIndexKey>& keys);
     };
 
-    bool WriteBlock(const CBlock& block, const CBlockIndex* pindex) override;
+    bool CustomAppend(const interfaces::BlockInfo& block) override;
 
     /// Custom rewind to handle spent index cleanup
     bool Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip) override;

--- a/src/index/spentindex.h
+++ b/src/index/spentindex.h
@@ -64,7 +64,7 @@ protected:
 
 public:
     /// Constructs a new SpentIndex.
-    explicit SpentIndex(size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+    explicit SpentIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
 
     /// Destructor
     virtual ~SpentIndex() override;

--- a/src/index/timestampindex.cpp
+++ b/src/index/timestampindex.cpp
@@ -57,8 +57,10 @@ TimestampIndex::TimestampIndex(std::unique_ptr<interfaces::Chain> chain, size_t 
 
 TimestampIndex::~TimestampIndex() = default;
 
-bool TimestampIndex::WriteBlock(const CBlock& block, const CBlockIndex* pindex)
+bool TimestampIndex::CustomAppend(const interfaces::BlockInfo& block)
 {
+    const CBlockIndex* pindex = m_chainstate->m_blockman.LookupBlockIndex(block.hash);
+    assert(pindex);
     // Skip genesis block
     if (pindex->nHeight == 0) return true;
 

--- a/src/index/timestampindex.cpp
+++ b/src/index/timestampindex.cpp
@@ -71,8 +71,11 @@ bool TimestampIndex::CustomAppend(const interfaces::BlockInfo& block)
     return m_db->Write(key);
 }
 
-bool TimestampIndex::Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip)
+bool TimestampIndex::CustomRewind(const interfaces::BlockKey& current_tip_key, const interfaces::BlockKey& new_tip_key)
 {
+    const CBlockIndex* current_tip = m_chainstate->m_blockman.LookupBlockIndex(current_tip_key.hash);
+    const CBlockIndex* new_tip = m_chainstate->m_blockman.LookupBlockIndex(new_tip_key.hash);
+    assert(current_tip && new_tip);
     assert(current_tip->GetAncestor(new_tip->nHeight) == new_tip);
 
     // Erase timestamp index entries for blocks being rewound
@@ -88,7 +91,7 @@ bool TimestampIndex::Rewind(const CBlockIndex* current_tip, const CBlockIndex* n
     }
 
     // Call base class Rewind to update the best block pointer
-    return BaseIndex::Rewind(current_tip, new_tip);
+    return true;
 }
 
 BaseIndex::DB& TimestampIndex::GetDB() const { return *m_db; }

--- a/src/index/timestampindex.cpp
+++ b/src/index/timestampindex.cpp
@@ -49,7 +49,8 @@ bool TimestampIndex::DB::EraseTimestampIndex(const CTimestampIndexKey& key)
     return CDBWrapper::Erase(std::make_pair(DB_TIMESTAMPINDEX, key));
 }
 
-TimestampIndex::TimestampIndex(size_t n_cache_size, bool f_memory, bool f_wipe) :
+TimestampIndex::TimestampIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory, bool f_wipe) :
+    BaseIndex(std::move(chain)),
     m_db(std::make_unique<TimestampIndex::DB>(n_cache_size, f_memory, f_wipe))
 {
 }

--- a/src/index/timestampindex.cpp
+++ b/src/index/timestampindex.cpp
@@ -8,6 +8,7 @@
 #include <logging.h>
 #include <tinyformat.h>
 #include <util/system.h>
+#include <validation.h>
 
 constexpr uint8_t DB_TIMESTAMPINDEX{'s'};
 
@@ -59,7 +60,7 @@ TimestampIndex::~TimestampIndex() = default;
 
 bool TimestampIndex::CustomAppend(const interfaces::BlockInfo& block)
 {
-    const CBlockIndex* pindex = m_chainstate->m_blockman.LookupBlockIndex(block.hash);
+    const CBlockIndex* pindex = WITH_LOCK(cs_main, return m_chainstate->m_blockman.LookupBlockIndex(block.hash));
     assert(pindex);
     // Skip genesis block
     if (pindex->nHeight == 0) return true;
@@ -73,6 +74,7 @@ bool TimestampIndex::CustomAppend(const interfaces::BlockInfo& block)
 
 bool TimestampIndex::CustomRewind(const interfaces::BlockKey& current_tip_key, const interfaces::BlockKey& new_tip_key)
 {
+    LOCK(cs_main);
     const CBlockIndex* current_tip = m_chainstate->m_blockman.LookupBlockIndex(current_tip_key.hash);
     const CBlockIndex* new_tip = m_chainstate->m_blockman.LookupBlockIndex(new_tip_key.hash);
     assert(current_tip && new_tip);

--- a/src/index/timestampindex.h
+++ b/src/index/timestampindex.h
@@ -43,7 +43,7 @@ protected:
     bool CustomAppend(const interfaces::BlockInfo& block) override;
 
     /// Custom rewind to handle timestamp index cleanup
-    bool Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip) override;
+    bool CustomRewind(const interfaces::BlockKey& current_tip, const interfaces::BlockKey& new_tip) override;
 
     BaseIndex::DB& GetDB() const override;
     const char* GetName() const override { return "timestampindex"; }

--- a/src/index/timestampindex.h
+++ b/src/index/timestampindex.h
@@ -40,7 +40,7 @@ protected:
         bool EraseTimestampIndex(const CTimestampIndexKey& key);
     };
 
-    bool WriteBlock(const CBlock& block, const CBlockIndex* pindex) override;
+    bool CustomAppend(const interfaces::BlockInfo& block) override;
 
     /// Custom rewind to handle timestamp index cleanup
     bool Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip) override;

--- a/src/index/timestampindex.h
+++ b/src/index/timestampindex.h
@@ -53,7 +53,7 @@ protected:
 
 public:
     /// Constructs a new TimestampIndex.
-    explicit TimestampIndex(size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+    explicit TimestampIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
 
     /// Destructor
     virtual ~TimestampIndex() override;

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -48,8 +48,8 @@ bool TxIndex::DB::WriteTxs(const std::vector<std::pair<uint256, CDiskTxPos>>& v_
     return WriteBatch(batch);
 }
 
-TxIndex::TxIndex(size_t n_cache_size, bool f_memory, bool f_wipe)
-    : m_db(std::make_unique<TxIndex::DB>(n_cache_size, f_memory, f_wipe))
+TxIndex::TxIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory, bool f_wipe)
+    : BaseIndex(std::move(chain)), m_db(std::make_unique<TxIndex::DB>(n_cache_size, f_memory, f_wipe))
 {}
 
 TxIndex::~TxIndex() = default;

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -54,17 +54,16 @@ TxIndex::TxIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, 
 
 TxIndex::~TxIndex() = default;
 
-bool TxIndex::WriteBlock(const CBlock& block, const CBlockIndex* pindex)
+bool TxIndex::CustomAppend(const interfaces::BlockInfo& block)
 {
     // Exclude genesis block transaction because outputs are not spendable.
-    if (pindex->nHeight == 0) return true;
+    if (block.height == 0) return true;
 
-    CDiskTxPos pos{
-        WITH_LOCK(::cs_main, return pindex->GetBlockPos()),
-        GetSizeOfCompactSize(block.vtx.size())};
+    assert(block.data);
+    CDiskTxPos pos({block.file_number, block.data_pos}, GetSizeOfCompactSize(block.data->vtx.size()));
     std::vector<std::pair<uint256, CDiskTxPos>> vPos;
-    vPos.reserve(block.vtx.size());
-    for (const auto& tx : block.vtx) {
+    vPos.reserve(block.data->vtx.size());
+    for (const auto& tx : block.data->vtx) {
         vPos.emplace_back(tx->GetHash(), pos);
         pos.nTxOffset += ::GetSerializeSize(*tx, CLIENT_VERSION);
     }

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -25,7 +25,7 @@ private:
     bool AllowPrune() const override { return false; }
 
 protected:
-    bool WriteBlock(const CBlock& block, const CBlockIndex* pindex) override;
+    bool CustomAppend(const interfaces::BlockInfo& block) override;
 
     BaseIndex::DB& GetDB() const override;
 

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -33,7 +33,7 @@ protected:
 
 public:
     /// Constructs the index, which becomes available to be queried.
-    explicit TxIndex(size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+    explicit TxIndex(std::unique_ptr<interfaces::Chain> chain, size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
 
     // Destructor is declared because this class contains a unique_ptr to an incomplete type.
     virtual ~TxIndex() override;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -2336,43 +2336,43 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     // ********************************************************* Step 8: start indexers
     if (args.GetBoolArg("-txindex", DEFAULT_TXINDEX)) {
-        g_txindex = std::make_unique<TxIndex>(cache_sizes.tx_index, false, fReindex);
-        if (!g_txindex->Start(chainman.ActiveChainstate())) {
+        g_txindex = std::make_unique<TxIndex>(interfaces::MakeChain(node), cache_sizes.tx_index, false, fReindex);
+        if (!g_txindex->Start()) {
             return false;
         }
     }
 
     if (args.GetBoolArg("-addressindex", DEFAULT_ADDRESSINDEX)) {
-        g_addressindex = std::make_unique<AddressIndex>(cache_sizes.address_index, false, fReindex);
-        if (!g_addressindex->Start(chainman.ActiveChainstate())) {
+        g_addressindex = std::make_unique<AddressIndex>(interfaces::MakeChain(node), cache_sizes.address_index, false, fReindex);
+        if (!g_addressindex->Start()) {
             return false;
         }
     }
 
     if (args.GetBoolArg("-timestampindex", DEFAULT_TIMESTAMPINDEX)) {
-        g_timestampindex = std::make_unique<TimestampIndex>(cache_sizes.timestamp_index, false, fReindex);
-        if (!g_timestampindex->Start(chainman.ActiveChainstate())) {
+        g_timestampindex = std::make_unique<TimestampIndex>(interfaces::MakeChain(node), cache_sizes.timestamp_index, false, fReindex);
+        if (!g_timestampindex->Start()) {
             return false;
         }
     }
 
     if (args.GetBoolArg("-spentindex", DEFAULT_SPENTINDEX)) {
-        g_spentindex = std::make_unique<SpentIndex>(cache_sizes.spent_index, false, fReindex);
-        if (!g_spentindex->Start(chainman.ActiveChainstate())) {
+        g_spentindex = std::make_unique<SpentIndex>(interfaces::MakeChain(node), cache_sizes.spent_index, false, fReindex);
+        if (!g_spentindex->Start()) {
             return false;
         }
     }
 
     for (const auto& filter_type : g_enabled_filter_types) {
-        InitBlockFilterIndex(filter_type, cache_sizes.filter_index, false, fReindex);
-        if (!GetBlockFilterIndex(filter_type)->Start(chainman.ActiveChainstate())) {
+        InitBlockFilterIndex([&]{ return interfaces::MakeChain(node); }, filter_type, cache_sizes.filter_index, false, fReindex);
+        if (!GetBlockFilterIndex(filter_type)->Start()) {
             return false;
         }
     }
 
     if (args.GetBoolArg("-coinstatsindex", DEFAULT_COINSTATSINDEX)) {
-        g_coin_stats_index = std::make_unique<CoinStatsIndex>(/* cache size */ 0, false, fReindex);
-        if (!g_coin_stats_index->Start(chainman.ActiveChainstate())) {
+        g_coin_stats_index = std::make_unique<CoinStatsIndex>(interfaces::MakeChain(node), /* cache size */ 0, false, fReindex);
+        if (!g_coin_stats_index->Start()) {
             return false;
         }
     }

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -69,6 +69,8 @@ public:
     FoundBlock& mtpTime(int64_t& mtp_time) { m_mtp_time = &mtp_time; return *this; }
     //! Return whether block is in the active (most-work) chain.
     FoundBlock& inActiveChain(bool& in_active_chain) { m_in_active_chain = &in_active_chain; return *this; }
+    //! Return locator if block is in the active chain.
+    FoundBlock& locator(CBlockLocator& locator) { m_locator = &locator; return *this; }
     //! Return next block in the active chain if current block is in the active chain.
     FoundBlock& nextBlock(const FoundBlock& next_block) { m_next_block = &next_block; return *this; }
     //! Read block data from disk. If the block exists but doesn't have data
@@ -81,6 +83,7 @@ public:
     int64_t* m_max_time = nullptr;
     int64_t* m_mtp_time = nullptr;
     bool* m_in_active_chain = nullptr;
+    CBlockLocator* m_locator = nullptr;
     const FoundBlock* m_next_block = nullptr;
     CBlock* m_data = nullptr;
     mutable bool found = false;

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -336,6 +336,10 @@ public:
 
     //! Return true if an assumed-valid chain is in use.
     virtual bool hasAssumedValidChain() = 0;
+
+    //! Get internal node context. Useful for testing, but not
+    //! accessible across processes.
+    virtual node::NodeContext* context() { return nullptr; }
 };
 
 //! Interface to let node manage chain clients (wallets, or maybe tools for

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -50,6 +50,12 @@ namespace interfaces {
 class Wallet;
 class Handler;
 
+//! Hash/height pair to help track and identify blocks.
+struct BlockKey {
+    uint256 hash;
+    int height = -1;
+};
+
 //! Helper for findBlock to selectively return pieces of block data. If block is
 //! found, data will be returned by setting specified output variables. If block
 //! is not found, output variables will keep their previous values.

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -20,6 +20,7 @@
 class ArgsManager;
 class CBlock;
 class CConnman;
+class CBlockUndo;
 class CFeeRate;
 class CRPCCommand;
 class CScheduler;
@@ -77,6 +78,19 @@ public:
     const FoundBlock* m_next_block = nullptr;
     CBlock* m_data = nullptr;
     mutable bool found = false;
+};
+
+//! Block data sent with blockConnected, blockDisconnected notifications.
+struct BlockInfo {
+    const uint256& hash;
+    const uint256* prev_hash = nullptr;
+    int height = -1;
+    int file_number = -1;
+    unsigned data_pos = 0;
+    const CBlock* data = nullptr;
+    const CBlockUndo* undo_data = nullptr;
+
+    BlockInfo(const uint256& hash LIFETIMEBOUND) : hash(hash) {}
 };
 
 //! Interface giving clients (wallet processes, maybe other analysis tools in
@@ -272,8 +286,8 @@ public:
         virtual ~Notifications() {}
         virtual void transactionAddedToMempool(const CTransactionRef& tx, int64_t nAcceptTime) {}
         virtual void transactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRemovalReason reason) {}
-        virtual void blockConnected(const CBlock& block, int height) {}
-        virtual void blockDisconnected(const CBlock& block, int height) {}
+        virtual void blockConnected(const BlockInfo& block) {}
+        virtual void blockDisconnected(const BlockInfo& block) {}
         virtual void updatedBlockTip() {}
         virtual void chainStateFlushed(const CBlockLocator& locator) {}
         virtual void notifyChainLock(const CBlockIndex* pindexChainLock, const std::shared_ptr<const chainlock::ChainLockSig>& clsig) {}

--- a/src/kernel/chain.cpp
+++ b/src/kernel/chain.cpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <chain.h>
+#include <interfaces/chain.h>
+#include <sync.h>
+#include <uint256.h>
+
+class CBlock;
+
+namespace kernel {
+interfaces::BlockInfo MakeBlockInfo(const CBlockIndex* index, const CBlock* data)
+{
+    interfaces::BlockInfo info{index ? *index->phashBlock : uint256::ZERO};
+    if (index) {
+        info.prev_hash = index->pprev ? index->pprev->phashBlock : nullptr;
+        info.height = index->nHeight;
+        LOCK(::cs_main);
+        info.file_number = index->nFile;
+        info.data_pos = index->nDataPos;
+    }
+    info.data = data;
+    return info;
+}
+} // namespace kernel

--- a/src/kernel/chain.h
+++ b/src/kernel/chain.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2022 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_KERNEL_CHAIN_H
+#define BITCOIN_KERNEL_CHAIN_H
+
+class CBlock;
+class CBlockIndex;
+namespace interfaces {
+struct BlockInfo;
+} // namespace interfaces
+
+namespace kernel {
+//! Return data from block index.
+interfaces::BlockInfo MakeBlockInfo(const CBlockIndex* block_index, const CBlock* data = nullptr);
+} // namespace kernel
+
+#endif // BITCOIN_KERNEL_CHAIN_H

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -1515,6 +1515,7 @@ public:
         return chainman().IsSnapshotActive();
     }
 
+    NodeContext* context() override { return &m_node; }
     NodeContext& m_node;
 };
 } // namespace

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -1081,6 +1081,7 @@ bool FillBlock(const CBlockIndex* index, const FoundBlock& block, UniqueLock<Rec
     if (block.m_max_time) *block.m_max_time = index->GetBlockTimeMax();
     if (block.m_mtp_time) *block.m_mtp_time = index->GetMedianTimePast();
     if (block.m_in_active_chain) *block.m_in_active_chain = active[index->nHeight] == index;
+    if (block.m_locator) { *block.m_locator = active.GetLocator(index); }
     if (block.m_next_block) FillBlock(active[index->nHeight] == index ? active[index->nHeight + 1] : nullptr, *block.m_next_block, lock, active);
     if (block.m_data) {
         REVERSE_LOCK(lock);

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -39,6 +39,7 @@
 #include <netaddress.h>
 #include <netbase.h>
 #include <node/blockstorage.h>
+#include <kernel/chain.h>
 #include <node/coin.h>
 #include <node/context.h>
 #include <node/interface_ui.h>
@@ -1105,11 +1106,11 @@ public:
     }
     void BlockConnected(const std::shared_ptr<const CBlock>& block, const CBlockIndex* index) override
     {
-        m_notifications->blockConnected(*block, index->nHeight);
+        m_notifications->blockConnected(kernel::MakeBlockInfo(index, block.get()));
     }
     void BlockDisconnected(const std::shared_ptr<const CBlock>& block, const CBlockIndex* index) override
     {
-        m_notifications->blockDisconnected(*block, index->nHeight);
+        m_notifications->blockDisconnected(kernel::MakeBlockInfo(index, block.get()));
     }
     void UpdatedBlockTip(const CBlockIndex* index, const CBlockIndex* fork_index, bool is_ibd) override
     {

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -7,6 +7,7 @@
 #include <consensus/merkle.h>
 #include <consensus/validation.h>
 #include <index/blockfilterindex.h>
+#include <interfaces/chain.h>
 #include <node/miner.h>
 #include <pow.h>
 #include <script/standard.h>
@@ -110,7 +111,7 @@ bool BuildChainTestingSetup::BuildChain(const CBlockIndex* pindex,
 
 BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
 {
-    BlockFilterIndex filter_index(BlockFilterType::BASIC_FILTER, 1 << 20, true);
+    BlockFilterIndex filter_index(interfaces::MakeChain(m_node), BlockFilterType::BASIC_FILTER, 1 << 20, true);
 
     uint256 last_header;
 
@@ -137,7 +138,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
     // BlockUntilSyncedToCurrentChain should return false before index is started.
     BOOST_CHECK(!filter_index.BlockUntilSyncedToCurrentChain());
 
-    BOOST_REQUIRE(filter_index.Start(m_node.chainman->ActiveChainstate()));
+    BOOST_REQUIRE(filter_index.Start());
 
     // Allow filter index to catch up with the block index.
     IndexWaitSynced(filter_index);
@@ -273,14 +274,14 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_init_destroy, BasicTestingSetup)
     filter_index = GetBlockFilterIndex(BlockFilterType::BASIC_FILTER);
     BOOST_CHECK(filter_index == nullptr);
 
-    BOOST_CHECK(InitBlockFilterIndex(BlockFilterType::BASIC_FILTER, 1 << 20, true, false));
+    BOOST_CHECK(InitBlockFilterIndex([&]{ return interfaces::MakeChain(m_node); }, BlockFilterType::BASIC_FILTER, 1 << 20, true, false));
 
     filter_index = GetBlockFilterIndex(BlockFilterType::BASIC_FILTER);
     BOOST_CHECK(filter_index != nullptr);
     BOOST_CHECK(filter_index->GetFilterType() == BlockFilterType::BASIC_FILTER);
 
     // Initialize returns false if index already exists.
-    BOOST_CHECK(!InitBlockFilterIndex(BlockFilterType::BASIC_FILTER, 1 << 20, true, false));
+    BOOST_CHECK(!InitBlockFilterIndex([&]{ return interfaces::MakeChain(m_node); }, BlockFilterType::BASIC_FILTER, 1 << 20, true, false));
 
     int iter_count = 0;
     ForEachBlockFilterIndex([&iter_count](BlockFilterIndex& _index) { iter_count++; });
@@ -295,7 +296,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_init_destroy, BasicTestingSetup)
     BOOST_CHECK(filter_index == nullptr);
 
     // Reinitialize index.
-    BOOST_CHECK(InitBlockFilterIndex(BlockFilterType::BASIC_FILTER, 1 << 20, true, false));
+    BOOST_CHECK(InitBlockFilterIndex([&]{ return interfaces::MakeChain(m_node); }, BlockFilterType::BASIC_FILTER, 1 << 20, true, false));
 
     DestroyAllBlockFilterIndexes();
 

--- a/src/test/coinstatsindex_tests.cpp
+++ b/src/test/coinstatsindex_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <chainparams.h>
 #include <index/coinstatsindex.h>
+#include <interfaces/chain.h>
 #include <test/util/index.h>
 #include <test/util/setup_common.h>
 #include <test/util/validation.h>
@@ -16,7 +17,7 @@ BOOST_AUTO_TEST_SUITE(coinstatsindex_tests)
 
 BOOST_FIXTURE_TEST_CASE(coinstatsindex_initial_sync, TestChain100Setup)
 {
-    CoinStatsIndex coin_stats_index{1 << 20, true};
+    CoinStatsIndex coin_stats_index{interfaces::MakeChain(m_node), 1 << 20, true};
 
     const CBlockIndex* block_index;
     {
@@ -31,7 +32,7 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_initial_sync, TestChain100Setup)
     // is started.
     BOOST_CHECK(!coin_stats_index.BlockUntilSyncedToCurrentChain());
 
-    BOOST_REQUIRE(coin_stats_index.Start(m_node.chainman->ActiveChainstate()));
+    BOOST_REQUIRE(coin_stats_index.Start());
 
     IndexWaitSynced(coin_stats_index);
 
@@ -81,8 +82,8 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_unclean_shutdown, TestChain100Setup)
     CChainState& chainstate = Assert(m_node.chainman)->ActiveChainstate();
     const CChainParams& params = Params();
     {
-        CoinStatsIndex index{1 << 20};
-        BOOST_REQUIRE(index.Start(chainstate));
+        CoinStatsIndex index{interfaces::MakeChain(m_node), 1 << 20};
+        BOOST_REQUIRE(index.Start());
         IndexWaitSynced(index);
         std::shared_ptr<const CBlock> new_block;
         CBlockIndex* new_block_index = nullptr;
@@ -107,9 +108,9 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_unclean_shutdown, TestChain100Setup)
     }
 
     {
-        CoinStatsIndex index{1 << 20};
+        CoinStatsIndex index{interfaces::MakeChain(m_node), 1 << 20};
         // Make sure the index can be loaded.
-        BOOST_REQUIRE(index.Start(chainstate));
+        BOOST_REQUIRE(index.Start());
         index.Stop();
     }
 }

--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <chainparams.h>
 #include <index/txindex.h>
+#include <interfaces/chain.h>
 #include <script/standard.h>
 #include <test/util/index.h>
 #include <test/util/setup_common.h>
@@ -15,7 +16,7 @@ BOOST_AUTO_TEST_SUITE(txindex_tests)
 
 BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChain100Setup)
 {
-    TxIndex txindex(1 << 20, true);
+    TxIndex txindex(interfaces::MakeChain(m_node), 1 << 20, true);
 
     CTransactionRef tx_disk;
     uint256 block_hash;
@@ -28,7 +29,7 @@ BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChain100Setup)
     // BlockUntilSyncedToCurrentChain should return false before txindex is started.
     BOOST_CHECK(!txindex.BlockUntilSyncedToCurrentChain());
 
-    BOOST_REQUIRE(txindex.Start(m_node.chainman->ActiveChainstate()));
+    BOOST_REQUIRE(txindex.Start());
 
     // Allow tx index to catch up with the block index.
     IndexWaitSynced(txindex);

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -459,9 +459,9 @@ TestChainSetup::TestChainSetup(int num_blocks, const std::string& chain_name, co
     this->mineBlocks(num_blocks);
 
     // Initialize transaction index *after* chain has been constructed
-    g_txindex = std::make_unique<TxIndex>(1 << 20, true);
+    g_txindex = std::make_unique<TxIndex>(interfaces::MakeChain(m_node), 1 << 20, true);
     assert(!g_txindex->BlockUntilSyncedToCurrentChain());
-    if (!g_txindex->Start(m_node.chainman->ActiveChainstate())) {
+    if (!g_txindex->Start()) {
         throw std::runtime_error("TxIndex::Start() failed.");
     }
     IndexWaitSynced(*g_txindex);

--- a/src/wallet/test/fuzz/notifications.cpp
+++ b/src/wallet/test/fuzz/notifications.cpp
@@ -135,8 +135,13 @@ FUZZ_TARGET(wallet_notifications, .init = initialize_setup)
                     block.vtx.emplace_back(MakeTransactionRef(tx));
                 }
                 // Mine block
-                a.wallet->blockConnected(block, chain.size());
-                b.wallet->blockConnected(block, chain.size());
+                const uint256& hash = block.GetHash();
+                interfaces::BlockInfo info{hash};
+                info.prev_hash = &block.hashPrevBlock;
+                info.height = chain.size();
+                info.data = &block;
+                a.wallet->blockConnected(info);
+                b.wallet->blockConnected(info);
                 // Store the coins for the next block
                 Coins coins_new;
                 for (const auto& tx : block.vtx) {
@@ -152,8 +157,13 @@ FUZZ_TARGET(wallet_notifications, .init = initialize_setup)
                 auto& [coins, block]{chain.back()};
                 if (block.vtx.empty()) return; // Can only disconnect if the block was submitted first
                 // Disconnect block
-                a.wallet->blockDisconnected(block, chain.size() - 1);
-                b.wallet->blockDisconnected(block, chain.size() - 1);
+                const uint256& hash = block.GetHash();
+                interfaces::BlockInfo info{hash};
+                info.prev_hash = &block.hashPrevBlock;
+                info.height = chain.size() - 1;
+                info.data = &block;
+                a.wallet->blockDisconnected(info);
+                b.wallet->blockDisconnected(info);
                 chain.pop_back();
             });
         auto& [coins, first_block]{chain.front()};

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1472,17 +1472,17 @@ void CWallet::transactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRe
     }
 }
 
-void CWallet::blockConnected(const CBlock& block, int height)
+void CWallet::blockConnected(const interfaces::BlockInfo& block)
 {
-    const uint256& block_hash = block.GetHash();
+    assert(block.data);
     LOCK(cs_wallet);
 
-    m_last_block_processed_height = height;
-    m_last_block_processed = block_hash;
+    m_last_block_processed_height = block.height;
+    m_last_block_processed = block.hash;
     WalletBatch batch(GetDatabase());
-    for (size_t index = 0; index < block.vtx.size(); index++) {
-        SyncTransaction(block.vtx[index], TxStateConfirmed{block_hash, height, static_cast<int>(index)}, batch);
-        transactionRemovedFromMempool(block.vtx[index], MemPoolRemovalReason::BLOCK);
+    for (size_t index = 0; index < block.data->vtx.size(); index++) {
+        SyncTransaction(block.data->vtx[index], TxStateConfirmed{block.hash, block.height, static_cast<int>(index)}, batch);
+        transactionRemovedFromMempool(block.data->vtx[index], MemPoolRemovalReason::BLOCK);
     }
 
     // reset cache to make sure no longer immature coins are included
@@ -1490,21 +1490,22 @@ void CWallet::blockConnected(const CBlock& block, int height)
     fAnonymizableTallyCachedNonDenom = false;
 }
 
-void CWallet::blockDisconnected(const CBlock& block, int height)
+void CWallet::blockDisconnected(const interfaces::BlockInfo& block)
 {
+    assert(block.data);
     LOCK(cs_wallet);
 
     // At block disconnection, this will change an abandoned transaction to
     // be unconfirmed, whether or not the transaction is added back to the mempool.
     // User may have to call abandontransaction again. It may be addressed in the
     // future with a stickier abandoned state or even removing abandontransaction call.
-    m_last_block_processed_height = height - 1;
-    m_last_block_processed = block.hashPrevBlock;
+    m_last_block_processed_height = block.height - 1;
+    m_last_block_processed = *Assert(block.prev_hash);
 
-    int disconnect_height = height;
+    int disconnect_height = block.height;
 
     WalletBatch batch(GetDatabase());
-    for (const CTransactionRef& ptx : block.vtx) {
+    for (const CTransactionRef& ptx : Assert(block.data)->vtx) {
         SyncTransaction(ptx, TxStateInactive{}, batch);
 
         for (const CTxIn& tx_in : ptx->vin) {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -683,8 +683,8 @@ public:
     CWalletTx* AddToWallet(CTransactionRef tx, const TxState& state, const UpdateWalletTxFn& update_wtx=nullptr, bool fFlushOnClose=true, bool rescanning_old_block = false);
     bool LoadToWallet(const uint256& hash, const UpdateWalletTxFn& fill_wtx) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void transactionAddedToMempool(const CTransactionRef& tx, int64_t nAcceptTime) override;
-    void blockConnected(const CBlock& block, int height) override;
-    void blockDisconnected(const CBlock& block, int height) override;
+    void blockConnected(const interfaces::BlockInfo& block) override;
+    void blockDisconnected(const interfaces::BlockInfo& block) override;
     void updatedBlockTip() override;
     int64_t RescanFromTime(int64_t startTime, const WalletRescanReserver& reserver, bool update);
 

--- a/test/lint/lint-circular-dependencies.py
+++ b/test/lint/lint-circular-dependencies.py
@@ -22,12 +22,17 @@ EXPECTED_CIRCULAR_DEPENDENCIES = (
     "kernel/coinstats -> validation -> kernel/coinstats",
     "kernel/mempool_persist -> validation -> kernel/mempool_persist",
     # Dash
+    "active/context -> governance/superblock -> core_io -> index/spentindex -> index/base -> node/context -> active/context",
     "banman -> common/bloom -> evo/assetlocktx -> llmq/quorumsman -> llmq/blockprocessor -> net -> banman",
-    "coinjoin/client -> coinjoin/util -> wallet/wallet -> psbt -> node/transaction -> net_processing -> coinjoin/walletman -> coinjoin/client",
+    "coinjoin/client -> core_io -> index/spentindex -> index/base -> node/context -> coinjoin/walletman -> coinjoin/client",
+    "coinjoin/coinjoin -> core_io -> index/spentindex -> index/base -> node/context -> coinjoin/coinjoin",
+    "coinjoin/coinjoin -> core_io -> index/spentindex -> index/base -> node/context -> net_processing -> coinjoin/coinjoin",
     "common/bloom -> evo/assetlocktx -> llmq/commitment -> evo/deterministicmns -> evo/simplifiedmns -> merkleblock -> common/bloom",
     "common/bloom -> evo/assetlocktx -> llmq/quorumsman -> llmq/blockprocessor -> net -> common/bloom",
     "consensus/tx_verify -> evo/assetlocktx -> llmq/commitment -> validation -> consensus/tx_verify",
     "consensus/tx_verify -> evo/assetlocktx -> llmq/commitment -> validation -> txmempool -> consensus/tx_verify",
+    "core_io -> index/spentindex -> index/base -> node/context -> evo/chainhelper -> governance/superblock -> core_io",
+    "core_io -> index/spentindex -> index/base -> node/context -> net_processing -> evo/smldiff -> core_io",
     "evo/assetlocktx -> llmq/commitment -> validation -> txmempool -> evo/assetlocktx",
     "evo/chainhelper -> evo/creditpool -> validation -> evo/chainhelper",
     "evo/deterministicmns -> evo/providertx -> validation -> evo/deterministicmns",
@@ -40,6 +45,8 @@ EXPECTED_CIRCULAR_DEPENDENCIES = (
     "evo/specialtxman -> validation -> evo/specialtxman",
     "governance/superblock -> validation -> masternode/payments -> governance/superblock",
     "instantsend/instantsend -> node/blockstorage -> validation -> txmempool -> instantsend/instantsend",
+    "index/base -> node/context -> net_processing -> index/blockfilterindex -> index/base",
+    "index/base -> node/context -> net_processing -> index/txindex -> index/base",
     "llmq/blockprocessor -> llmq/utils -> llmq/snapshot -> llmq/blockprocessor",
     "llmq/commitment -> llmq/utils -> llmq/snapshot -> llmq/commitment",
     "net -> netmessagemaker -> net",
@@ -49,8 +56,6 @@ EXPECTED_CIRCULAR_DEPENDENCIES = (
     "qt/guiutil -> qt/qvalidatedlineedit -> qt/guiutil",
     "wallet/coinjoin -> wallet/receive -> wallet/coinjoin",
 
-    # Temporary, removed in followup https://github.com/bitcoin/bitcoin/pull/24230
-    "index/base -> node/context -> net_processing -> index/blockfilterindex -> index/base",
 )
 
 CODE_DIR = "src"

--- a/test/lint/lint-circular-dependencies.py
+++ b/test/lint/lint-circular-dependencies.py
@@ -48,6 +48,9 @@ EXPECTED_CIRCULAR_DEPENDENCIES = (
     "qt/clientfeeds -> qt/clientmodel -> qt/clientfeeds",
     "qt/guiutil -> qt/qvalidatedlineedit -> qt/guiutil",
     "wallet/coinjoin -> wallet/receive -> wallet/coinjoin",
+
+    # Temporary, removed in followup https://github.com/bitcoin/bitcoin/pull/24230
+    "index/base -> node/context -> net_processing -> index/blockfilterindex -> index/base",
 )
 
 CODE_DIR = "src"


### PR DESCRIPTION
## Issue being fixed or feature implemented

Dash's later assumeutxo backports rely on `src/kernel/chain.{h,cpp}`, but those files and the high-level index notification interfaces were originally introduced by bitcoin#25494. Backporting the complete upstream PR preserves the real file history and lets later backports contain only their own attributable hunks.

## What was done?

- Fully backported all seven commits from bitcoin#25494 in upstream order.
- Introduced `interfaces::BlockInfo`, `kernel::MakeBlockInfo`, and `kernel/chain.{h,cpp}`.
- Migrated the base, transaction, block-filter, and coin-stats indexes to the high-level `interfaces::Chain`, `BlockInfo`, and `BlockKey` APIs.
- Adapted Dash-only AddressIndex, TimestampIndex, and SpentIndex implementations to the same constructor, append, and rewind interfaces.
- Preserved Dash wallet batching and disconnect-conflict handling, CoinJoin cache invalidation, ChainLock and InstantSend notifications, newer index synchronization/pruning protections, and Dash's existing mempool notification signatures.
- Updated the circular-dependency expectations for the concrete Dash dependency graph introduced by this refactor.

Upstream PR: bitcoin/bitcoin#25494

## How Has This Been Tested?

- `make -j7`
- `./src/test/test_dash --run_test=blockfilter_index_tests,coinstatsindex_tests,txindex_tests`
- `test/functional/test_runner.py feature_addressindex.py feature_spentindex.py feature_timestampindex.py feature_index_prune.py`
- `test/lint/lint-circular-dependencies.py`
- `git diff --check origin/develop...HEAD`

All completed successfully on macOS arm64.

## Breaking Changes

No externally visible breaking changes. Internal index constructors and extension hooks now use the high-level chain interfaces introduced upstream.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [ ] I have assigned this pull request to a milestone
