### PR TITLE
feat(gui): masternode and shared masternode management

### DIFF
--- a/doc/release-notes-decentralized-mn-ui.md
+++ b/doc/release-notes-decentralized-mn-ui.md
@@ -22,10 +22,18 @@ wallet without hand-assembling `protx` commands in the debug console.
   existing collateral output already held by the wallet, or external collateral
   held in another wallet or on a hardware device (prepare, sign the message
   out-of-band, then submit).
-- Owner and voting addresses are generated from the wallet; the operator BLS key
-  is either generated (its secret shown once, behind a confirmation, with the
-  matching `masternodeblsprivkey` line for `dash.conf`) or supplied as a hosting
-  provider's public key.
+- Owner and voting addresses are generated from the wallet, so its backup covers
+  them. The operator BLS key is generated and saved in the wallet (new default),
+  generated without saving (its secret shown once, behind a confirmation), or
+  supplied as a hosting provider's public key. Either way the matching
+  `masternodeblsprivkey` line for the masternode server's `dash.conf` is shown.
+
+## Transaction history
+
+- Dash special transactions now have their own types in the transaction list:
+  Masternode Registration, Masternode Update and Masternode Dissolution, with a
+  matching entry in the type filter. A registration previously appeared as a
+  "Payment to yourself" whose amount was only the network fee.
 
 ## Maintenance
 

--- a/doc/release-notes-decentralized-mn-ui.md
+++ b/doc/release-notes-decentralized-mn-ui.md
@@ -1,0 +1,52 @@
+# Masternode management in the GUI
+
+The Masternodes tab in dash-qt gains a full set of management flows, so a
+masternode, evonode or shared masternode can be created and maintained from the
+wallet without hand-assembling `protx` commands in the debug console.
+
+## Recognition
+
+- Shared masternodes appear in the list with the type "Shared", have their own
+  entry in the type filter (the "Regular" filter now shows only single-owner
+  masternodes), and match the text filter by their share owner, refund and
+  reward addresses. A masternode is recognized as owned when the wallet holds
+  any of its share owner keys.
+- The details dialog shows the collateral share table with per-share amounts and
+  addresses, the shares belonging to this wallet, the early-exit penalty terms
+  and the remaining early period.
+
+## Registration
+
+- A wizard registers a masternode (1,000 DASH) or evonode (4,000 DASH) using one
+  of three collateral paths: funding the collateral from the wallet, using an
+  existing collateral output already held by the wallet, or external collateral
+  held in another wallet or on a hardware device (prepare, sign the message
+  out-of-band, then submit).
+- Owner and voting addresses are generated from the wallet; the operator BLS key
+  is either generated (its secret shown once, behind a confirmation, with the
+  matching `masternodeblsprivkey` line for `dash.conf`) or supplied as a hosting
+  provider's public key.
+
+## Maintenance
+
+- Update Service, Update Registrar and Revoke are available from the list's
+  context menu, with the evonode platform fields where applicable. Update
+  Registrar is not offered for shared masternodes, which rotate their keys
+  unanimously instead.
+
+## Shared masternodes (requires v24)
+
+- Creating a shared masternode is a resumable session: participants pass a
+  session file between their wallets to agree the share table and terms, each
+  contributes one funding output equal to their share, and each signs. Every
+  signature and every imported copy is verified against the transaction actually
+  being registered before it is accepted, so the terms shown always match the
+  terms signed.
+- Shared masternodes can change a share's reward address, rotate their operator
+  and voting keys unanimously, and dissolve either unilaterally (with a live
+  payout and penalty preview) or unanimously (penalty-free). Each participant can
+  also generate standby dissolution transactions that never expire, to recover
+  their principal without cooperation if a key is lost.
+
+Shared-masternode features are shown only once the v24 hard fork is active on the
+connected network.

--- a/doc/release-notes-decentralized-mn-ui.md
+++ b/doc/release-notes-decentralized-mn-ui.md
@@ -24,12 +24,14 @@ wallet without hand-assembling `protx` commands in the debug console.
   out-of-band, then submit).
 - Owner and voting addresses are generated from the wallet, so its backup covers
   them. The operator BLS key is **derived from the wallet's recovery phrase** at
-  `m/9'/coin'/3'/3'/index` (new default for HD wallets) — the same derivation the
-  Dash mobile wallets use, so the recovery phrase alone restores the key. Wallets
-  with no reachable seed can instead generate and store the key in the wallet
-  file, and generating without saving (secret shown once) remains available, as
-  does supplying a hosting provider's public key. Either way the matching
-  `masternodeblsprivkey` line for the masternode server's `dash.conf` is shown.
+  `m/9'/coin'/3'/3'/index` — the same derivation the Dash mobile wallets use, so
+  the recovery phrase alone restores it. Each masternode gets its own index, and
+  keys already registered on-chain are skipped, so a wallet restored from its
+  phrase never reuses another masternode's key. Wallets with no recovery phrase
+  (imported descriptors, raw seeds, pre-HD wallets) generate a key that is shown
+  once for the owner to save, and a hosting provider's public key can be supplied
+  instead. In every case the matching `masternodeblsprivkey` line for the
+  masternode server's `dash.conf` is shown.
 - **Show Operator Key** in the masternode list's context menu shows the operator
   secret again for any masternode whose key this wallet holds, whether derived or
   stored.

--- a/doc/release-notes-decentralized-mn-ui.md
+++ b/doc/release-notes-decentralized-mn-ui.md
@@ -23,10 +23,16 @@ wallet without hand-assembling `protx` commands in the debug console.
   held in another wallet or on a hardware device (prepare, sign the message
   out-of-band, then submit).
 - Owner and voting addresses are generated from the wallet, so its backup covers
-  them. The operator BLS key is generated and saved in the wallet (new default),
-  generated without saving (its secret shown once, behind a confirmation), or
-  supplied as a hosting provider's public key. Either way the matching
+  them. The operator BLS key is **derived from the wallet's recovery phrase** at
+  `m/9'/coin'/3'/3'/index` (new default for HD wallets) — the same derivation the
+  Dash mobile wallets use, so the recovery phrase alone restores the key. Wallets
+  with no reachable seed can instead generate and store the key in the wallet
+  file, and generating without saving (secret shown once) remains available, as
+  does supplying a hosting provider's public key. Either way the matching
   `masternodeblsprivkey` line for the masternode server's `dash.conf` is shown.
+- **Show Operator Key** in the masternode list's context menu shows the operator
+  secret again for any masternode whose key this wallet holds, whether derived or
+  stored.
 
 ## Transaction history
 

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -89,6 +89,7 @@ QT_MOC_CPP = \
   qt/moc_proposallist.cpp \
   qt/moc_proposalmodel.cpp \
   qt/moc_proposalresume.cpp \
+  qt/moc_protxsender.cpp \
   qt/moc_psbtoperationsdialog.cpp \
   qt/moc_qrdialog.cpp \
   qt/moc_qrimagewidget.cpp \
@@ -123,6 +124,7 @@ QT_MOC = \
   qt/bitcoinamountfield.moc \
   qt/intro.moc \
   qt/overviewpage.moc \
+  qt/protxsender.moc \
   qt/rpcconsole.moc
 
 QT_QRC_CPP = qt/qrc_bitcoin.cpp
@@ -177,6 +179,7 @@ BITCOIN_QT_H = \
   qt/proposallist.h \
   qt/proposalmodel.h \
   qt/proposalresume.h \
+  qt/protxsender.h \
   qt/psbtoperationsdialog.h \
   qt/qrdialog.h \
   qt/qrimagewidget.h \
@@ -310,6 +313,7 @@ BITCOIN_QT_WALLET_CPP = \
   qt/proposalcreate.cpp \
   qt/proposallist.cpp \
   qt/proposalresume.cpp \
+  qt/protxsender.cpp \
   qt/psbtoperationsdialog.cpp \
   qt/qrdialog.cpp \
   qt/qrimagewidget.cpp \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -104,6 +104,7 @@ QT_MOC_CPP = \
   qt/moc_rpcconsole.cpp \
   qt/moc_sendcoinsdialog.cpp \
   qt/moc_sharedmncreatedialog.cpp \
+  qt/moc_sharedmndialogs.cpp \
   qt/moc_sendcoinsentry.cpp \
   qt/moc_signverifymessagedialog.cpp \
   qt/moc_splashscreen.cpp \
@@ -201,6 +202,7 @@ BITCOIN_QT_H = \
   qt/sendcoinsentry.h \
   qt/sendcoinsrecipient.h \
   qt/sharedmncreatedialog.h \
+  qt/sharedmndialogs.h \
   qt/signverifymessagedialog.h \
   qt/splashscreen.h \
   qt/trafficgraphdata.h \
@@ -336,6 +338,7 @@ BITCOIN_QT_WALLET_CPP = \
   qt/sendcoinsdialog.cpp \
   qt/sendcoinsentry.cpp \
   qt/sharedmncreatedialog.cpp \
+  qt/sharedmndialogs.cpp \
   qt/signverifymessagedialog.cpp \
   qt/transactiondesc.cpp \
   qt/transactionfilterproxy.cpp \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -71,6 +71,7 @@ QT_MOC_CPP = \
   qt/moc_intro.cpp \
   qt/moc_macdockiconhandler.cpp \
   qt/moc_macnotificationhandler.cpp \
+  qt/moc_masternodedialogs.cpp \
   qt/moc_masternodelist.cpp \
   qt/moc_masternodemodel.cpp \
   qt/moc_masternodewidgets.cpp \
@@ -162,6 +163,7 @@ BITCOIN_QT_H = \
   qt/macdockiconhandler.h \
   qt/macnotificationhandler.h \
   qt/macos_appnap.h \
+  qt/masternodedialogs.h \
   qt/masternodelist.h \
   qt/masternodemodel.h \
   qt/masternodewidgets.h \
@@ -309,6 +311,7 @@ BITCOIN_QT_WALLET_CPP = \
   qt/createwalletdialog.cpp \
   qt/descriptiondialog.cpp \
   qt/editaddressdialog.cpp \
+  qt/masternodedialogs.cpp \
   qt/masternodelist.cpp \
   qt/masternodewidgets.cpp \
   qt/masternodewizard.cpp \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -73,6 +73,8 @@ QT_MOC_CPP = \
   qt/moc_macnotificationhandler.cpp \
   qt/moc_masternodelist.cpp \
   qt/moc_masternodemodel.cpp \
+  qt/moc_masternodewidgets.cpp \
+  qt/moc_masternodewizard.cpp \
   qt/moc_mnemonicverificationdialog.cpp \
   qt/moc_modaloverlay.cpp \
   qt/moc_networkwidget.cpp \
@@ -162,6 +164,8 @@ BITCOIN_QT_H = \
   qt/macos_appnap.h \
   qt/masternodelist.h \
   qt/masternodemodel.h \
+  qt/masternodewidgets.h \
+  qt/masternodewizard.h \
   qt/mnemonicverificationdialog.h \
   qt/modaloverlay.h \
   qt/networkstyle.h \
@@ -306,6 +310,8 @@ BITCOIN_QT_WALLET_CPP = \
   qt/descriptiondialog.cpp \
   qt/editaddressdialog.cpp \
   qt/masternodelist.cpp \
+  qt/masternodewidgets.cpp \
+  qt/masternodewizard.cpp \
   qt/mnemonicverificationdialog.cpp \
   qt/openuridialog.cpp \
   qt/overviewpage.cpp \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -103,6 +103,7 @@ QT_MOC_CPP = \
   qt/moc_recentrequeststablemodel.cpp \
   qt/moc_rpcconsole.cpp \
   qt/moc_sendcoinsdialog.cpp \
+  qt/moc_sharedmncreatedialog.cpp \
   qt/moc_sendcoinsentry.cpp \
   qt/moc_signverifymessagedialog.cpp \
   qt/moc_splashscreen.cpp \
@@ -169,6 +170,7 @@ BITCOIN_QT_H = \
   qt/masternodewidgets.h \
   qt/masternodewizard.h \
   qt/mnemonicverificationdialog.h \
+  qt/mnsharesession.h \
   qt/modaloverlay.h \
   qt/networkstyle.h \
   qt/networkwidget.h \
@@ -198,6 +200,7 @@ BITCOIN_QT_H = \
   qt/sendcoinsdialog.h \
   qt/sendcoinsentry.h \
   qt/sendcoinsrecipient.h \
+  qt/sharedmncreatedialog.h \
   qt/signverifymessagedialog.h \
   qt/splashscreen.h \
   qt/trafficgraphdata.h \
@@ -316,6 +319,7 @@ BITCOIN_QT_WALLET_CPP = \
   qt/masternodewidgets.cpp \
   qt/masternodewizard.cpp \
   qt/mnemonicverificationdialog.cpp \
+  qt/mnsharesession.cpp \
   qt/openuridialog.cpp \
   qt/overviewpage.cpp \
   qt/paymentserver.cpp \
@@ -331,6 +335,7 @@ BITCOIN_QT_WALLET_CPP = \
   qt/recentrequeststablemodel.cpp \
   qt/sendcoinsdialog.cpp \
   qt/sendcoinsentry.cpp \
+  qt/sharedmncreatedialog.cpp \
   qt/signverifymessagedialog.cpp \
   qt/transactiondesc.cpp \
   qt/transactionfilterproxy.cpp \

--- a/src/Makefile.qttest.include
+++ b/src/Makefile.qttest.include
@@ -16,12 +16,14 @@ TEST_QT_MOC_CPP = \
 if ENABLE_WALLET
 TEST_QT_MOC_CPP += \
   qt/test/moc_addressbooktests.cpp \
+  qt/test/moc_mnsharesessiontests.cpp \
   qt/test/moc_wallettests.cpp
 endif # ENABLE_WALLET
 
 TEST_QT_H = \
   qt/test/addressbooktests.h \
   qt/test/apptests.h \
+  qt/test/mnsharesessiontests.h \
   qt/test/optiontests.h \
   qt/test/rpcnestedtests.h \
   qt/test/uritests.h \
@@ -45,6 +47,7 @@ qt_test_test_dash_qt_SOURCES = \
 if ENABLE_WALLET
 qt_test_test_dash_qt_SOURCES += \
   qt/test/addressbooktests.cpp \
+  qt/test/mnsharesessiontests.cpp \
   qt/test/wallettests.cpp \
   wallet/test/wallet_test_fixture.cpp
 endif # ENABLE_WALLET

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -98,6 +98,8 @@ public:
     virtual const int32_t& getPoSePenalty() const = 0;
     virtual const int32_t& getRegisteredHeight() const = 0;
     virtual const uint16_t& getOperatorReward() const = 0;
+    //! Registered operator public key, 48 bytes, basic-scheme serialization
+    virtual std::vector<unsigned char> getOperatorPubKeyBytes() const = 0;
     virtual const uint256& getProTxHash() const = 0;
     //! Whether this masternode's collateral is pooled by multiple parties (non-empty share table)
     virtual bool isShared() const = 0;

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -10,7 +10,9 @@
 #include <net_types.h>                 // For banmap_t
 #include <netaddress.h>                // For Network
 #include <netbase.h>                   // For ConnectionDirection
+#include <pubkey.h>                    // For CKeyID
 #include <saltedhasher.h>              // For StaticSaltedHasher
+#include <script/script.h>             // For CScript
 #include <support/allocators/secure.h> // For SecureString
 #include <uint256.h>
 #include <util/settings.h>             // For util::SettingsValue
@@ -33,10 +35,8 @@ class CDeterministicMNList;
 class CFeeRate;
 class CGovernanceObject;
 class CGovernanceVote;
-class CKeyID;
 class CNodeStats;
 class Coin;
-class CScript;
 class CService;
 class RPCTimerInterface;
 class UniValue;
@@ -63,6 +63,17 @@ class Loader;
 } // namespace CoinJoin
 struct BlockTip;
 
+//! One collateral share of a shared masternode (mirrors CCollateralShare)
+struct MnShare
+{
+    CAmount amount{0};
+    CScript scriptRefund;
+    CScript scriptReward; //!< empty means rewards pay to scriptRefund
+    CKeyID keyIDOwner;
+
+    const CScript& rewardScript() const { return scriptReward.empty() ? scriptRefund : scriptReward; }
+};
+
 //! Interface for a masternode entry
 class MnEntry
 {
@@ -88,6 +99,12 @@ public:
     virtual const int32_t& getRegisteredHeight() const = 0;
     virtual const uint16_t& getOperatorReward() const = 0;
     virtual const uint256& getProTxHash() const = 0;
+    //! Whether this masternode's collateral is pooled by multiple parties (non-empty share table)
+    virtual bool isShared() const = 0;
+    //! The collateral share table; empty unless isShared()
+    virtual std::vector<MnShare> getShares() const = 0;
+    virtual const uint32_t& getEarlyPeriodBlocks() const = 0;
+    virtual const CAmount& getEarlyPenalty() const = 0;
 };
 
 using MnEntryCPtr = std::shared_ptr<const MnEntry>;
@@ -416,6 +433,9 @@ public:
 
     //! Is loading blocks.
     virtual bool isLoadingBlocks() = 0;
+
+    //! Whether the v24 hard fork (shared masternodes, extended ProTx addresses) is active at the tip.
+    virtual bool isV24Active() = 0;
 
     //! Set network active.
     virtual void setNetworkActive(bool active) = 0;

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -130,27 +130,28 @@ public:
     //! Sign special transaction payload
     virtual bool signSpecialTxPayload(const uint256& hash, const CKeyID& keyid, std::vector<unsigned char>& vchSig) = 0;
 
-    //! Store a masternode operator BLS secret key (32 raw bytes) in this wallet, keyed by
-    //! its public key. Returns false and fills error when it cannot be stored.
-    virtual bool addMasternodeOperatorKey(const std::vector<unsigned char>& secret, std::string& error) = 0;
-    //! Whether this wallet can store masternode operator keys (false for watch-only wallets)
-    virtual bool canStoreMasternodeOperatorKey() = 0;
-    //! Whether this wallet can derive operator keys from its HD seed
+    //! Whether this wallet can derive masternode operator keys from its HD seed
     virtual bool canDeriveMasternodeOperatorKey() = 0;
-    //! Derive the next unused masternode operator key from this wallet's HD seed,
-    //! persist the index it used and return the 32-byte secret plus the human
-    //! readable derivation path. Requires an unlocked wallet.
-    virtual bool deriveMasternodeOperatorKey(std::vector<unsigned char>& secret, std::string& path,
+    //! Derive this wallet's next unused masternode operator key, record the index it
+    //! used and return the 32-byte secret plus its derivation path. `in_use` holds
+    //! 48-byte operator public keys that are already taken (every operator key
+    //! registered on-chain), so a wallet restored from its recovery phrase cannot hand
+    //! out a key another masternode already uses. Requires an unlocked wallet.
+    virtual bool deriveMasternodeOperatorKey(const std::vector<std::vector<unsigned char>>& in_use,
+                                             std::vector<unsigned char>& secret, std::string& path,
                                              std::string& error) = 0;
-    //! Fetch an operator secret this wallet holds, by its 48-byte public key.
-    //! Works for both derived and stored keys. Requires an unlocked wallet.
-    //! `path` comes back holding the derivation path of a key derived from the HD
-    //! seed, and empty for a key stored in the wallet.
+    //! Whether this wallet can produce the operator secret for this 48-byte public key.
+    //! Cheap and unlock-free: true when an index record matches it, or optimistically
+    //! when the wallet can derive at all (the real work happens in
+    //! getMasternodeOperatorKey, which reports failure precisely).
+    virtual bool haveMasternodeOperatorKey(const std::vector<unsigned char>& pubkey) = 0;
+    //! Fetch the operator secret for a 48-byte public key, from the recorded index or by
+    //! scanning a bounded range of indexes so a wallet restored from its recovery phrase
+    //! still finds the keys of masternodes it registered. Fills `path` with the
+    //! derivation path. Requires an unlocked wallet.
     virtual bool getMasternodeOperatorKey(const std::vector<unsigned char>& pubkey,
                                           std::vector<unsigned char>& secret, std::string& path,
                                           std::string& error) = 0;
-    //! Public keys (48 bytes each) of every operator key this wallet holds
-    virtual std::vector<std::vector<unsigned char>> listMasternodeOperatorKeys() = 0;
 
     //! Return whether wallet has private key.
     virtual bool isSpendable(const CScript& script) = 0;

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -135,6 +135,22 @@ public:
     virtual bool addMasternodeOperatorKey(const std::vector<unsigned char>& secret, std::string& error) = 0;
     //! Whether this wallet can store masternode operator keys (false for watch-only wallets)
     virtual bool canStoreMasternodeOperatorKey() = 0;
+    //! Whether this wallet can derive operator keys from its HD seed
+    virtual bool canDeriveMasternodeOperatorKey() = 0;
+    //! Derive the next unused masternode operator key from this wallet's HD seed,
+    //! persist the index it used and return the 32-byte secret plus the human
+    //! readable derivation path. Requires an unlocked wallet.
+    virtual bool deriveMasternodeOperatorKey(std::vector<unsigned char>& secret, std::string& path,
+                                             std::string& error) = 0;
+    //! Fetch an operator secret this wallet holds, by its 48-byte public key.
+    //! Works for both derived and stored keys. Requires an unlocked wallet.
+    //! `path` comes back holding the derivation path of a key derived from the HD
+    //! seed, and empty for a key stored in the wallet.
+    virtual bool getMasternodeOperatorKey(const std::vector<unsigned char>& pubkey,
+                                          std::vector<unsigned char>& secret, std::string& path,
+                                          std::string& error) = 0;
+    //! Public keys (48 bytes each) of every operator key this wallet holds
+    virtual std::vector<std::vector<unsigned char>> listMasternodeOperatorKeys() = 0;
 
     //! Return whether wallet has private key.
     virtual bool isSpendable(const CScript& script) = 0;

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -130,6 +130,12 @@ public:
     //! Sign special transaction payload
     virtual bool signSpecialTxPayload(const uint256& hash, const CKeyID& keyid, std::vector<unsigned char>& vchSig) = 0;
 
+    //! Store a masternode operator BLS secret key (32 raw bytes) in this wallet, keyed by
+    //! its public key. Returns false and fills error when it cannot be stored.
+    virtual bool addMasternodeOperatorKey(const std::vector<unsigned char>& secret, std::string& error) = 0;
+    //! Whether this wallet can store masternode operator keys (false for watch-only wallets)
+    virtual bool canStoreMasternodeOperatorKey() = 0;
+
     //! Return whether wallet has private key.
     virtual bool isSpendable(const CScript& script) = 0;
     virtual bool isSpendable(const CTxDestination& dest) = 0;

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -154,6 +154,18 @@ public:
     const int32_t& getRegisteredHeight() const override { return m_dmn->pdmnState->nRegisteredHeight; }
     const uint16_t& getOperatorReward() const override { return m_dmn->nOperatorReward; }
     const uint256& getProTxHash() const override { return m_dmn->proTxHash; }
+    bool isShared() const override { return m_dmn->pdmnState->IsShared(); }
+    std::vector<interfaces::MnShare> getShares() const override
+    {
+        std::vector<interfaces::MnShare> ret;
+        ret.reserve(m_dmn->pdmnState->shares.size());
+        for (const auto& share : m_dmn->pdmnState->shares) {
+            ret.push_back({share.amount, share.scriptRefund, share.scriptReward, share.keyIDOwner});
+        }
+        return ret;
+    }
+    const uint32_t& getEarlyPeriodBlocks() const override { return m_dmn->pdmnState->nEarlyPeriodBlocks; }
+    const CAmount& getEarlyPenalty() const override { return m_dmn->pdmnState->nEarlyPenalty; }
 };
 
 class MnListImpl : public MnList
@@ -946,6 +958,11 @@ public:
         return m_context->active_ctx != nullptr;
     }
     bool isLoadingBlocks() override { return node::fReindex || node::fImporting; }
+    bool isV24Active() override
+    {
+        LOCK(::cs_main);
+        return DeploymentActiveAfter(chainman().ActiveChain().Tip(), chainman(), Consensus::DEPLOYMENT_V24);
+    }
     void setNetworkActive(bool active) override
     {
         if (m_context->connman) {

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -960,6 +960,8 @@ public:
     bool isLoadingBlocks() override { return node::fReindex || node::fImporting; }
     bool isV24Active() override
     {
+        // Can briefly block the calling (GUI) thread while validation holds
+        // cs_main; callers that poll should cache the result once it turns true
         LOCK(::cs_main);
         return DeploymentActiveAfter(chainman().ActiveChain().Tip(), chainman(), Consensus::DEPLOYMENT_V24);
     }

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -153,6 +153,12 @@ public:
     const int32_t& getPoSePenalty() const override { return m_dmn->pdmnState->nPoSePenalty; }
     const int32_t& getRegisteredHeight() const override { return m_dmn->pdmnState->nRegisteredHeight; }
     const uint16_t& getOperatorReward() const override { return m_dmn->nOperatorReward; }
+    std::vector<unsigned char> getOperatorPubKeyBytes() const override
+    {
+        // The basic scheme is picked explicitly so that the bytes stay the same across a scheme
+        // activation, which is what lets the wallet compare them against its own operator keys
+        return m_dmn->pdmnState->pubKeyOperator.Get().ToByteVector(/*specificLegacyScheme=*/false);
+    }
     const uint256& getProTxHash() const override { return m_dmn->proTxHash; }
     bool isShared() const override { return m_dmn->pdmnState->IsShared(); }
     std::vector<interfaces::MnShare> getShares() const override

--- a/src/qt/forms/masternodelist.ui
+++ b/src/qt/forms/masternodelist.ui
@@ -58,6 +58,11 @@
              <string>Evo</string>
             </property>
            </item>
+           <item>
+            <property name="text">
+             <string>Shared</string>
+            </property>
+           </item>
           </widget>
          </item>
          <item>

--- a/src/qt/forms/masternodelist.ui
+++ b/src/qt/forms/masternodelist.ui
@@ -108,6 +108,16 @@
            </property>
           </widget>
          </item>
+         <item>
+          <widget class="QPushButton" name="btnSharedMasternode">
+           <property name="toolTip">
+            <string>Create a masternode with collateral pooled by multiple parties, or continue a saved session</string>
+           </property>
+           <property name="text">
+            <string>Shared Masternode…</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </item>
        <item row="1" column="0">

--- a/src/qt/forms/masternodelist.ui
+++ b/src/qt/forms/masternodelist.ui
@@ -98,6 +98,16 @@
            </property>
           </widget>
          </item>
+         <item>
+          <widget class="QPushButton" name="btnRegisterMasternode">
+           <property name="toolTip">
+            <string>Register a new masternode or evonode using this wallet</string>
+           </property>
+           <property name="text">
+            <string>Register Masternode…</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </item>
        <item row="1" column="0">

--- a/src/qt/masternodedialogs.cpp
+++ b/src/qt/masternodedialogs.cpp
@@ -502,8 +502,12 @@ ShowOperatorKeyDialog::ShowOperatorKeyDialog(WalletModel* wallet_model, const QS
             failure = tr("The wallet stayed locked, so the operator secret key cannot be shown.");
         } else if (!wallet_model->wallet().getMasternodeOperatorKey(operator_pubkey, secret, derivation_path,
                                                                     error)) {
-            failure = tr("This wallet could not produce the operator secret key: %1")
-                          .arg(QString::fromStdString(error));
+            // Not a fault: the context menu offers this whenever the wallet might
+            // be able to derive the key, and only this lookup settles it
+            failure = error.empty() ?
+                          tr("This wallet cannot produce the operator key for this masternode.") :
+                          tr("This wallet cannot produce the operator key for this masternode: %1")
+                              .arg(QString::fromStdString(error));
         }
     }
 
@@ -530,15 +534,17 @@ ShowOperatorKeyDialog::ShowOperatorKeyDialog(WalletModel* wallet_model, const QS
                                             this));
         layout->addSpacing(GROUP_SPACING);
         layout->addWidget(makeHint(derivation_path.empty() ?
-                                       tr("This key is stored in this wallet — include it in your wallet backup.") :
-                                       tr("This key is derived from this wallet's recovery phrase (path %1), so "
+                                       tr("This key comes from this wallet's recovery phrase, so restoring that "
+                                          "phrase brings it back.") :
+                                       tr("This key comes from this wallet's recovery phrase (path %1), so "
                                           "restoring that phrase brings it back.")
                                            .arg(QString::fromStdString(derivation_path)),
                                    this));
     } else {
+        // A statement of fact, not an error: nothing went wrong when the key
+        // simply is not this wallet's
         auto* failure_label = new QLabel(failure, this);
         failure_label->setWordWrap(true);
-        failure_label->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
         layout->addWidget(failure_label);
     }
 

--- a/src/qt/masternodedialogs.cpp
+++ b/src/qt/masternodedialogs.cpp
@@ -24,6 +24,7 @@
 #include <QLineEdit>
 #include <QMessageBox>
 #include <QPushButton>
+#include <QSpinBox>
 #include <QStringList>
 #include <QVBoxLayout>
 
@@ -104,11 +105,24 @@ void MasternodeActionDialog::setupUi(const QString& title, const QString& intro,
         m_ok_button->setToolTip(tr("This wallet is watch-only and cannot sign transactions."));
     }
     connect(m_button_box, &QDialogButtonBox::accepted, this, &MasternodeActionDialog::submit);
-    connect(m_button_box, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    connect(m_button_box, &QDialogButtonBox::rejected, this, &MasternodeActionDialog::reject);
     layout->addWidget(m_button_box);
 
     GUIUtil::updateFonts();
     validate();
+}
+
+FeeSourcePicker* MasternodeActionDialog::addFeeSourceRow(QFormLayout* form, const QString& note)
+{
+    auto* picker = new FeeSourcePicker(this);
+    picker->setWalletModel(m_wallet_model);
+    auto* fee_note = new QLabel(note, this);
+    fee_note->setWordWrap(true);
+    auto* fee_box = new QVBoxLayout();
+    fee_box->addWidget(picker);
+    fee_box->addWidget(fee_note);
+    form->addRow(tr("Fee source:"), fee_box);
+    return picker;
 }
 
 bool MasternodeActionDialog::canSign() const
@@ -134,6 +148,14 @@ void MasternodeActionDialog::clearError()
 {
     m_status_label->clear();
     m_status_label->setVisible(false);
+}
+
+void MasternodeActionDialog::reject()
+{
+    // runProTx pumps events in a nested loop; dismissing the dialog then would
+    // suggest the in-flight transaction was cancelled when it is still sent
+    if (m_busy) return;
+    QDialog::reject();
 }
 
 void MasternodeActionDialog::setBusy(bool busy)
@@ -194,13 +216,27 @@ UpdateServiceDialog::UpdateServiceDialog(interfaces::Node& node, WalletModel* wa
     auto* form = new QFormLayout();
 
     m_addrs_edit = new QLineEdit(this);
-    m_addrs_edit->setText(entry.service());
     m_addrs_edit->setPlaceholderText(tr("IP:PORT, comma-separated for multiple entries"));
-    if (!m_v24_active) {
-        m_addrs_edit->setToolTip(tr("Multiple addresses require the v24 hard fork to be active."));
-    }
     connect(m_addrs_edit, &QLineEdit::textChanged, this, &UpdateServiceDialog::validate);
-    form->addRow(tr("Service addresses:"), m_addrs_edit);
+    if (m_v24_active) {
+        // Only the primary address is known here; prefilling it could silently
+        // drop registered secondary addresses, since the submitted list replaces
+        // the masternode's entire address set.
+        auto* addrs_note = new QLabel(tr("Enter the full new address list; it replaces every currently registered "
+                                         "address. The current addresses (primary: %1) are not prefilled.")
+                                          .arg(entry.service()),
+                                      this);
+        addrs_note->setWordWrap(true);
+        auto* addrs_box = new QVBoxLayout();
+        addrs_box->addWidget(m_addrs_edit);
+        addrs_box->addWidget(addrs_note);
+        form->addRow(tr("Service addresses:"), addrs_box);
+    } else {
+        // Pre-v24 a masternode has exactly one core address, so prefilling is safe
+        m_addrs_edit->setText(entry.service());
+        m_addrs_edit->setToolTip(tr("Multiple addresses require the v24 hard fork to be active."));
+        form->addRow(tr("Service address:"), m_addrs_edit);
+    }
 
     m_operator_key_edit = new QLineEdit(this);
     m_operator_key_edit->setEchoMode(QLineEdit::Password);
@@ -214,15 +250,29 @@ UpdateServiceDialog::UpdateServiceDialog(interfaces::Node& node, WalletModel* wa
         connect(m_platform_node_id_edit, &QLineEdit::textChanged, this, &UpdateServiceDialog::validate);
         form->addRow(tr("Platform node ID:"), m_platform_node_id_edit);
 
-        m_platform_p2p_edit = new QLineEdit(this);
-        m_platform_p2p_edit->setPlaceholderText(tr("IP:PORT, comma-separated for multiple entries"));
-        connect(m_platform_p2p_edit, &QLineEdit::textChanged, this, &UpdateServiceDialog::validate);
-        form->addRow(tr("Platform P2P addresses:"), m_platform_p2p_edit);
+        if (m_v24_active) {
+            m_platform_p2p_edit = new QLineEdit(this);
+            m_platform_p2p_edit->setPlaceholderText(tr("IP:PORT, comma-separated for multiple entries"));
+            connect(m_platform_p2p_edit, &QLineEdit::textChanged, this, &UpdateServiceDialog::validate);
+            form->addRow(tr("Platform P2P addresses:"), m_platform_p2p_edit);
 
-        m_platform_https_edit = new QLineEdit(this);
-        m_platform_https_edit->setPlaceholderText(tr("IP:PORT, comma-separated for multiple entries"));
-        connect(m_platform_https_edit, &QLineEdit::textChanged, this, &UpdateServiceDialog::validate);
-        form->addRow(tr("Platform HTTPS addresses:"), m_platform_https_edit);
+            m_platform_https_edit = new QLineEdit(this);
+            m_platform_https_edit->setPlaceholderText(tr("IP:PORT, comma-separated for multiple entries"));
+            connect(m_platform_https_edit, &QLineEdit::textChanged, this, &UpdateServiceDialog::validate);
+            form->addRow(tr("Platform HTTPS addresses:"), m_platform_https_edit);
+        } else {
+            // Pre-v24 a ProUpServTx only carries bare Platform port numbers,
+            // applied to the service address
+            m_platform_p2p_port_edit = new QSpinBox(this);
+            m_platform_p2p_port_edit->setRange(1, 65535);
+            m_platform_p2p_port_edit->setValue(26656);
+            form->addRow(tr("Platform P2P port:"), m_platform_p2p_port_edit);
+
+            m_platform_https_port_edit = new QSpinBox(this);
+            m_platform_https_port_edit->setRange(1, 65535);
+            m_platform_https_port_edit->setValue(443);
+            form->addRow(tr("Platform HTTPS port:"), m_platform_https_port_edit);
+        }
     }
 
     if (m_operator_reward_pct > 0) {
@@ -233,18 +283,9 @@ UpdateServiceDialog::UpdateServiceDialog(interfaces::Node& node, WalletModel* wa
         form->addRow(tr("Operator payout address:"), m_operator_payout_edit);
     }
 
-    m_fee_source = new FeeSourcePicker(this);
-    m_fee_source->setWalletModel(wallet_model);
-    m_fee_source->refresh();
-    auto* fee_note = new QLabel(m_is_shared ?
-                                    tr("Required: a shared masternode has no payout address of its own to pay the transaction fee from.") :
-                                    tr("Optional: when no address is selected the fee is paid from the operator payout or masternode payout address."),
-                                this);
-    fee_note->setWordWrap(true);
-    auto* fee_box = new QVBoxLayout();
-    fee_box->addWidget(m_fee_source);
-    fee_box->addWidget(fee_note);
-    form->addRow(tr("Fee source:"), fee_box);
+    m_fee_source = addFeeSourceRow(form, m_is_shared ?
+                                             tr("Required: a shared masternode has no payout address of its own to pay the transaction fee from.") :
+                                             tr("Optional: when no address is selected the fee is paid from the operator payout or masternode payout address."));
 
     setupUi(m_type == MnType::Evo ? tr("Update Evonode Service") : tr("Update Masternode Service"),
             tr("Update the network addresses this masternode is reachable at. Signing requires the operator secret key. A successful update also revives a PoSe-banned masternode."),
@@ -262,8 +303,11 @@ void UpdateServiceDialog::validate()
     }
     if (m_type == MnType::Evo) {
         ok &= IsHexString(m_platform_node_id_edit->text().trimmed(), 40);
-        ok &= !SplitAddressList(m_platform_p2p_edit->text()).isEmpty();
-        ok &= !SplitAddressList(m_platform_https_edit->text()).isEmpty();
+        if (m_v24_active) {
+            ok &= !SplitAddressList(m_platform_p2p_edit->text()).isEmpty();
+            ok &= !SplitAddressList(m_platform_https_edit->text()).isEmpty();
+        }
+        // Pre-v24 the port spinboxes enforce a valid range on their own
     }
     setOkValid(ok);
 }
@@ -282,8 +326,14 @@ void UpdateServiceDialog::submit()
     params.pushKV("operatorKey", m_operator_key_edit->text().trimmed().toStdString());
     if (m_type == MnType::Evo) {
         params.pushKV("platformNodeID", m_platform_node_id_edit->text().trimmed().toStdString());
-        params.pushKV("platformP2PAddrs", AddressArray(SplitAddressList(m_platform_p2p_edit->text())));
-        params.pushKV("platformHTTPSAddrs", AddressArray(SplitAddressList(m_platform_https_edit->text())));
+        if (m_v24_active) {
+            params.pushKV("platformP2PAddrs", AddressArray(SplitAddressList(m_platform_p2p_edit->text())));
+            params.pushKV("platformHTTPSAddrs", AddressArray(SplitAddressList(m_platform_https_edit->text())));
+        } else {
+            // Pre-v24 ProTx versions only accept bare port numbers here
+            params.pushKV("platformP2PAddrs", m_platform_p2p_port_edit->value());
+            params.pushKV("platformHTTPSAddrs", m_platform_https_port_edit->value());
+        }
     }
     if (m_operator_payout_edit && !m_operator_payout_edit->text().isEmpty()) {
         params.pushKV("operatorPayoutAddress", m_operator_payout_edit->text().trimmed().toStdString());
@@ -322,15 +372,7 @@ UpdateRegistrarDialog::UpdateRegistrarDialog(interfaces::Node& node, WalletModel
     connect(m_payout_edit, &QLineEdit::textChanged, this, &UpdateRegistrarDialog::validate);
     form->addRow(tr("Payout address:"), m_payout_edit);
 
-    m_fee_source = new FeeSourcePicker(this);
-    m_fee_source->setWalletModel(wallet_model);
-    m_fee_source->refresh();
-    auto* fee_note = new QLabel(tr("Optional: when no address is selected the fee is paid from the masternode payout address."), this);
-    fee_note->setWordWrap(true);
-    auto* fee_box = new QVBoxLayout();
-    fee_box->addWidget(m_fee_source);
-    fee_box->addWidget(fee_note);
-    form->addRow(tr("Fee source:"), fee_box);
+    m_fee_source = addFeeSourceRow(form, tr("Optional: when no address is selected the fee is paid from the masternode payout address."));
 
     setupUi(tr("Update Masternode Registrar"),
             tr("Update the operator key, voting address or payout address of this masternode. The masternode owner key must be present in this wallet. Fields left blank keep their current value."),
@@ -401,18 +443,9 @@ RevokeDialog::RevokeDialog(interfaces::Node& node, WalletModel* wallet_model, co
     connect(m_operator_key_edit, &QLineEdit::textChanged, this, &RevokeDialog::validate);
     form->addRow(tr("Operator secret key:"), m_operator_key_edit);
 
-    m_fee_source = new FeeSourcePicker(this);
-    m_fee_source->setWalletModel(wallet_model);
-    m_fee_source->refresh();
-    auto* fee_note = new QLabel(m_is_shared ?
-                                    tr("Required: a shared masternode has no payout address of its own to pay the transaction fee from.") :
-                                    tr("Optional: when no address is selected the fee is paid from the operator payout or masternode payout address."),
-                                this);
-    fee_note->setWordWrap(true);
-    auto* fee_box = new QVBoxLayout();
-    fee_box->addWidget(m_fee_source);
-    fee_box->addWidget(fee_note);
-    form->addRow(tr("Fee source:"), fee_box);
+    m_fee_source = addFeeSourceRow(form, m_is_shared ?
+                                             tr("Required: a shared masternode has no payout address of its own to pay the transaction fee from.") :
+                                             tr("Optional: when no address is selected the fee is paid from the operator payout or masternode payout address."));
 
     setupUi(tr("Revoke Masternode Service"),
             tr("Revoking clears the masternode's service address and PoSe-bans it until a new operator key is set with a registrar update. The collateral is not affected. This is mainly needed before re-registering with the same IP address or operator key."),

--- a/src/qt/masternodedialogs.cpp
+++ b/src/qt/masternodedialogs.cpp
@@ -1,0 +1,444 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/masternodedialogs.h>
+
+#include <interfaces/node.h>
+#include <interfaces/wallet.h>
+#include <univalue.h>
+
+#include <qt/guiutil.h>
+#include <qt/masternodemodel.h>
+#include <qt/masternodewidgets.h>
+#include <qt/protxsender.h>
+#include <qt/qvalidatedlineedit.h>
+#include <qt/walletmodel.h>
+
+#include <QApplication>
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QEventLoop>
+#include <QFormLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QStringList>
+#include <QVBoxLayout>
+
+namespace {
+//! Split a comma-separated ADDR:PORT list into trimmed, non-empty entries
+QStringList SplitAddressList(const QString& text)
+{
+    QStringList ret;
+    for (const QString& part : text.split(QLatin1Char(','), Qt::SkipEmptyParts)) {
+        const QString trimmed{part.trimmed()};
+        if (!trimmed.isEmpty()) ret << trimmed;
+    }
+    return ret;
+}
+
+UniValue AddressArray(const QStringList& addresses)
+{
+    UniValue arr(UniValue::VARR);
+    for (const QString& address : addresses) {
+        arr.push_back(address.toStdString());
+    }
+    return arr;
+}
+
+bool IsHexString(const QString& text, int length)
+{
+    if (text.size() != length) return false;
+    for (const QChar c : text) {
+        const char latin1{c.toLatin1()};
+        const bool is_hex_digit{(latin1 >= '0' && latin1 <= '9') || (latin1 >= 'a' && latin1 <= 'f') ||
+                                (latin1 >= 'A' && latin1 <= 'F')};
+        if (!is_hex_digit) return false;
+    }
+    return true;
+}
+} // anonymous namespace
+
+MasternodeActionDialog::MasternodeActionDialog(interfaces::Node& node, WalletModel* wallet_model, const MasternodeEntry& entry, QWidget* parent) :
+    QDialog(parent),
+    m_node{node},
+    m_wallet_model{wallet_model},
+    m_protx_hash{entry.proTxHash()},
+    m_is_shared{entry.isShared()},
+    m_sender{new ProTxSender(node, this)}
+{
+}
+
+void MasternodeActionDialog::setupUi(const QString& title, const QString& intro, QLayout* form, const QString& ok_text)
+{
+    setWindowTitle(title);
+    setMinimumWidth(650);
+
+    auto* layout = new QVBoxLayout(this);
+
+    auto* intro_label = new QLabel(intro, this);
+    intro_label->setWordWrap(true);
+    layout->addWidget(intro_label);
+
+    auto* protx_label = new QLabel(tr("Masternode: %1").arg(m_protx_hash), this);
+    protx_label->setWordWrap(true);
+    protx_label->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    layout->addWidget(protx_label);
+
+    layout->addLayout(form);
+
+    m_status_label = new QLabel(this);
+    m_status_label->setWordWrap(true);
+    m_status_label->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
+    m_status_label->setVisible(false);
+    layout->addWidget(m_status_label);
+
+    m_button_box = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+    m_ok_button = m_button_box->button(QDialogButtonBox::Ok);
+    m_ok_button->setText(ok_text);
+    if (!m_wallet_model) {
+        m_ok_button->setToolTip(tr("No wallet is available."));
+    } else if (m_wallet_model->wallet().privateKeysDisabled()) {
+        m_ok_button->setToolTip(tr("This wallet is watch-only and cannot sign transactions."));
+    }
+    connect(m_button_box, &QDialogButtonBox::accepted, this, &MasternodeActionDialog::submit);
+    connect(m_button_box, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    layout->addWidget(m_button_box);
+
+    GUIUtil::updateFonts();
+    validate();
+}
+
+bool MasternodeActionDialog::canSign() const
+{
+    return m_wallet_model != nullptr && !m_wallet_model->wallet().privateKeysDisabled();
+}
+
+void MasternodeActionDialog::setOkValid(bool valid)
+{
+    m_valid = valid;
+    if (m_ok_button) {
+        m_ok_button->setEnabled(valid && canSign() && !m_busy);
+    }
+}
+
+void MasternodeActionDialog::showError(const QString& message)
+{
+    m_status_label->setText(message);
+    m_status_label->setVisible(true);
+}
+
+void MasternodeActionDialog::clearError()
+{
+    m_status_label->clear();
+    m_status_label->setVisible(false);
+}
+
+void MasternodeActionDialog::setBusy(bool busy)
+{
+    m_busy = busy;
+    if (busy) {
+        QApplication::setOverrideCursor(Qt::WaitCursor);
+    } else {
+        QApplication::restoreOverrideCursor();
+    }
+    m_button_box->setEnabled(!busy);
+    setOkValid(m_valid);
+}
+
+void MasternodeActionDialog::runProTx(const QString& method, const UniValue& params)
+{
+    if (m_busy || !canSign()) return;
+
+    WalletModel::UnlockContext ctx(m_wallet_model->requestUnlock());
+    if (!ctx.isValid()) return;
+
+    clearError();
+    setBusy(true);
+
+    ProTxResult result;
+    QEventLoop loop;
+    connect(m_sender, &ProTxSender::finished, &loop, [&](const ProTxResult& r) {
+        result = r;
+        loop.quit();
+    });
+    if (!m_sender->execute(method, params, m_wallet_model)) {
+        setBusy(false);
+        return;
+    }
+    // The unlock context cannot be moved, so wait here on the GUI thread to keep
+    // it alive until the worker thread reports back
+    loop.exec();
+    setBusy(false);
+
+    if (!result.ok) {
+        showError(result.message);
+        return;
+    }
+
+    const QString txid{result.value.isStr() ? QString::fromStdString(result.value.get_str()) :
+                                              QString::fromStdString(result.value.write())};
+    QMessageBox::information(this, windowTitle(),
+                             tr("The transaction was sent successfully.") + "\n\n" + tr("Transaction ID: %1").arg(txid));
+    accept();
+}
+
+UpdateServiceDialog::UpdateServiceDialog(interfaces::Node& node, WalletModel* wallet_model, const MasternodeEntry& entry, QWidget* parent) :
+    MasternodeActionDialog(node, wallet_model, entry, parent),
+    m_type{entry.type()},
+    m_operator_reward_pct{entry.operatorRewardPct()},
+    m_v24_active{node.isV24Active()}
+{
+    auto* form = new QFormLayout();
+
+    m_addrs_edit = new QLineEdit(this);
+    m_addrs_edit->setText(entry.service());
+    m_addrs_edit->setPlaceholderText(tr("IP:PORT, comma-separated for multiple entries"));
+    if (!m_v24_active) {
+        m_addrs_edit->setToolTip(tr("Multiple addresses require the v24 hard fork to be active."));
+    }
+    connect(m_addrs_edit, &QLineEdit::textChanged, this, &UpdateServiceDialog::validate);
+    form->addRow(tr("Service addresses:"), m_addrs_edit);
+
+    m_operator_key_edit = new QLineEdit(this);
+    m_operator_key_edit->setEchoMode(QLineEdit::Password);
+    m_operator_key_edit->setPlaceholderText(tr("Operator BLS secret key (64 hex characters)"));
+    connect(m_operator_key_edit, &QLineEdit::textChanged, this, &UpdateServiceDialog::validate);
+    form->addRow(tr("Operator secret key:"), m_operator_key_edit);
+
+    if (m_type == MnType::Evo) {
+        m_platform_node_id_edit = new QLineEdit(this);
+        m_platform_node_id_edit->setPlaceholderText(tr("Platform node ID (40 hex characters)"));
+        connect(m_platform_node_id_edit, &QLineEdit::textChanged, this, &UpdateServiceDialog::validate);
+        form->addRow(tr("Platform node ID:"), m_platform_node_id_edit);
+
+        m_platform_p2p_edit = new QLineEdit(this);
+        m_platform_p2p_edit->setPlaceholderText(tr("IP:PORT, comma-separated for multiple entries"));
+        connect(m_platform_p2p_edit, &QLineEdit::textChanged, this, &UpdateServiceDialog::validate);
+        form->addRow(tr("Platform P2P addresses:"), m_platform_p2p_edit);
+
+        m_platform_https_edit = new QLineEdit(this);
+        m_platform_https_edit->setPlaceholderText(tr("IP:PORT, comma-separated for multiple entries"));
+        connect(m_platform_https_edit, &QLineEdit::textChanged, this, &UpdateServiceDialog::validate);
+        form->addRow(tr("Platform HTTPS addresses:"), m_platform_https_edit);
+    }
+
+    if (m_operator_reward_pct > 0) {
+        m_operator_payout_edit = new QValidatedLineEdit(this);
+        GUIUtil::setupAddressWidget(m_operator_payout_edit, this);
+        m_operator_payout_edit->setPlaceholderText(tr("Leave blank to keep the current operator payout address"));
+        connect(m_operator_payout_edit, &QLineEdit::textChanged, this, &UpdateServiceDialog::validate);
+        form->addRow(tr("Operator payout address:"), m_operator_payout_edit);
+    }
+
+    m_fee_source = new FeeSourcePicker(this);
+    m_fee_source->setWalletModel(wallet_model);
+    m_fee_source->refresh();
+    auto* fee_note = new QLabel(m_is_shared ?
+                                    tr("Required: a shared masternode has no payout address of its own to pay the transaction fee from.") :
+                                    tr("Optional: when no address is selected the fee is paid from the operator payout or masternode payout address."),
+                                this);
+    fee_note->setWordWrap(true);
+    auto* fee_box = new QVBoxLayout();
+    fee_box->addWidget(m_fee_source);
+    fee_box->addWidget(fee_note);
+    form->addRow(tr("Fee source:"), fee_box);
+
+    setupUi(m_type == MnType::Evo ? tr("Update Evonode Service") : tr("Update Masternode Service"),
+            tr("Update the network addresses this masternode is reachable at. Signing requires the operator secret key. A successful update also revives a PoSe-banned masternode."),
+            form, tr("Send Update"));
+}
+
+void UpdateServiceDialog::validate()
+{
+    const QStringList addrs{SplitAddressList(m_addrs_edit->text())};
+    bool ok{!addrs.isEmpty()};
+    if (!m_v24_active && addrs.size() > 1) ok = false;
+    ok &= IsHexString(m_operator_key_edit->text().trimmed(), 64);
+    if (m_operator_payout_edit) {
+        ok &= m_operator_payout_edit->text().isEmpty() || m_operator_payout_edit->isValid();
+    }
+    if (m_type == MnType::Evo) {
+        ok &= IsHexString(m_platform_node_id_edit->text().trimmed(), 40);
+        ok &= !SplitAddressList(m_platform_p2p_edit->text()).isEmpty();
+        ok &= !SplitAddressList(m_platform_https_edit->text()).isEmpty();
+    }
+    setOkValid(ok);
+}
+
+void UpdateServiceDialog::submit()
+{
+    const QString fee_source{m_fee_source->selectedAddress()};
+    if (m_is_shared && fee_source.isEmpty()) {
+        showError(tr("Select a fee source address. A shared masternode requires one."));
+        return;
+    }
+
+    UniValue params(UniValue::VOBJ);
+    params.pushKV("proTxHash", m_protx_hash.toStdString());
+    params.pushKV("coreP2PAddrs", AddressArray(SplitAddressList(m_addrs_edit->text())));
+    params.pushKV("operatorKey", m_operator_key_edit->text().trimmed().toStdString());
+    if (m_type == MnType::Evo) {
+        params.pushKV("platformNodeID", m_platform_node_id_edit->text().trimmed().toStdString());
+        params.pushKV("platformP2PAddrs", AddressArray(SplitAddressList(m_platform_p2p_edit->text())));
+        params.pushKV("platformHTTPSAddrs", AddressArray(SplitAddressList(m_platform_https_edit->text())));
+    }
+    if (m_operator_payout_edit && !m_operator_payout_edit->text().isEmpty()) {
+        params.pushKV("operatorPayoutAddress", m_operator_payout_edit->text().trimmed().toStdString());
+    }
+    if (!fee_source.isEmpty()) {
+        params.pushKV("feeSourceAddress", fee_source.toStdString());
+    }
+
+    runProTx(m_type == MnType::Evo ? "protx update_service_evo" : "protx update_service", params);
+}
+
+UpdateRegistrarDialog::UpdateRegistrarDialog(interfaces::Node& node, WalletModel* wallet_model, const MasternodeEntry& entry, QWidget* parent) :
+    MasternodeActionDialog(node, wallet_model, entry, parent)
+{
+    auto* form = new QFormLayout();
+
+    m_operator_pubkey_edit = new QLineEdit(this);
+    m_operator_pubkey_edit->setPlaceholderText(tr("Leave blank to keep the current operator key"));
+    connect(m_operator_pubkey_edit, &QLineEdit::textChanged, this, &UpdateRegistrarDialog::validate);
+    form->addRow(tr("Operator public key:"), m_operator_pubkey_edit);
+
+    auto* warning_label = new QLabel(tr("Changing the operator key immediately PoSe-bans the masternode. It stays banned until the new operator sends a provider update service transaction."), this);
+    warning_label->setWordWrap(true);
+    warning_label->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_WARNING));
+    form->addRow(warning_label);
+
+    m_voting_edit = new QValidatedLineEdit(this);
+    GUIUtil::setupAddressWidget(m_voting_edit, this);
+    m_voting_edit->setPlaceholderText(tr("Leave blank to keep the current voting address"));
+    connect(m_voting_edit, &QLineEdit::textChanged, this, &UpdateRegistrarDialog::validate);
+    form->addRow(tr("Voting address:"), m_voting_edit);
+
+    m_payout_edit = new QValidatedLineEdit(this);
+    GUIUtil::setupAddressWidget(m_payout_edit, this);
+    m_payout_edit->setPlaceholderText(tr("Leave blank to keep the current payout address"));
+    connect(m_payout_edit, &QLineEdit::textChanged, this, &UpdateRegistrarDialog::validate);
+    form->addRow(tr("Payout address:"), m_payout_edit);
+
+    m_fee_source = new FeeSourcePicker(this);
+    m_fee_source->setWalletModel(wallet_model);
+    m_fee_source->refresh();
+    auto* fee_note = new QLabel(tr("Optional: when no address is selected the fee is paid from the masternode payout address."), this);
+    fee_note->setWordWrap(true);
+    auto* fee_box = new QVBoxLayout();
+    fee_box->addWidget(m_fee_source);
+    fee_box->addWidget(fee_note);
+    form->addRow(tr("Fee source:"), fee_box);
+
+    setupUi(tr("Update Masternode Registrar"),
+            tr("Update the operator key, voting address or payout address of this masternode. The masternode owner key must be present in this wallet. Fields left blank keep their current value."),
+            form, tr("Send Update"));
+
+    // Shared masternodes manage keys and payouts per share; a ProUpRegTx does not
+    // apply to them. Callers should not offer this dialog for shared rows, but
+    // guard here as well.
+    if (m_is_shared) {
+        m_operator_pubkey_edit->setEnabled(false);
+        m_voting_edit->setEnabled(false);
+        m_payout_edit->setEnabled(false);
+        m_fee_source->setEnabled(false);
+        showError(tr("This masternode is shared. Shared masternodes are updated per share and cannot use a registrar update."));
+    }
+}
+
+void UpdateRegistrarDialog::validate()
+{
+    if (m_is_shared) {
+        setOkValid(false);
+        return;
+    }
+    const QString operator_pubkey{m_operator_pubkey_edit->text().trimmed()};
+    const bool any_change{!operator_pubkey.isEmpty() || !m_voting_edit->text().isEmpty() || !m_payout_edit->text().isEmpty()};
+    bool ok{any_change};
+    if (!operator_pubkey.isEmpty()) ok &= IsHexString(operator_pubkey, 96);
+    ok &= m_voting_edit->text().isEmpty() || m_voting_edit->isValid();
+    ok &= m_payout_edit->text().isEmpty() || m_payout_edit->isValid();
+    setOkValid(ok);
+}
+
+void UpdateRegistrarDialog::submit()
+{
+    if (m_is_shared) return;
+
+    // The three update fields are mandatory RPC arguments; an empty string keeps
+    // the current value.
+    UniValue params(UniValue::VOBJ);
+    params.pushKV("proTxHash", m_protx_hash.toStdString());
+    params.pushKV("operatorPubKey", m_operator_pubkey_edit->text().trimmed().toStdString());
+    params.pushKV("votingAddress", m_voting_edit->text().trimmed().toStdString());
+    params.pushKV("payoutAddress", m_payout_edit->text().trimmed().toStdString());
+    const QString fee_source{m_fee_source->selectedAddress()};
+    if (!fee_source.isEmpty()) {
+        params.pushKV("feeSourceAddress", fee_source.toStdString());
+    }
+
+    runProTx("protx update_registrar", params);
+}
+
+RevokeDialog::RevokeDialog(interfaces::Node& node, WalletModel* wallet_model, const MasternodeEntry& entry, QWidget* parent) :
+    MasternodeActionDialog(node, wallet_model, entry, parent)
+{
+    auto* form = new QFormLayout();
+
+    // Values follow CProUpRevTx::RevocationReason
+    m_reason_combo = new QComboBox(this);
+    m_reason_combo->addItem(tr("Not specified"), 0);
+    m_reason_combo->addItem(tr("Termination of service"), 1);
+    m_reason_combo->addItem(tr("Compromised keys"), 2);
+    m_reason_combo->addItem(tr("Change of keys"), 3);
+    form->addRow(tr("Reason:"), m_reason_combo);
+
+    m_operator_key_edit = new QLineEdit(this);
+    m_operator_key_edit->setEchoMode(QLineEdit::Password);
+    m_operator_key_edit->setPlaceholderText(tr("Operator BLS secret key (64 hex characters)"));
+    connect(m_operator_key_edit, &QLineEdit::textChanged, this, &RevokeDialog::validate);
+    form->addRow(tr("Operator secret key:"), m_operator_key_edit);
+
+    m_fee_source = new FeeSourcePicker(this);
+    m_fee_source->setWalletModel(wallet_model);
+    m_fee_source->refresh();
+    auto* fee_note = new QLabel(m_is_shared ?
+                                    tr("Required: a shared masternode has no payout address of its own to pay the transaction fee from.") :
+                                    tr("Optional: when no address is selected the fee is paid from the operator payout or masternode payout address."),
+                                this);
+    fee_note->setWordWrap(true);
+    auto* fee_box = new QVBoxLayout();
+    fee_box->addWidget(m_fee_source);
+    fee_box->addWidget(fee_note);
+    form->addRow(tr("Fee source:"), fee_box);
+
+    setupUi(tr("Revoke Masternode Service"),
+            tr("Revoking clears the masternode's service address and PoSe-bans it until a new operator key is set with a registrar update. The collateral is not affected. This is mainly needed before re-registering with the same IP address or operator key."),
+            form, tr("Revoke"));
+}
+
+void RevokeDialog::validate()
+{
+    setOkValid(IsHexString(m_operator_key_edit->text().trimmed(), 64));
+}
+
+void RevokeDialog::submit()
+{
+    const QString fee_source{m_fee_source->selectedAddress()};
+    if (m_is_shared && fee_source.isEmpty()) {
+        showError(tr("Select a fee source address. A shared masternode requires one."));
+        return;
+    }
+
+    UniValue params(UniValue::VOBJ);
+    params.pushKV("proTxHash", m_protx_hash.toStdString());
+    params.pushKV("operatorKey", m_operator_key_edit->text().trimmed().toStdString());
+    params.pushKV("reason", m_reason_combo->currentData().toInt());
+    if (!fee_source.isEmpty()) {
+        params.pushKV("feeSourceAddress", fee_source.toStdString());
+    }
+
+    runProTx("protx revoke", params);
+}

--- a/src/qt/masternodedialogs.cpp
+++ b/src/qt/masternodedialogs.cpp
@@ -7,6 +7,7 @@
 #include <interfaces/node.h>
 #include <interfaces/wallet.h>
 #include <univalue.h>
+#include <util/strencodings.h>
 
 #include <qt/guiutil.h>
 #include <qt/masternodemodel.h>
@@ -27,6 +28,8 @@
 #include <QSpinBox>
 #include <QStringList>
 #include <QVBoxLayout>
+
+#include <string>
 
 namespace {
 //! Split a comma-separated ADDR:PORT list into trimmed, non-empty entries
@@ -474,4 +477,74 @@ void RevokeDialog::submit()
     }
 
     runProTx("protx revoke", params);
+}
+
+ShowOperatorKeyDialog::ShowOperatorKeyDialog(WalletModel* wallet_model, const QString& protx_hash,
+                                             const std::vector<unsigned char>& operator_pubkey, QWidget* parent) :
+    QDialog(parent)
+{
+    using namespace MasternodeWidgetUtil;
+
+    setWindowTitle(tr("Operator Key"));
+    setMinimumWidth(650);
+
+    // Read the key back out of the wallet first: without it this dialog has
+    // nothing to show but the reason why
+    std::vector<unsigned char> secret;
+    std::string derivation_path;
+    QString failure;
+    if (wallet_model == nullptr) {
+        failure = tr("No wallet is available.");
+    } else {
+        WalletModel::UnlockContext ctx(wallet_model->requestUnlock());
+        std::string error;
+        if (!ctx.isValid()) {
+            failure = tr("The wallet stayed locked, so the operator secret key cannot be shown.");
+        } else if (!wallet_model->wallet().getMasternodeOperatorKey(operator_pubkey, secret, derivation_path,
+                                                                    error)) {
+            failure = tr("This wallet could not produce the operator secret key: %1")
+                          .arg(QString::fromStdString(error));
+        }
+    }
+
+    auto* layout = new QVBoxLayout(this);
+    layout->setSpacing(TITLE_SPACING);
+
+    auto* protx_label = new QLabel(tr("Masternode: %1").arg(protx_hash), this);
+    protx_label->setWordWrap(true);
+    protx_label->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    layout->addWidget(protx_label);
+
+    if (failure.isEmpty()) {
+        const QString public_hex{QString::fromStdString(HexStr(operator_pubkey))};
+        const QString secret_hex{QString::fromStdString(HexStr(secret))};
+        layout->addWidget(makeHint(tr("Operator public key"), this));
+        layout->addWidget(makeCopyableValue(chunked(public_hex), public_hex, this));
+        layout->addSpacing(GROUP_SPACING);
+        layout->addWidget(makeHint(tr("Operator secret key"), this));
+        layout->addWidget(makeCopyableValue(chunked(secret_hex), secret_hex, this));
+        layout->addSpacing(GROUP_SPACING);
+        layout->addWidget(makeHint(tr("Add this line to dash.conf on your masternode server:"), this));
+        const QString conf_line{QString("masternodeblsprivkey=%1").arg(secret_hex)};
+        layout->addWidget(makeCopyableValue(QString("masternodeblsprivkey=%1").arg(chunked(secret_hex)), conf_line,
+                                            this));
+        layout->addSpacing(GROUP_SPACING);
+        layout->addWidget(makeHint(derivation_path.empty() ?
+                                       tr("This key is stored in this wallet — include it in your wallet backup.") :
+                                       tr("This key is derived from this wallet's recovery phrase (path %1), so "
+                                          "restoring that phrase brings it back.")
+                                           .arg(QString::fromStdString(derivation_path)),
+                                   this));
+    } else {
+        auto* failure_label = new QLabel(failure, this);
+        failure_label->setWordWrap(true);
+        failure_label->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
+        layout->addWidget(failure_label);
+    }
+
+    auto* button_box = new QDialogButtonBox(QDialogButtonBox::Close, this);
+    connect(button_box, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    layout->addWidget(button_box);
+
+    GUIUtil::updateFonts();
 }

--- a/src/qt/masternodedialogs.h
+++ b/src/qt/masternodedialogs.h
@@ -10,6 +10,8 @@
 #include <QDialog>
 #include <QString>
 
+#include <vector>
+
 class FeeSourcePicker;
 class MasternodeEntry;
 class ProTxSender;
@@ -162,6 +164,22 @@ private:
     QComboBox* m_reason_combo{nullptr};
     QLineEdit* m_operator_key_edit{nullptr};
     FeeSourcePicker* m_fee_source{nullptr};
+};
+
+//! Show the operator secret key this wallet holds for a masternode, together
+//! with the dash.conf line the masternode server needs. Sends nothing: it only
+//! reads the key back out of the wallet, which is why it is a plain dialog
+//! rather than a MasternodeActionDialog.
+class ShowOperatorKeyDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    //! `operator_pubkey` must be one of listMasternodeOperatorKeys(), passed back
+    //! as the wallet's own bytes. The wallet is unlocked while constructing; when
+    //! that is refused the dialog shows the reason instead of the key.
+    ShowOperatorKeyDialog(WalletModel* wallet_model, const QString& protx_hash,
+                          const std::vector<unsigned char>& operator_pubkey, QWidget* parent = nullptr);
 };
 
 #endif // BITCOIN_QT_MASTERNODEDIALOGS_H

--- a/src/qt/masternodedialogs.h
+++ b/src/qt/masternodedialogs.h
@@ -15,10 +15,12 @@ class MasternodeEntry;
 class ProTxSender;
 class QComboBox;
 class QDialogButtonBox;
+class QFormLayout;
 class QLabel;
 class QLayout;
 class QLineEdit;
 class QPushButton;
+class QSpinBox;
 class QValidatedLineEdit;
 class UniValue;
 class WalletModel;
@@ -34,12 +36,21 @@ class MasternodeActionDialog : public QDialog
 {
     Q_OBJECT
 
+public Q_SLOTS:
+    //! Ignore Esc, Cancel and window-close while a protx command is in flight,
+    //! so the dialog cannot disappear mid-transaction
+    void reject() override;
+
 protected:
     MasternodeActionDialog(interfaces::Node& node, WalletModel* wallet_model, const MasternodeEntry& entry, QWidget* parent);
 
     //! Complete construction: place `form` between the intro text and the error
     //! label + button box, then run the first validate() pass
     void setupUi(const QString& title, const QString& intro, QLayout* form, const QString& ok_text);
+
+    //! Append a "Fee source:" row (picker plus explanatory `note`) to `form` and
+    //! return the picker, already wired to the dialog's wallet model
+    FeeSourcePicker* addFeeSourceRow(QFormLayout* form, const QString& note);
 
     //! True when a wallet able to sign transactions is available
     bool canSign() const;
@@ -100,8 +111,12 @@ private:
     QLineEdit* m_addrs_edit{nullptr};
     QLineEdit* m_operator_key_edit{nullptr};
     QLineEdit* m_platform_node_id_edit{nullptr};
+    // v24 active: ADDR:PORT lists. Pre-v24 a ProUpServTx only carries bare
+    // Platform port numbers, so port spinboxes are shown instead.
     QLineEdit* m_platform_p2p_edit{nullptr};
     QLineEdit* m_platform_https_edit{nullptr};
+    QSpinBox* m_platform_p2p_port_edit{nullptr};
+    QSpinBox* m_platform_https_port_edit{nullptr};
     QValidatedLineEdit* m_operator_payout_edit{nullptr};
     FeeSourcePicker* m_fee_source{nullptr};
 };

--- a/src/qt/masternodedialogs.h
+++ b/src/qt/masternodedialogs.h
@@ -175,9 +175,10 @@ class ShowOperatorKeyDialog : public QDialog
     Q_OBJECT
 
 public:
-    //! `operator_pubkey` must be one of listMasternodeOperatorKeys(), passed back
-    //! as the wallet's own bytes. The wallet is unlocked while constructing; when
-    //! that is refused the dialog shows the reason instead of the key.
+    //! `operator_pubkey` is the masternode's registered operator public key, 48
+    //! bytes in basic-scheme serialization. The wallet is unlocked while
+    //! constructing; when that is refused, or the key turns out not to be this
+    //! wallet's after all, the dialog says so instead of showing a key.
     ShowOperatorKeyDialog(WalletModel* wallet_model, const QString& protx_hash,
                           const std::vector<unsigned char>& operator_pubkey, QWidget* parent = nullptr);
 };

--- a/src/qt/masternodedialogs.h
+++ b/src/qt/masternodedialogs.h
@@ -1,0 +1,152 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_MASTERNODEDIALOGS_H
+#define BITCOIN_QT_MASTERNODEDIALOGS_H
+
+#include <evo/dmn_types.h>
+
+#include <QDialog>
+#include <QString>
+
+class FeeSourcePicker;
+class MasternodeEntry;
+class ProTxSender;
+class QComboBox;
+class QDialogButtonBox;
+class QLabel;
+class QLayout;
+class QLineEdit;
+class QPushButton;
+class QValidatedLineEdit;
+class UniValue;
+class WalletModel;
+
+namespace interfaces {
+class Node;
+} // namespace interfaces
+
+//! Shared scaffolding for the small masternode maintenance dialogs: intro text,
+//! a caller-built form, an error label and OK/Cancel buttons; wallet and
+//! watch-only gating; and the unlock + busy-state + ProTxSender round trip.
+class MasternodeActionDialog : public QDialog
+{
+    Q_OBJECT
+
+protected:
+    MasternodeActionDialog(interfaces::Node& node, WalletModel* wallet_model, const MasternodeEntry& entry, QWidget* parent);
+
+    //! Complete construction: place `form` between the intro text and the error
+    //! label + button box, then run the first validate() pass
+    void setupUi(const QString& title, const QString& intro, QLayout* form, const QString& ok_text);
+
+    //! True when a wallet able to sign transactions is available
+    bool canSign() const;
+    //! Record the outcome of the derived dialog's validate() pass; the OK button
+    //! additionally requires canSign() and no command in flight
+    void setOkValid(bool valid);
+    void showError(const QString& message);
+    void clearError();
+    //! Unlock the wallet, execute `method` with named `params` on the RPC bridge
+    //! and report the outcome (error label on failure, txid message box + accept()
+    //! on success). Waits in a local event loop so the unlock context stays alive
+    //! on the GUI thread across the call; the dialog is disabled meanwhile.
+    void runProTx(const QString& method, const UniValue& params);
+
+    interfaces::Node& m_node;
+    WalletModel* const m_wallet_model;
+    const QString m_protx_hash;
+    const bool m_is_shared;
+
+protected Q_SLOTS:
+    //! Recompute field validity and call setOkValid()
+    virtual void validate() = 0;
+    //! Perform final checks, assemble named params and call runProTx()
+    virtual void submit() = 0;
+
+private:
+    void setBusy(bool busy);
+
+    ProTxSender* m_sender;
+    QDialogButtonBox* m_button_box{nullptr};
+    QPushButton* m_ok_button{nullptr};
+    QLabel* m_status_label{nullptr};
+    bool m_busy{false};
+    bool m_valid{false};
+};
+
+//! Send a ProUpServTx ("protx update_service" / "protx update_service_evo"):
+//! update the network addresses (and for evonodes the Platform fields) of a
+//! masternode, signed with the operator secret key. Also revives a PoSe-banned
+//! masternode. A fee source is mandatory for shared masternodes, which have no
+//! payout address of their own to draw the fee from.
+class UpdateServiceDialog : public MasternodeActionDialog
+{
+    Q_OBJECT
+
+public:
+    UpdateServiceDialog(interfaces::Node& node, WalletModel* wallet_model, const MasternodeEntry& entry, QWidget* parent = nullptr);
+
+protected:
+    void validate() override;
+    void submit() override;
+
+private:
+    const MnType m_type;
+    const uint16_t m_operator_reward_pct;
+    const bool m_v24_active;
+
+    QLineEdit* m_addrs_edit{nullptr};
+    QLineEdit* m_operator_key_edit{nullptr};
+    QLineEdit* m_platform_node_id_edit{nullptr};
+    QLineEdit* m_platform_p2p_edit{nullptr};
+    QLineEdit* m_platform_https_edit{nullptr};
+    QValidatedLineEdit* m_operator_payout_edit{nullptr};
+    FeeSourcePicker* m_fee_source{nullptr};
+};
+
+//! Send a ProUpRegTx ("protx update_registrar"): update the operator key,
+//! voting address and/or payout address of a masternode. Requires the owner key
+//! in the wallet. Never applicable to shared masternodes (guarded here as well
+//! as at the call site).
+class UpdateRegistrarDialog : public MasternodeActionDialog
+{
+    Q_OBJECT
+
+public:
+    UpdateRegistrarDialog(interfaces::Node& node, WalletModel* wallet_model, const MasternodeEntry& entry, QWidget* parent = nullptr);
+
+protected:
+    void validate() override;
+    void submit() override;
+
+private:
+    QLineEdit* m_operator_pubkey_edit{nullptr};
+    QValidatedLineEdit* m_voting_edit{nullptr};
+    QValidatedLineEdit* m_payout_edit{nullptr};
+    FeeSourcePicker* m_fee_source{nullptr};
+};
+
+//! Send a ProUpRevTx ("protx revoke"): clear the masternode's service address
+//! and PoSe-ban it until a new operator key is set, signed with the operator
+//! secret key. Mainly needed before re-registering with the same IP address or
+//! operator key.
+class RevokeDialog : public MasternodeActionDialog
+{
+    Q_OBJECT
+
+public:
+    RevokeDialog(interfaces::Node& node, WalletModel* wallet_model, const MasternodeEntry& entry, QWidget* parent = nullptr);
+
+protected:
+    void validate() override;
+    void submit() override;
+
+private:
+    QComboBox* m_reason_combo{nullptr};
+    QLineEdit* m_operator_key_edit{nullptr};
+    FeeSourcePicker* m_fee_source{nullptr};
+};
+
+#endif // BITCOIN_QT_MASTERNODEDIALOGS_H

--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -25,7 +25,8 @@
 
 bool MasternodeListSortFilterProxyModel::filterAcceptsRow(int source_row, const QModelIndex& source_parent) const
 {
-    // "Type" filter
+    // "Type" filter. Shared masternodes are MnType::Regular but surface as MasternodeModel::TYPE_SHARED
+    // here, so the "Regular" filter shows only single-owner masternodes.
     if (m_type_filter != TypeFilter::All) {
         QModelIndex idx = sourceModel()->index(source_row, MasternodeModel::TYPE, source_parent);
         int type = sourceModel()->data(idx, Qt::EditRole).toInt();
@@ -33,6 +34,9 @@ bool MasternodeListSortFilterProxyModel::filterAcceptsRow(int source_row, const 
             return false;
         }
         if (m_type_filter == TypeFilter::Evo && type != static_cast<int>(MnType::Evo)) {
+            return false;
+        }
+        if (m_type_filter == TypeFilter::Shared && type != MasternodeModel::TYPE_SHARED) {
             return false;
         }
     }
@@ -231,9 +235,8 @@ void MasternodeList::updateMasternodeList()
         })};
         bool fMyMasternode{setOutpts.count(entry->collateralOutpointRaw()) ||
                            walletModel->wallet().isSpendable(PKHash(entry->keyIdOwnerRaw())) ||
-                           owns_share ||
                            walletModel->wallet().isSpendable(PKHash(entry->keyIdVotingRaw())) ||
-                           owns_payout ||
+                           owns_payout || owns_share ||
                            walletModel->wallet().isSpendable(entry->scriptOperatorPayoutRaw())};
         if (fMyMasternode) {
             owned_mns.insert(entry->proTxHash());
@@ -335,7 +338,17 @@ void MasternodeList::extraInfoDIP3_clicked()
         return;
     }
 
-    auto* dialog = new DescriptionDialog(tr("Details for Masternode %1").arg(entry->proTxHash()), entry->toHtml(), /*parent=*/this);
+    QSet<int> my_share_indexes;
+    if (walletModel && entry->isShared()) {
+        const auto& shares{entry->shares()};
+        for (size_t i = 0; i < shares.size(); ++i) {
+            if (walletModel->wallet().isSpendable(PKHash(shares[i].keyIDOwner))) {
+                my_share_indexes.insert(static_cast<int>(i));
+            }
+        }
+    }
+    auto* dialog = new DescriptionDialog(tr("Details for Masternode %1").arg(entry->proTxHash()),
+                                         entry->toHtml(m_model->currentHeight(), my_share_indexes), /*parent=*/this);
     dialog->resize(1000, 500);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->show();

--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -5,7 +5,9 @@
 #include <qt/masternodelist.h>
 #include <qt/forms/ui_masternodelist.h>
 
+#include <bls/bls.h>
 #include <script/standard.h>
+#include <univalue.h>
 
 #include <qt/clientfeeds.h>
 #include <qt/clientmodel.h>
@@ -26,6 +28,7 @@
 #include <QThread>
 
 #include <set>
+#include <vector>
 
 bool MasternodeListSortFilterProxyModel::filterAcceptsRow(int source_row, const QModelIndex& source_parent) const
 {
@@ -126,6 +129,7 @@ MasternodeList::MasternodeList(QWidget* parent) :
     contextMenuDIP3 = new QMenu(this);
     contextMenuDIP3->addAction(tr("Copy ProTx Hash"), this, &MasternodeList::copyProTxHash_clicked);
     contextMenuDIP3->addAction(tr("Copy Collateral Outpoint"), this, &MasternodeList::copyCollateralOutpoint_clicked);
+    m_action_show_operator_key = contextMenuDIP3->addAction(tr("Show Operator Key…"), this, &MasternodeList::onShowOperatorKey);
     contextMenuDIP3->addSeparator();
     m_action_update_service = contextMenuDIP3->addAction(tr("Update Service…"), this, &MasternodeList::onUpdateService);
     m_action_update_registrar = contextMenuDIP3->addAction(tr("Update Registrar…"), this, &MasternodeList::onUpdateRegistrar);
@@ -267,6 +271,13 @@ void MasternodeList::showContextMenuDIP3(const QPoint& point)
     }
     m_action_update_registrar->setToolTip(registrar_tooltip);
 
+    // Only offered when this wallet can actually produce the secret behind the
+    // registered operator public key
+    const bool have_operator_key{have_wallet && !heldOperatorKey(*entry).empty()};
+    m_action_show_operator_key->setEnabled(have_operator_key);
+    m_action_show_operator_key->setToolTip(
+        have_operator_key ? QString() : tr("This wallet does not hold this masternode's operator secret key"));
+
     // Every shared masternode renders the null owner key as the same placeholder
     // address, so filtering by it would match all shared entries
     m_action_filter_owner->setEnabled(entry != nullptr && !entry->isShared());
@@ -349,6 +360,56 @@ void MasternodeList::onDissolve()
         DissolveDialog dlg(clientModel->node(), walletModel, *entry, m_model->currentHeight(), this);
         dlg.exec();
     }
+}
+
+std::vector<unsigned char> MasternodeList::heldOperatorKey(const MasternodeEntry& entry) const
+{
+    if (!walletModel) {
+        return {};
+    }
+    // TODO: read the operator key off the entry once MasternodeEntry exposes it
+    // instead of only its JSON rendering
+    UniValue json;
+    if (!json.read(entry.toJson().toStdString())) {
+        return {};
+    }
+    const UniValue& state{json.find_value("state")};
+    if (!state.isObject()) {
+        return {};
+    }
+    const UniValue& registered{state.find_value("pubKeyOperator")};
+    if (!registered.isStr()) {
+        return {};
+    }
+    const QString registered_hex{QString::fromStdString(registered.get_str())};
+    for (const auto& raw : walletModel->wallet().listMasternodeOperatorKeys()) {
+        CBLSPublicKey key;
+        key.SetBytes(raw, /*specificLegacyScheme=*/false);
+        if (!key.IsValid()) {
+            continue;
+        }
+        // A masternode registered before the basic scheme renders its key the
+        // legacy way, so compare against both renderings of the wallet's own key
+        if (registered_hex == QString::fromStdString(key.ToString(/*specificLegacyScheme=*/false)) ||
+            registered_hex == QString::fromStdString(key.ToString(/*specificLegacyScheme=*/true))) {
+            return raw;
+        }
+    }
+    return {};
+}
+
+void MasternodeList::onShowOperatorKey()
+{
+    const auto* entry = selectedEntryForDialog();
+    if (!entry) {
+        return;
+    }
+    const std::vector<unsigned char> pubkey{heldOperatorKey(*entry)};
+    if (pubkey.empty()) {
+        return;
+    }
+    ShowOperatorKeyDialog dlg(walletModel, entry->proTxHash(), pubkey, this);
+    dlg.exec();
 }
 
 void MasternodeList::onRotateSharedKeys()

--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -137,7 +137,7 @@ MasternodeList::MasternodeList(QWidget* parent) :
     QMenu* filterMenu = contextMenuDIP3->addMenu(tr("Filter by"));
     filterMenu->addAction(tr("Collateral Address"), this, &MasternodeList::filterByCollateralAddress);
     filterMenu->addAction(tr("Payout Address"), this, &MasternodeList::filterByPayoutAddress);
-    filterMenu->addAction(tr("Owner Address"), this, &MasternodeList::filterByOwnerAddress);
+    m_action_filter_owner = filterMenu->addAction(tr("Owner Address"), this, &MasternodeList::filterByOwnerAddress);
     filterMenu->addAction(tr("Voting Address"), this, &MasternodeList::filterByVotingAddress);
 
     ui->btnRegisterMasternode->setEnabled(false);
@@ -177,9 +177,13 @@ void MasternodeList::changeEvent(QEvent* event)
 void MasternodeList::setClientModel(ClientModel* model)
 {
     this->clientModel = model;
+    updateActionButtons();
     if (!clientModel) {
         return;
     }
+    // Re-check the v24 gate as the chain advances so the Shared Masternode button
+    // unlocks when the fork activates
+    connect(clientModel, &ClientModel::numBlocksChanged, this, &MasternodeList::updateActionButtons);
     m_feed = clientModel->feedMasternode();
     if (m_feed) {
         connect(m_feed, &MasternodeFeed::dataReady, this, &MasternodeList::updateMasternodeList);
@@ -194,16 +198,32 @@ void MasternodeList::setWalletModel(WalletModel* model)
     ui->btnRegisterMasternode->setEnabled(walletModel != nullptr);
     if (!walletModel) {
         ui->btnRegisterMasternode->setToolTip(tr("Registering a masternode requires a wallet"));
-        ui->btnSharedMasternode->setToolTip(tr("Managing shared masternodes requires a wallet"));
-    } else if (clientModel && !clientModel->node().isV24Active()) {
-        ui->btnSharedMasternode->setToolTip(tr("Shared masternodes require the v24 hard fork, which is not active on this network yet"));
     } else {
-        ui->btnSharedMasternode->setEnabled(true);
-    }
-    if (walletModel) {
         QSettings settings;
         ui->checkBoxOwned->setChecked(settings.value("mnListOwnedOnly", false).toBool());
     }
+    updateActionButtons();
+}
+
+void MasternodeList::updateActionButtons()
+{
+    // setWalletModel runs before setClientModel (WalletView constructor vs.
+    // WalletFrame::setClientModel), so the v24 gate is re-evaluated whenever either
+    // model is set and on every tip change until the fork activates
+    if (!walletModel) {
+        ui->btnSharedMasternode->setEnabled(false);
+        ui->btnSharedMasternode->setToolTip(tr("Managing shared masternodes requires a wallet"));
+        return;
+    }
+    if (!m_v24_active && clientModel) {
+        // Latched once active: isV24Active() takes cs_main, so avoid re-locking on
+        // every block signal after activation
+        m_v24_active = clientModel->node().isV24Active();
+    }
+    ui->btnSharedMasternode->setEnabled(clientModel != nullptr && m_v24_active);
+    ui->btnSharedMasternode->setToolTip(
+        m_v24_active ? QString{} :
+                       tr("Shared masternodes require the v24 hard fork, which is not active on this network yet"));
 }
 
 void MasternodeList::showRegisterWizard()
@@ -240,10 +260,16 @@ void MasternodeList::showContextMenuDIP3(const QPoint& point)
     const bool can_update_registrar{have_wallet && !entry->isShared() &&
                                     walletModel->wallet().isSpendable(PKHash(entry->keyIdOwnerRaw()))};
     m_action_update_registrar->setEnabled(can_update_registrar);
-    m_action_update_registrar->setToolTip(
-        !have_wallet || can_update_registrar ? QString{} :
-        entry->isShared() ? tr("Shared masternodes update their keys with a unanimous key rotation instead") :
-                            tr("Requires this masternode's owner key in the wallet"));
+    QString registrar_tooltip;
+    if (have_wallet && !can_update_registrar) {
+        registrar_tooltip = entry->isShared() ? tr("Shared masternodes update their keys with a unanimous key rotation instead")
+                                              : tr("Requires this masternode's owner key in the wallet");
+    }
+    m_action_update_registrar->setToolTip(registrar_tooltip);
+
+    // Every shared masternode renders the null owner key as the same placeholder
+    // address, so filtering by it would match all shared entries
+    m_action_filter_owner->setEnabled(entry != nullptr && !entry->isShared());
 
     // Shared-only actions need one of this masternode's share owner keys in the wallet
     bool owns_share{false};
@@ -253,10 +279,12 @@ void MasternodeList::showContextMenuDIP3(const QPoint& point)
             return walletModel->wallet().isSpendable(PKHash(share.keyIDOwner));
         });
     }
-    const QString shared_tooltip{!have_wallet ? QString{} :
-                                 !entry->isShared() ? tr("Only available for shared masternodes") :
-                                 !owns_share       ? tr("Requires one of this masternode's share owner keys in the wallet") :
-                                                     QString{}};
+    QString shared_tooltip;
+    if (have_wallet && !entry->isShared()) {
+        shared_tooltip = tr("Only available for shared masternodes");
+    } else if (have_wallet && !owns_share) {
+        shared_tooltip = tr("Requires one of this masternode's share owner keys in the wallet");
+    }
     for (auto* action : {m_action_update_share, m_action_dissolve, m_action_rotate_keys}) {
         action->setEnabled(owns_share);
         action->setToolTip(shared_tooltip);
@@ -271,64 +299,64 @@ void MasternodeList::showContextMenuDIP3(const QPoint& point)
     contextMenuDIP3->exec(QCursor::pos());
 }
 
-void MasternodeList::onUpdateService()
+const MasternodeEntry* MasternodeList::selectedEntryForDialog(std::optional<bool> shared)
 {
     const auto* entry = GetSelectedEntry();
     if (!entry || !clientModel || !walletModel) {
-        return;
+        return nullptr;
     }
-    UpdateServiceDialog dlg(clientModel->node(), walletModel, *entry, this);
-    dlg.exec();
+    if (shared && entry->isShared() != *shared) {
+        return nullptr;
+    }
+    return entry;
+}
+
+void MasternodeList::onUpdateService()
+{
+    if (const auto* entry = selectedEntryForDialog()) {
+        UpdateServiceDialog dlg(clientModel->node(), walletModel, *entry, this);
+        dlg.exec();
+    }
 }
 
 void MasternodeList::onUpdateRegistrar()
 {
-    const auto* entry = GetSelectedEntry();
-    if (!entry || !clientModel || !walletModel || entry->isShared()) {
-        return;
+    if (const auto* entry = selectedEntryForDialog(/*shared=*/false)) {
+        UpdateRegistrarDialog dlg(clientModel->node(), walletModel, *entry, this);
+        dlg.exec();
     }
-    UpdateRegistrarDialog dlg(clientModel->node(), walletModel, *entry, this);
-    dlg.exec();
 }
 
 void MasternodeList::onRevoke()
 {
-    const auto* entry = GetSelectedEntry();
-    if (!entry || !clientModel || !walletModel) {
-        return;
+    if (const auto* entry = selectedEntryForDialog()) {
+        RevokeDialog dlg(clientModel->node(), walletModel, *entry, this);
+        dlg.exec();
     }
-    RevokeDialog dlg(clientModel->node(), walletModel, *entry, this);
-    dlg.exec();
 }
 
 void MasternodeList::onUpdateShare()
 {
-    const auto* entry = GetSelectedEntry();
-    if (!entry || !clientModel || !walletModel || !entry->isShared()) {
-        return;
+    if (const auto* entry = selectedEntryForDialog(/*shared=*/true)) {
+        UpdateShareDialog dlg(clientModel->node(), walletModel, *entry, this);
+        dlg.exec();
     }
-    UpdateShareDialog dlg(clientModel->node(), walletModel, *entry, this);
-    dlg.exec();
 }
 
 void MasternodeList::onDissolve()
 {
-    const auto* entry = GetSelectedEntry();
-    if (!entry || !clientModel || !walletModel || !entry->isShared()) {
-        return;
+    if (const auto* entry = selectedEntryForDialog(/*shared=*/true)) {
+        DissolveDialog dlg(clientModel->node(), walletModel, *entry, m_model->currentHeight(), this);
+        dlg.exec();
     }
-    DissolveDialog dlg(clientModel->node(), walletModel, *entry, m_model->currentHeight(), this);
-    dlg.exec();
 }
 
 void MasternodeList::onRotateSharedKeys()
 {
-    const auto* entry = GetSelectedEntry();
-    if (!entry || !clientModel || !walletModel || !entry->isShared()) {
-        return;
+    if (const auto* entry = selectedEntryForDialog(/*shared=*/true)) {
+        RotateSharedKeysDialog dlg(clientModel->node(), walletModel, *entry, this);
+        dlg.exec();
     }
-    RotateSharedKeysDialog dlg(clientModel->node(), walletModel, *entry, this);
-    dlg.exec();
 }
 
 void MasternodeList::updateMasternodeList()
@@ -535,7 +563,9 @@ void MasternodeList::filterByPayoutAddress()
 void MasternodeList::filterByOwnerAddress()
 {
     const auto* entry = GetSelectedEntry();
-    if (entry) {
+    // Shared masternodes have a null owner key rendered as the same placeholder
+    // address for every shared entry, so filtering by it would match them all
+    if (entry && !entry->isShared()) {
         ui->filterText->setText(entry->ownerAddress());
     }
 }

--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -11,6 +11,7 @@
 #include <qt/clientmodel.h>
 #include <qt/descriptiondialog.h>
 #include <qt/guiutil.h>
+#include <qt/masternodewizard.h>
 #include <qt/walletmodel.h>
 
 #include <QApplication>
@@ -129,6 +130,9 @@ MasternodeList::MasternodeList(QWidget* parent) :
     filterMenu->addAction(tr("Owner Address"), this, &MasternodeList::filterByOwnerAddress);
     filterMenu->addAction(tr("Voting Address"), this, &MasternodeList::filterByVotingAddress);
 
+    ui->btnRegisterMasternode->setEnabled(false);
+    connect(ui->btnRegisterMasternode, &QPushButton::clicked, this, &MasternodeList::showRegisterWizard);
+
     connect(ui->tableViewMasternodes, &QTableView::customContextMenuRequested, this, &MasternodeList::showContextMenuDIP3);
     connect(ui->tableViewMasternodes, &QTableView::doubleClicked, this, &MasternodeList::extraInfoDIP3_clicked);
     connect(m_proxy_model, &QSortFilterProxyModel::rowsInserted, this, &MasternodeList::updateFilteredCount);
@@ -175,10 +179,23 @@ void MasternodeList::setWalletModel(WalletModel* model)
 {
     this->walletModel = model;
     ui->checkBoxOwned->setEnabled(walletModel != nullptr);
+    ui->btnRegisterMasternode->setEnabled(walletModel != nullptr);
+    if (!walletModel) {
+        ui->btnRegisterMasternode->setToolTip(tr("Registering a masternode requires a wallet"));
+    }
     if (walletModel) {
         QSettings settings;
         ui->checkBoxOwned->setChecked(settings.value("mnListOwnedOnly", false).toBool());
     }
+}
+
+void MasternodeList::showRegisterWizard()
+{
+    if (!clientModel || !walletModel) {
+        return;
+    }
+    RegisterMasternodeWizard dlg(clientModel->node(), walletModel, this);
+    dlg.exec();
 }
 
 void MasternodeList::showContextMenuDIP3(const QPoint& point)

--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -11,6 +11,7 @@
 #include <qt/clientmodel.h>
 #include <qt/descriptiondialog.h>
 #include <qt/guiutil.h>
+#include <qt/masternodedialogs.h>
 #include <qt/masternodewizard.h>
 #include <qt/walletmodel.h>
 
@@ -123,6 +124,10 @@ MasternodeList::MasternodeList(QWidget* parent) :
     contextMenuDIP3 = new QMenu(this);
     contextMenuDIP3->addAction(tr("Copy ProTx Hash"), this, &MasternodeList::copyProTxHash_clicked);
     contextMenuDIP3->addAction(tr("Copy Collateral Outpoint"), this, &MasternodeList::copyCollateralOutpoint_clicked);
+    contextMenuDIP3->addSeparator();
+    m_action_update_service = contextMenuDIP3->addAction(tr("Update Service…"), this, &MasternodeList::onUpdateService);
+    m_action_update_registrar = contextMenuDIP3->addAction(tr("Update Registrar…"), this, &MasternodeList::onUpdateRegistrar);
+    m_action_revoke = contextMenuDIP3->addAction(tr("Revoke…"), this, &MasternodeList::onRevoke);
 
     QMenu* filterMenu = contextMenuDIP3->addMenu(tr("Filter by"));
     filterMenu->addAction(tr("Collateral Address"), this, &MasternodeList::filterByCollateralAddress);
@@ -201,9 +206,55 @@ void MasternodeList::showRegisterWizard()
 void MasternodeList::showContextMenuDIP3(const QPoint& point)
 {
     QModelIndex index = ui->tableViewMasternodes->indexAt(point);
-    if (index.isValid()) {
-        contextMenuDIP3->exec(QCursor::pos());
+    if (!index.isValid()) {
+        return;
     }
+
+    const auto* entry = GetSelectedEntry();
+    const bool have_wallet{walletModel != nullptr && entry != nullptr};
+    m_action_update_service->setEnabled(have_wallet);
+    m_action_revoke->setEnabled(have_wallet);
+    // ProUpRegTx is rejected for shared masternodes (owner keys are per share); it also needs
+    // the owner key in this wallet
+    const bool can_update_registrar{have_wallet && !entry->isShared() &&
+                                    walletModel->wallet().isSpendable(PKHash(entry->keyIdOwnerRaw()))};
+    m_action_update_registrar->setEnabled(can_update_registrar);
+    m_action_update_registrar->setToolTip(
+        !have_wallet || can_update_registrar ? QString{} :
+        entry->isShared() ? tr("Shared masternodes update their keys with a unanimous key rotation instead") :
+                            tr("Requires this masternode's owner key in the wallet"));
+
+    contextMenuDIP3->exec(QCursor::pos());
+}
+
+void MasternodeList::onUpdateService()
+{
+    const auto* entry = GetSelectedEntry();
+    if (!entry || !clientModel || !walletModel) {
+        return;
+    }
+    UpdateServiceDialog dlg(clientModel->node(), walletModel, *entry, this);
+    dlg.exec();
+}
+
+void MasternodeList::onUpdateRegistrar()
+{
+    const auto* entry = GetSelectedEntry();
+    if (!entry || !clientModel || !walletModel || entry->isShared()) {
+        return;
+    }
+    UpdateRegistrarDialog dlg(clientModel->node(), walletModel, *entry, this);
+    dlg.exec();
+}
+
+void MasternodeList::onRevoke()
+{
+    const auto* entry = GetSelectedEntry();
+    if (!entry || !clientModel || !walletModel) {
+        return;
+    }
+    RevokeDialog dlg(clientModel->node(), walletModel, *entry, this);
+    dlg.exec();
 }
 
 void MasternodeList::updateMasternodeList()

--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -13,6 +13,7 @@
 #include <qt/guiutil.h>
 #include <qt/masternodedialogs.h>
 #include <qt/masternodewizard.h>
+#include <qt/sharedmncreatedialog.h>
 #include <qt/walletmodel.h>
 
 #include <QApplication>
@@ -137,6 +138,8 @@ MasternodeList::MasternodeList(QWidget* parent) :
 
     ui->btnRegisterMasternode->setEnabled(false);
     connect(ui->btnRegisterMasternode, &QPushButton::clicked, this, &MasternodeList::showRegisterWizard);
+    ui->btnSharedMasternode->setEnabled(false);
+    connect(ui->btnSharedMasternode, &QPushButton::clicked, this, &MasternodeList::showSharedMnCreateDialog);
 
     connect(ui->tableViewMasternodes, &QTableView::customContextMenuRequested, this, &MasternodeList::showContextMenuDIP3);
     connect(ui->tableViewMasternodes, &QTableView::doubleClicked, this, &MasternodeList::extraInfoDIP3_clicked);
@@ -187,6 +190,11 @@ void MasternodeList::setWalletModel(WalletModel* model)
     ui->btnRegisterMasternode->setEnabled(walletModel != nullptr);
     if (!walletModel) {
         ui->btnRegisterMasternode->setToolTip(tr("Registering a masternode requires a wallet"));
+        ui->btnSharedMasternode->setToolTip(tr("Managing shared masternodes requires a wallet"));
+    } else if (clientModel && !clientModel->node().isV24Active()) {
+        ui->btnSharedMasternode->setToolTip(tr("Shared masternodes require the v24 hard fork, which is not active on this network yet"));
+    } else {
+        ui->btnSharedMasternode->setEnabled(true);
     }
     if (walletModel) {
         QSettings settings;
@@ -200,6 +208,15 @@ void MasternodeList::showRegisterWizard()
         return;
     }
     RegisterMasternodeWizard dlg(clientModel->node(), walletModel, this);
+    dlg.exec();
+}
+
+void MasternodeList::showSharedMnCreateDialog()
+{
+    if (!clientModel || !walletModel) {
+        return;
+    }
+    SharedMnCreateDialog dlg(clientModel->node(), walletModel, this);
     dlg.exec();
 }
 

--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -14,6 +14,7 @@
 #include <qt/masternodedialogs.h>
 #include <qt/masternodewizard.h>
 #include <qt/sharedmncreatedialog.h>
+#include <qt/sharedmndialogs.h>
 #include <qt/walletmodel.h>
 
 #include <QApplication>
@@ -129,6 +130,9 @@ MasternodeList::MasternodeList(QWidget* parent) :
     m_action_update_service = contextMenuDIP3->addAction(tr("Update Service…"), this, &MasternodeList::onUpdateService);
     m_action_update_registrar = contextMenuDIP3->addAction(tr("Update Registrar…"), this, &MasternodeList::onUpdateRegistrar);
     m_action_revoke = contextMenuDIP3->addAction(tr("Revoke…"), this, &MasternodeList::onRevoke);
+    m_action_update_share = contextMenuDIP3->addAction(tr("Change My Reward Address…"), this, &MasternodeList::onUpdateShare);
+    m_action_dissolve = contextMenuDIP3->addAction(tr("Dissolve…"), this, &MasternodeList::onDissolve);
+    m_action_rotate_keys = contextMenuDIP3->addAction(tr("Rotate Operator/Voting Keys…"), this, &MasternodeList::onRotateSharedKeys);
 
     QMenu* filterMenu = contextMenuDIP3->addMenu(tr("Filter by"));
     filterMenu->addAction(tr("Collateral Address"), this, &MasternodeList::filterByCollateralAddress);
@@ -241,6 +245,29 @@ void MasternodeList::showContextMenuDIP3(const QPoint& point)
         entry->isShared() ? tr("Shared masternodes update their keys with a unanimous key rotation instead") :
                             tr("Requires this masternode's owner key in the wallet"));
 
+    // Shared-only actions need one of this masternode's share owner keys in the wallet
+    bool owns_share{false};
+    if (have_wallet && entry->isShared()) {
+        const auto& shares{entry->shares()};
+        owns_share = std::any_of(shares.begin(), shares.end(), [&](const auto& share) {
+            return walletModel->wallet().isSpendable(PKHash(share.keyIDOwner));
+        });
+    }
+    const QString shared_tooltip{!have_wallet ? QString{} :
+                                 !entry->isShared() ? tr("Only available for shared masternodes") :
+                                 !owns_share       ? tr("Requires one of this masternode's share owner keys in the wallet") :
+                                                     QString{}};
+    for (auto* action : {m_action_update_share, m_action_dissolve, m_action_rotate_keys}) {
+        action->setEnabled(owns_share);
+        action->setToolTip(shared_tooltip);
+        action->setVisible(!have_wallet || entry->isShared());
+    }
+    if (owns_share && !DissolveDialog::StandbyStored(entry->proTxHash())) {
+        m_action_dissolve->setText(tr("Dissolve…") + " ⚠ " + tr("(no standby dissolution stored)"));
+    } else {
+        m_action_dissolve->setText(tr("Dissolve…"));
+    }
+
     contextMenuDIP3->exec(QCursor::pos());
 }
 
@@ -271,6 +298,36 @@ void MasternodeList::onRevoke()
         return;
     }
     RevokeDialog dlg(clientModel->node(), walletModel, *entry, this);
+    dlg.exec();
+}
+
+void MasternodeList::onUpdateShare()
+{
+    const auto* entry = GetSelectedEntry();
+    if (!entry || !clientModel || !walletModel || !entry->isShared()) {
+        return;
+    }
+    UpdateShareDialog dlg(clientModel->node(), walletModel, *entry, this);
+    dlg.exec();
+}
+
+void MasternodeList::onDissolve()
+{
+    const auto* entry = GetSelectedEntry();
+    if (!entry || !clientModel || !walletModel || !entry->isShared()) {
+        return;
+    }
+    DissolveDialog dlg(clientModel->node(), walletModel, *entry, m_model->currentHeight(), this);
+    dlg.exec();
+}
+
+void MasternodeList::onRotateSharedKeys()
+{
+    const auto* entry = GetSelectedEntry();
+    if (!entry || !clientModel || !walletModel || !entry->isShared()) {
+        return;
+    }
+    RotateSharedKeysDialog dlg(clientModel->node(), walletModel, *entry, this);
     dlg.exec();
 }
 

--- a/src/qt/masternodelist.cpp
+++ b/src/qt/masternodelist.cpp
@@ -7,7 +7,6 @@
 
 #include <bls/bls.h>
 #include <script/standard.h>
-#include <univalue.h>
 
 #include <qt/clientfeeds.h>
 #include <qt/clientmodel.h>
@@ -271,9 +270,13 @@ void MasternodeList::showContextMenuDIP3(const QPoint& point)
     }
     m_action_update_registrar->setToolTip(registrar_tooltip);
 
-    // Only offered when this wallet can actually produce the secret behind the
-    // registered operator public key
-    const bool have_operator_key{have_wallet && !heldOperatorKey(*entry).empty()};
+    // Only offered when this wallet can produce the secret behind the registered
+    // operator public key. The wallet answers optimistically for keys it may only
+    // be able to derive; the dialog reports the exact outcome.
+    const std::vector<unsigned char> operator_pubkey{have_wallet ? registeredOperatorKey(*entry) :
+                                                                   std::vector<unsigned char>{}};
+    const bool have_operator_key{!operator_pubkey.empty() &&
+                                 walletModel->wallet().haveMasternodeOperatorKey(operator_pubkey)};
     m_action_show_operator_key->setEnabled(have_operator_key);
     m_action_show_operator_key->setToolTip(
         have_operator_key ? QString() : tr("This wallet does not hold this masternode's operator secret key"));
@@ -362,37 +365,20 @@ void MasternodeList::onDissolve()
     }
 }
 
-std::vector<unsigned char> MasternodeList::heldOperatorKey(const MasternodeEntry& entry) const
+std::vector<unsigned char> MasternodeList::registeredOperatorKey(const MasternodeEntry& entry)
 {
-    if (!walletModel) {
+    const std::string registered{entry.operatorPubKey().toStdString()};
+    if (registered.empty()) {
         return {};
     }
-    // TODO: read the operator key off the entry once MasternodeEntry exposes it
-    // instead of only its JSON rendering
-    UniValue json;
-    if (!json.read(entry.toJson().toStdString())) {
-        return {};
-    }
-    const UniValue& state{json.find_value("state")};
-    if (!state.isObject()) {
-        return {};
-    }
-    const UniValue& registered{state.find_value("pubKeyOperator")};
-    if (!registered.isStr()) {
-        return {};
-    }
-    const QString registered_hex{QString::fromStdString(registered.get_str())};
-    for (const auto& raw : walletModel->wallet().listMasternodeOperatorKeys()) {
-        CBLSPublicKey key;
-        key.SetBytes(raw, /*specificLegacyScheme=*/false);
-        if (!key.IsValid()) {
-            continue;
-        }
-        // A masternode registered before the basic scheme renders its key the
-        // legacy way, so compare against both renderings of the wallet's own key
-        if (registered_hex == QString::fromStdString(key.ToString(/*specificLegacyScheme=*/false)) ||
-            registered_hex == QString::fromStdString(key.ToString(/*specificLegacyScheme=*/true))) {
-            return raw;
+    // A masternode registered before the basic scheme renders its key the legacy
+    // way. Re-encoding tells which of the two renderings the node used, so a key
+    // that only decodes under the other scheme is not mistaken for a different
+    // one; the wallet is always asked in basic-scheme bytes.
+    CBLSPublicKey key;
+    for (const bool legacy : {false, true}) {
+        if (key.SetHexStr(registered, legacy) && key.ToString(legacy) == registered) {
+            return key.ToByteVector(/*specificLegacyScheme=*/false);
         }
     }
     return {};
@@ -404,7 +390,7 @@ void MasternodeList::onShowOperatorKey()
     if (!entry) {
         return;
     }
-    const std::vector<unsigned char> pubkey{heldOperatorKey(*entry)};
+    const std::vector<unsigned char> pubkey{registeredOperatorKey(*entry)};
     if (pubkey.empty()) {
         return;
     }

--- a/src/qt/masternodelist.h
+++ b/src/qt/masternodelist.h
@@ -106,6 +106,7 @@ private Q_SLOTS:
     void copyCollateralOutpoint_clicked();
     void copyProTxHash_clicked();
     void showRegisterWizard();
+    void showSharedMnCreateDialog();
     void extraInfoDIP3_clicked();
     void filterByCollateralAddress();
     void filterByOwnerAddress();

--- a/src/qt/masternodelist.h
+++ b/src/qt/masternodelist.h
@@ -17,6 +17,7 @@
 #include <atomic>
 #include <memory>
 #include <optional>
+#include <vector>
 
 class ClientModel;
 class MasternodeFeed;
@@ -97,6 +98,7 @@ private:
     QAction* m_action_update_share{nullptr};
     QAction* m_action_dissolve{nullptr};
     QAction* m_action_rotate_keys{nullptr};
+    QAction* m_action_show_operator_key{nullptr};
     QAction* m_action_filter_owner{nullptr};
     WalletModel* walletModel{nullptr};
     bool m_v24_active{false};
@@ -108,6 +110,10 @@ private:
     //! GetSelectedEntry plus the guards every action dialog needs: both models set and,
     //! if given, a matching isShared(). Returns nullptr when any guard fails.
     const MasternodeEntry* selectedEntryForDialog(std::optional<bool> shared = std::nullopt);
+    //! This wallet's own copy of `entry`'s registered operator public key, empty when
+    //! the wallet does not hold that key. Returned as the wallet's own 48 bytes, so
+    //! getMasternodeOperatorKey() gets back exactly what listMasternodeOperatorKeys() gave.
+    std::vector<unsigned char> heldOperatorKey(const MasternodeEntry& entry) const;
 
 Q_SIGNALS:
     void doubleClicked(const QModelIndex&);
@@ -132,6 +138,7 @@ private Q_SLOTS:
     void onUpdateRegistrar();
     void onUpdateService();
     void onUpdateShare();
+    void onShowOperatorKey();
     void showContextMenuDIP3(const QPoint&);
     void updateFilteredCount();
     void updateMasternodeList();

--- a/src/qt/masternodelist.h
+++ b/src/qt/masternodelist.h
@@ -93,6 +93,9 @@ private:
     QAction* m_action_update_service{nullptr};
     QAction* m_action_update_registrar{nullptr};
     QAction* m_action_revoke{nullptr};
+    QAction* m_action_update_share{nullptr};
+    QAction* m_action_dissolve{nullptr};
+    QAction* m_action_rotate_keys{nullptr};
     WalletModel* walletModel{nullptr};
 
     void setMasternodeList(MasternodeData&& data, QSet<QString>&& owned_mns);
@@ -116,9 +119,12 @@ private Q_SLOTS:
     void on_checkBoxOwned_stateChanged(int state);
     void on_comboBoxType_currentIndexChanged(int index);
     void on_filterText_textChanged(const QString& strFilterIn);
+    void onDissolve();
     void onRevoke();
+    void onRotateSharedKeys();
     void onUpdateRegistrar();
     void onUpdateService();
+    void onUpdateShare();
     void showContextMenuDIP3(const QPoint&);
     void updateFilteredCount();
     void updateMasternodeList();

--- a/src/qt/masternodelist.h
+++ b/src/qt/masternodelist.h
@@ -16,6 +16,7 @@
 
 #include <atomic>
 #include <memory>
+#include <optional>
 
 class ClientModel;
 class MasternodeFeed;
@@ -96,11 +97,17 @@ private:
     QAction* m_action_update_share{nullptr};
     QAction* m_action_dissolve{nullptr};
     QAction* m_action_rotate_keys{nullptr};
+    QAction* m_action_filter_owner{nullptr};
     WalletModel* walletModel{nullptr};
+    bool m_v24_active{false};
 
     void setMasternodeList(MasternodeData&& data, QSet<QString>&& owned_mns);
+    void updateActionButtons();
 
     const MasternodeEntry* GetSelectedEntry();
+    //! GetSelectedEntry plus the guards every action dialog needs: both models set and,
+    //! if given, a matching isShared(). Returns nullptr when any guard fails.
+    const MasternodeEntry* selectedEntryForDialog(std::optional<bool> shared = std::nullopt);
 
 Q_SIGNALS:
     void doubleClicked(const QModelIndex&);

--- a/src/qt/masternodelist.h
+++ b/src/qt/masternodelist.h
@@ -43,6 +43,7 @@ public:
         All,
         Regular,
         Evo,
+        Shared,
         COUNT
     };
 

--- a/src/qt/masternodelist.h
+++ b/src/qt/masternodelist.h
@@ -110,10 +110,10 @@ private:
     //! GetSelectedEntry plus the guards every action dialog needs: both models set and,
     //! if given, a matching isShared(). Returns nullptr when any guard fails.
     const MasternodeEntry* selectedEntryForDialog(std::optional<bool> shared = std::nullopt);
-    //! This wallet's own copy of `entry`'s registered operator public key, empty when
-    //! the wallet does not hold that key. Returned as the wallet's own 48 bytes, so
-    //! getMasternodeOperatorKey() gets back exactly what listMasternodeOperatorKeys() gave.
-    std::vector<unsigned char> heldOperatorKey(const MasternodeEntry& entry) const;
+    //! `entry`'s registered operator public key as the 48 basic-scheme bytes the
+    //! wallet interface expects, empty when the entry carries none or it does not
+    //! decode. Says nothing about whether this wallet holds the matching secret.
+    static std::vector<unsigned char> registeredOperatorKey(const MasternodeEntry& entry);
 
 Q_SIGNALS:
     void doubleClicked(const QModelIndex&);

--- a/src/qt/masternodelist.h
+++ b/src/qt/masternodelist.h
@@ -102,6 +102,7 @@ Q_SIGNALS:
 private Q_SLOTS:
     void copyCollateralOutpoint_clicked();
     void copyProTxHash_clicked();
+    void showRegisterWizard();
     void extraInfoDIP3_clicked();
     void filterByCollateralAddress();
     void filterByOwnerAddress();

--- a/src/qt/masternodelist.h
+++ b/src/qt/masternodelist.h
@@ -90,6 +90,9 @@ private:
     MasternodeListSortFilterProxyModel* m_proxy_model{nullptr};
     MasternodeModel* m_model{nullptr};
     QMenu* contextMenuDIP3{nullptr};
+    QAction* m_action_update_service{nullptr};
+    QAction* m_action_update_registrar{nullptr};
+    QAction* m_action_revoke{nullptr};
     WalletModel* walletModel{nullptr};
 
     void setMasternodeList(MasternodeData&& data, QSet<QString>&& owned_mns);
@@ -112,6 +115,9 @@ private Q_SLOTS:
     void on_checkBoxOwned_stateChanged(int state);
     void on_comboBoxType_currentIndexChanged(int index);
     void on_filterText_textChanged(const QString& strFilterIn);
+    void onRevoke();
+    void onUpdateRegistrar();
+    void onUpdateService();
     void showContextMenuDIP3(const QPoint&);
     void updateFilteredCount();
     void updateMasternodeList();

--- a/src/qt/masternodemodel.cpp
+++ b/src/qt/masternodemodel.cpp
@@ -11,6 +11,7 @@
 #include <script/script.h>
 #include <script/standard.h>
 
+#include <qt/bitcoinunits.h>
 #include <qt/clientmodel.h>
 #include <qt/guiutil.h>
 
@@ -38,6 +39,10 @@ std::optional<QString> JoinArray(const UniValue& arr)
 
 MasternodeEntry::MasternodeEntry(const interfaces::MnEntryCPtr& dmn, const QString& collateral_address, int next_payment_height) :
     m_banned{dmn->isBanned()},
+    m_shared{dmn->isShared()},
+    m_early_penalty{dmn->getEarlyPenalty()},
+    m_early_period_blocks{dmn->getEarlyPeriodBlocks()},
+    m_shares{dmn->getShares()},
     m_last_paid_height{dmn->getLastPaidHeight()},
     m_next_payment_height{next_payment_height},
     m_pose_penalty{dmn->getPoSePenalty()},
@@ -48,7 +53,7 @@ MasternodeEntry::MasternodeEntry(const interfaces::MnEntryCPtr& dmn, const QStri
     m_collateral_outpoint{QString::fromStdString(dmn->getCollateralOutpoint().ToStringShort())},
     m_protx_hash{QString::fromStdString(dmn->getProTxHash().ToString())},
     m_service{QString::fromStdString(dmn->getNetInfoPrimary().ToStringAddrPort())},
-    m_type_description{QString::fromStdString(std::string(GetMnType(dmn->getType()).description))},
+    m_type_description{dmn->isShared() ? QObject::tr("Shared") : QString::fromStdString(std::string(GetMnType(dmn->getType()).description))},
     m_voting_address{QString::fromStdString(EncodeDestination(PKHash(dmn->getKeyIdVoting())))},
     m_operator_reward_pct{dmn->getOperatorReward()}
 {
@@ -64,6 +69,29 @@ MasternodeEntry::MasternodeEntry(const interfaces::MnEntryCPtr& dmn, const QStri
         owner_addresses << QString::fromStdString(EncodeDestination(PKHash(key_id)));
     }
     m_owner_address = owner_addresses.isEmpty() ? QObject::tr("UNKNOWN") : owner_addresses.join(", ");
+
+    if (m_shared) {
+        // A fingerprint of the mutable share state (reward scripts, penalty terms) so
+        // reconcile() refreshes the row after a share update, plus a flat address list
+        // the text filter matches against
+        QStringList fingerprint, addresses;
+        for (const auto& share : m_shares) {
+            const QString owner{QString::fromStdString(EncodeDestination(PKHash(share.keyIDOwner)))};
+            QString refund, reward;
+            if (CTxDestination dest; ExtractDestination(share.scriptRefund, dest)) {
+                refund = QString::fromStdString(EncodeDestination(dest));
+            }
+            if (CTxDestination dest; ExtractDestination(share.rewardScript(), dest)) {
+                reward = QString::fromStdString(EncodeDestination(dest));
+            }
+            fingerprint << QString::number(share.amount) + ":" + owner + ":" + refund + ":" + reward;
+            addresses << owner << refund << reward;
+        }
+        m_shares_fingerprint = fingerprint.join("|") + "|" + QString::number(m_early_period_blocks) + "|" +
+                               QString::number(m_early_penalty);
+        addresses.removeDuplicates();
+        m_share_addresses = addresses.join(" ");
+    }
 
     QStringList payout_addresses;
     for (const auto& script_payout : dmn->getScriptPayouts()) {
@@ -124,7 +152,7 @@ MasternodeEntry::MasternodeEntry(const interfaces::MnEntryCPtr& dmn, const QStri
 
 MasternodeEntry::~MasternodeEntry() = default;
 
-QString MasternodeEntry::toHtml() const
+QString MasternodeEntry::toHtml(int current_height, const QSet<int>& my_share_indexes) const
 {
     QString ret;
     ret.reserve(4000);
@@ -134,8 +162,10 @@ QString MasternodeEntry::toHtml() const
     if (m_pub_key_operator) {
         ret += "<b>" + QObject::tr("Public Key Operator") + ":</b> " + m_pub_key_operator->toHtmlEscaped() + "<br>";
     }
-    ret += "<b>" + QObject::tr("Owner Address") + ":</b> " + m_owner_address.toHtmlEscaped() + "<br>";
-    ret += "<b>" + QObject::tr("Payout Address") + ":</b> " + m_payout_address.toHtmlEscaped() + "<br>";
+    if (!m_shared) {
+        ret += "<b>" + QObject::tr("Owner Address") + ":</b> " + m_owner_address.toHtmlEscaped() + "<br>";
+        ret += "<b>" + QObject::tr("Payout Address") + ":</b> " + m_payout_address.toHtmlEscaped() + "<br>";
+    }
     ret += "<b>" + QObject::tr("Voting Address") + ":</b> " + m_voting_address.toHtmlEscaped() + "<br>";
     ret += "<b>" + QObject::tr("Collateral Address") + ":</b> " + m_collateral_address.toHtmlEscaped() + "<br>";
     if (m_collateral_hash) {
@@ -153,6 +183,60 @@ QString MasternodeEntry::toHtml() const
         ret += "<b>" + QObject::tr("Consecutive Payments") + ":</b> " + QString::number(*m_consecutive_payments) + "<br>";
     }
     ret += "<b>" + QObject::tr("Operator Reward") + ":</b> " + QString::number(m_operator_reward_pct / 100.0, 'f', 2) + "%<br>";
+
+    if (m_shared) {
+        ret += "<br>";
+        const int64_t spacing{Params().GetConsensus().nPowTargetSpacing};
+        const int64_t early_until{static_cast<int64_t>(m_registered_height) + m_early_period_blocks};
+        ret += "<b>" + QObject::tr("Early-Exit Penalty") + ":</b> " +
+               BitcoinUnits::formatWithUnit(BitcoinUnits::Unit::DASH, m_early_penalty).toHtmlEscaped() + "<br>";
+        if (current_height > 0 && m_early_period_blocks > 0) {
+            if (current_height < early_until) {
+                ret += "<b>" + QObject::tr("Early Period Ends") + ":</b> " +
+                       QObject::tr("block %1 (%2 from now)")
+                           .arg(QString::number(early_until),
+                                GUIUtil::formatBlockDuration(early_until - current_height, spacing)) +
+                       "<br>";
+            } else {
+                ret += "<b>" + QObject::tr("Early Period Ends") + ":</b> " + QObject::tr("ended (block %1)").arg(early_until) + "<br>";
+            }
+        } else if (m_early_period_blocks > 0) {
+            ret += "<b>" + QObject::tr("Early Period Ends") + ":</b> " + QObject::tr("block %1").arg(early_until) + "<br>";
+        }
+
+        CAmount total{0};
+        for (const auto& share : m_shares) {
+            total += share.amount;
+        }
+        ret += "<br><b>" + QObject::tr("Collateral Shares") + ":</b>";
+        ret += "<table cellpadding='2'><tr><th align='left'>#</th><th align='left'>" + QObject::tr("Amount") +
+               "</th><th align='left'>" + QObject::tr("Owner Address") + "</th><th align='left'>" +
+               QObject::tr("Reward Address") + "</th><th align='left'>" + QObject::tr("Refund Address") + "</th></tr>";
+        for (size_t i = 0; i < m_shares.size(); ++i) {
+            const auto& share{m_shares[i]};
+            QString owner{QString::fromStdString(EncodeDestination(PKHash(share.keyIDOwner))).toHtmlEscaped()};
+            QString refund{QObject::tr("UNKNOWN")}, reward{QObject::tr("UNKNOWN")};
+            if (CTxDestination dest; ExtractDestination(share.scriptRefund, dest)) {
+                refund = QString::fromStdString(EncodeDestination(dest));
+            }
+            if (CTxDestination dest; ExtractDestination(share.rewardScript(), dest)) {
+                reward = QString::fromStdString(EncodeDestination(dest));
+            }
+            if (share.scriptReward.empty()) {
+                reward += " (" + QObject::tr("refund address") + ")";
+            }
+            if (my_share_indexes.contains(static_cast<int>(i))) {
+                owner += " <b>(" + QObject::tr("you") + ")</b>";
+            }
+            const double pct{total > 0 ? 100.0 * share.amount / total : 0.0};
+            ret += "<tr><td>" + QString::number(i) + "</td><td>" +
+                   BitcoinUnits::formatWithUnit(BitcoinUnits::Unit::DASH, share.amount).toHtmlEscaped() +
+                   " (" + QString::number(pct, 'f', 1) + "%)</td><td>" + owner + "</td><td>" +
+                   reward.toHtmlEscaped() + "</td><td>" + refund.toHtmlEscaped() + "</td></tr>";
+        }
+        ret += "</table>";
+    }
+
     if (m_network_addresses) {
         ret += "<b>" + QObject::tr("Network Addresses") + ":</b> " + m_network_addresses->toHtmlEscaped() + "<br>";
     }
@@ -261,7 +345,8 @@ QVariant MasternodeModel::data(const QModelIndex& index, int role) const
             entry->collateralAddress() + " " +
             entry->ownerAddress() + " " +
             entry->votingAddress() + " " +
-            entry->proTxHash()
+            entry->proTxHash() +
+            (entry->isShared() ? " " + entry->shareAddresses() : QString{})
         };
     } else if (role == Qt::DisplayRole) {
         switch (index.column()) {
@@ -292,7 +377,7 @@ QVariant MasternodeModel::data(const QModelIndex& index, int role) const
         case Column::SERVICE:
             return entry->serviceKey();
         case Column::TYPE:
-            return static_cast<int>(entry->type());
+            return entry->isShared() ? TYPE_SHARED : static_cast<int>(entry->type());
         case Column::STATUS:
             if (m_current_height > 0) {
                 if (entry->isBanned()) {

--- a/src/qt/masternodemodel.cpp
+++ b/src/qt/masternodemodel.cpp
@@ -343,7 +343,9 @@ QVariant MasternodeModel::data(const QModelIndex& index, int role) const
             entry->payoutAddress() + " " +
             entry->operatorReward() + " " +
             entry->collateralAddress() + " " +
-            entry->ownerAddress() + " " +
+            // Shared masternodes have a null owner key; its placeholder address is
+            // identical for all of them, so it must not be searchable
+            (entry->isShared() ? QString{} : entry->ownerAddress() + " ") +
             entry->votingAddress() + " " +
             entry->proTxHash() +
             (entry->isShared() ? " " + entry->shareAddresses() : QString{})

--- a/src/qt/masternodemodel.h
+++ b/src/qt/masternodemodel.h
@@ -104,7 +104,8 @@ public:
         // reconcile() keeps serving the stale entry
         return std::tie(m_banned, m_last_paid_height, m_next_payment_height, m_pose_penalty, m_service,
                         m_operator_reward_pct, m_payout_address, m_voting_address, m_operator_reward,
-                        m_pub_key_operator, m_shares_fingerprint);
+                        m_pub_key_operator, m_shares_fingerprint, m_network_addresses, m_platform_node_id,
+                        m_platform_p2p_addresses, m_platform_https_addresses);
     }
     QString toHtml(int current_height = 0, const QSet<int>& my_share_indexes = {}) const;
 };

--- a/src/qt/masternodemodel.h
+++ b/src/qt/masternodemodel.h
@@ -11,6 +11,7 @@
 #include <QAbstractTableModel>
 #include <QByteArray>
 #include <QIcon>
+#include <QSet>
 #include <QString>
 
 #include <memory>
@@ -22,6 +23,12 @@ class MasternodeEntry
 {
 private:
     bool m_banned{false};
+    bool m_shared{false};
+    CAmount m_early_penalty{0};
+    uint32_t m_early_period_blocks{0};
+    std::vector<interfaces::MnShare> m_shares;
+    QString m_shares_fingerprint{};
+    QString m_share_addresses{};
     int32_t m_last_paid_height{0};
     int32_t m_next_payment_height{0};
     int32_t m_pose_penalty{0};
@@ -56,6 +63,11 @@ public:
     ~MasternodeEntry();
 
     bool isBanned() const { return m_banned; }
+    bool isShared() const { return m_shared; }
+    CAmount earlyPenalty() const { return m_early_penalty; }
+    uint32_t earlyPeriodBlocks() const { return m_early_period_blocks; }
+    const std::vector<interfaces::MnShare>& shares() const { return m_shares; }
+    const QString& shareAddresses() const { return m_share_addresses; }
     int lastPaidHeight() const { return m_last_paid_height; }
     int nextPaymentHeight() const { return m_next_payment_height; }
     int posePenalty() const { return m_pose_penalty; }
@@ -87,9 +99,14 @@ public:
 
     auto toTie() const
     {
-        return std::tie(m_banned, m_last_paid_height, m_next_payment_height, m_pose_penalty, m_service, m_operator_reward_pct);
+        // Must cover every field the UI renders that can change without the entry being
+        // re-registered (incl. ProUpRegTx/ProUpShareTx/ProUpSharedRegTx effects), otherwise
+        // reconcile() keeps serving the stale entry
+        return std::tie(m_banned, m_last_paid_height, m_next_payment_height, m_pose_penalty, m_service,
+                        m_operator_reward_pct, m_payout_address, m_voting_address, m_operator_reward,
+                        m_pub_key_operator, m_shares_fingerprint);
     }
-    QString toHtml() const;
+    QString toHtml(int current_height = 0, const QSet<int>& my_share_indexes = {}) const;
 };
 
 using MasternodeEntryList = std::vector<std::shared_ptr<MasternodeEntry>>;
@@ -120,6 +137,10 @@ public:
         COUNT
     };
 
+    //! TYPE-column sort/filter value for shared masternodes; distinct from every MnType value
+    //! (shared masternodes are MnType::Regular with a pooled collateral)
+    static constexpr int TYPE_SHARED{-1};
+
     explicit MasternodeModel(QObject* parent = nullptr);
     ~MasternodeModel();
 
@@ -133,6 +154,7 @@ public:
     void append(std::shared_ptr<MasternodeEntry>&& entry);
     void remove(int row);
     void reconcile(MasternodeEntryList&& entries);
+    int currentHeight() const { return m_current_height; }
     void setCurrentHeight(int height) { m_current_height = height; }
     const MasternodeEntry* getEntryAt(const QModelIndex& index) const;
 };

--- a/src/qt/masternodemodel.h
+++ b/src/qt/masternodemodel.h
@@ -95,6 +95,10 @@ public:
     const QString& toJson() const { return m_json; }
     const QString& typeDescription() const { return m_type_description; }
     const QString& votingAddress() const { return m_voting_address; }
+    //! Registered operator public key, hex, exactly as the node renders it: legacy
+    //! scheme for a masternode registered before the basic scheme activated. Empty
+    //! when the entry carries none.
+    QString operatorPubKey() const { return m_pub_key_operator.value_or(QString()); }
     const uint256& proTxHashRaw() const { return m_dmn->getProTxHash(); }
 
     auto toTie() const

--- a/src/qt/masternodewidgets.cpp
+++ b/src/qt/masternodewidgets.cpp
@@ -1,0 +1,209 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/masternodewidgets.h>
+
+#include <bls/bls.h>
+#include <chainparams.h>
+#include <interfaces/wallet.h>
+#include <key_io.h>
+#include <netbase.h>
+#include <script/standard.h>
+#include <util/strencodings.h>
+
+#include <qt/bitcoinunits.h>
+#include <qt/optionsmodel.h>
+#include <qt/qvalidatedlineedit.h>
+#include <qt/walletmodel.h>
+
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QRadioButton>
+#include <QRegularExpression>
+#include <QSet>
+#include <QVBoxLayout>
+#include <QVariant>
+
+#include <algorithm>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace {
+constexpr int BALANCE_ROLE{Qt::UserRole + 1};
+} // anonymous namespace
+
+namespace MasternodeWidgetUtil {
+
+QStringList parseServiceList(const QString& input, QString& err)
+{
+    err.clear();
+    QStringList ret;
+    QSet<QString> seen;
+    const QStringList tokens{input.split(QRegularExpression("[,\\s]+"), Qt::SkipEmptyParts)};
+    for (const QString& token : tokens) {
+        const std::optional<CService> service{
+            Lookup(token.toStdString(), Params().GetDefaultPort(), /*fAllowLookup=*/false)};
+        if (!service.has_value() || !service->IsValid()) {
+            err = QObject::tr("Invalid address \"%1\". Expected format: IP:PORT (e.g. 1.2.3.4:%2).")
+                      .arg(token)
+                      .arg(Params().GetDefaultPort());
+            return {};
+        }
+        const QString normalized{QString::fromStdString(service->ToStringAddrPort())};
+        if (seen.contains(normalized)) {
+            err = QObject::tr("Duplicate address \"%1\".").arg(normalized);
+            return {};
+        }
+        seen.insert(normalized);
+        ret << normalized;
+    }
+    return ret;
+}
+
+bool isP2PKHAddress(const QString& address)
+{
+    const CTxDestination dest{DecodeDestination(address.trimmed().toStdString())};
+    return std::holds_alternative<PKHash>(dest);
+}
+
+bool isP2PKHorP2SHAddress(const QString& address)
+{
+    const CTxDestination dest{DecodeDestination(address.trimmed().toStdString())};
+    return std::holds_alternative<PKHash>(dest) || std::holds_alternative<ScriptHash>(dest);
+}
+
+} // namespace MasternodeWidgetUtil
+
+FeeSourcePicker::FeeSourcePicker(QWidget* parent) :
+    QComboBox(parent)
+{
+    setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLengthWithIcon);
+    setMinimumContentsLength(40);
+}
+
+void FeeSourcePicker::setWalletModel(WalletModel* wallet_model)
+{
+    m_wallet_model = wallet_model;
+    refresh();
+}
+
+void FeeSourcePicker::setMinimumBalance(CAmount minimum)
+{
+    if (m_minimum_balance == minimum) return;
+    m_minimum_balance = minimum;
+    refresh();
+}
+
+void FeeSourcePicker::refresh()
+{
+    clear();
+    if (m_wallet_model == nullptr) return;
+
+    std::vector<std::pair<QString, CAmount>> entries;
+    for (const auto& [dest, coins] : m_wallet_model->wallet().listCoins()) {
+        CAmount total{0};
+        for (const auto& [outpoint, txout] : coins) {
+            if (txout.is_spent || txout.depth_in_main_chain < 0) continue;
+            if (m_wallet_model->wallet().isLockedCoin(outpoint)) continue;
+            total += txout.txout.nValue;
+        }
+        if (total <= 0 || total < m_minimum_balance) continue;
+        entries.emplace_back(QString::fromStdString(EncodeDestination(dest)), total);
+    }
+    std::sort(entries.begin(), entries.end(),
+              [](const auto& lhs, const auto& rhs) { return lhs.second > rhs.second; });
+
+    const auto unit{m_wallet_model->getOptionsModel()->getDisplayUnit()};
+    for (const auto& [address, balance] : entries) {
+        addItem(QString("%1 (%2)").arg(address, BitcoinUnits::formatWithUnit(unit, balance, /*plussign=*/false,
+                                                                             BitcoinUnits::SeparatorStyle::ALWAYS)),
+                address);
+        setItemData(count() - 1, static_cast<qlonglong>(balance), BALANCE_ROLE);
+    }
+    if (count() > 0) setCurrentIndex(0);
+}
+
+QString FeeSourcePicker::selectedAddress() const
+{
+    return currentData().toString();
+}
+
+CAmount FeeSourcePicker::selectedBalance() const
+{
+    if (currentIndex() < 0) return 0;
+    return static_cast<CAmount>(itemData(currentIndex(), BALANCE_ROLE).toLongLong());
+}
+
+OperatorKeyWidget::OperatorKeyWidget(QWidget* parent) :
+    QWidget(parent)
+{
+    // Generate the key pair up front so toggling the radios never discards a
+    // key the user may already have seen.
+    CBLSSecretKey secret_key;
+    secret_key.MakeNewKey();
+    m_generated_secret = QString::fromStdString(secret_key.ToString(/*specificLegacyScheme=*/false));
+    m_generated_public = QString::fromStdString(secret_key.GetPublicKey().ToString(/*specificLegacyScheme=*/false));
+
+    m_generate_radio = new QRadioButton(tr("Generate a new operator key (recommended)"), this);
+    m_generate_radio->setChecked(true);
+    m_generated_label = new QLabel(m_generated_public, this);
+    m_generated_label->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    m_generated_label->setWordWrap(true);
+    m_existing_radio = new QRadioButton(tr("Use an existing operator public key"), this);
+    m_existing_edit = new QValidatedLineEdit(this);
+    m_existing_edit->setPlaceholderText(tr("Operator BLS public key (96 hexadecimal characters, basic scheme)"));
+    m_existing_edit->setEnabled(false);
+
+    auto* layout = new QVBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->addWidget(m_generate_radio);
+    auto* generated_row = new QHBoxLayout();
+    generated_row->addSpacing(24);
+    generated_row->addWidget(m_generated_label, /*stretch=*/1);
+    layout->addLayout(generated_row);
+    layout->addWidget(m_existing_radio);
+    auto* existing_row = new QHBoxLayout();
+    existing_row->addSpacing(24);
+    existing_row->addWidget(m_existing_edit, /*stretch=*/1);
+    layout->addLayout(existing_row);
+
+    connect(m_generate_radio, &QRadioButton::toggled, this, &OperatorKeyWidget::updateState);
+    connect(m_existing_edit, &QLineEdit::textChanged, this, &OperatorKeyWidget::updateState);
+}
+
+void OperatorKeyWidget::updateState()
+{
+    const bool use_existing{m_existing_radio->isChecked()};
+    m_existing_edit->setEnabled(use_existing);
+    if (use_existing) {
+        const QString text{m_existing_edit->text().trimmed()};
+        // Leave the neutral style while empty; only flag actual invalid input
+        m_existing_edit->setValid(text.isEmpty() || isValid());
+    }
+    Q_EMIT changed();
+}
+
+QString OperatorKeyWidget::publicKeyHex() const
+{
+    if (m_generate_radio->isChecked()) return m_generated_public;
+    return isValid() ? m_existing_edit->text().trimmed() : QString();
+}
+
+QString OperatorKeyWidget::secretHex() const
+{
+    return hasGeneratedSecret() ? m_generated_secret : QString();
+}
+
+bool OperatorKeyWidget::hasGeneratedSecret() const
+{
+    return m_generate_radio->isChecked();
+}
+
+bool OperatorKeyWidget::isValid() const
+{
+    if (m_generate_radio->isChecked()) return true;
+    CBLSPublicKey pubkey;
+    return pubkey.SetHexStr(m_existing_edit->text().trimmed().toStdString(), /*specificLegacyScheme=*/false);
+}

--- a/src/qt/masternodewidgets.cpp
+++ b/src/qt/masternodewidgets.cpp
@@ -239,17 +239,6 @@ OperatorKeyWidget::OperatorKeyWidget(QWidget* parent) :
     m_generated_secret = QString::fromStdString(secret_key.ToString(/*specificLegacyScheme=*/false));
     m_generated_public = QString::fromStdString(secret_key.GetPublicKey().ToString(/*specificLegacyScheme=*/false));
 
-    // The key is 96 hex characters: it gets its own full-width line, otherwise it
-    // wraps against the edge of whatever sits beside it
-    const auto public_key_row = [this](QWidget* body) {
-        auto* column{new QVBoxLayout()};
-        column->setContentsMargins(0, 0, 0, 0);
-        column->setSpacing(TITLE_SPACING);
-        column->addWidget(makeHint(tr("Public key"), body));
-        column->addWidget(makeValue(chunked(m_generated_public), body, /*monospace=*/true));
-        return column;
-    };
-
     m_derive_radio = new QRadioButton(tr("Derive from this wallet's recovery phrase"), this);
     auto derive_card{makeOptionCard(this, m_derive_radio,
                                     tr("The secret key comes from this wallet's recovery phrase, so restoring that "
@@ -276,19 +265,16 @@ OperatorKeyWidget::OperatorKeyWidget(QWidget* parent) :
     m_derive_key_box->setVisible(false);
     derive_card.body_layout->addWidget(m_derive_key_box);
 
-    m_store_radio = new QRadioButton(tr("Generate and save in this wallet"), this);
-    auto store_card{makeOptionCard(this, m_store_radio,
-                                   tr("The secret key is stored in this wallet, so the wallet backup covers it."))};
-    m_store_card = store_card.card;
-    m_store_body = store_card.body;
-    store_card.body_layout->addLayout(public_key_row(m_store_body));
-
     m_generate_radio = new QRadioButton(tr("Generate without saving"), this);
     m_generate_radio->setChecked(true);
     auto generate_card{makeOptionCard(this, m_generate_radio,
                                       tr("The secret key is shown once after registering and kept nowhere else."))};
     m_generate_body = generate_card.body;
-    generate_card.body_layout->addLayout(public_key_row(m_generate_body));
+    // The key is 96 hex characters: it gets its own full-width line, otherwise it
+    // wraps against the edge of whatever sits beside it
+    generate_card.body_layout->addWidget(makeHint(tr("Public key"), m_generate_body));
+    generate_card.body_layout->addWidget(makeValue(chunked(m_generated_public), m_generate_body,
+                                                   /*monospace=*/true));
 
     m_existing_radio = new QRadioButton(tr("Use an existing operator public key"), this);
     auto existing_card{makeOptionCard(this, m_existing_radio,
@@ -304,7 +290,6 @@ OperatorKeyWidget::OperatorKeyWidget(QWidget* parent) :
     // longer applies and a button group has to keep them exclusive.
     auto* group{new QButtonGroup(this)};
     group->addButton(m_derive_radio);
-    group->addButton(m_store_radio);
     group->addButton(m_generate_radio);
     group->addButton(m_existing_radio);
 
@@ -312,17 +297,14 @@ OperatorKeyWidget::OperatorKeyWidget(QWidget* parent) :
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(TITLE_SPACING);
     layout->addWidget(m_derive_card);
-    layout->addWidget(m_store_card);
     layout->addWidget(generate_card.card);
     layout->addWidget(existing_card.card);
 
-    // Both stay hidden until a caller commits to deriving or storing the secret;
-    // dialogs that can do neither keep the generate/paste pair they always had.
+    // Stays hidden until a caller commits to deriving the secret; dialogs whose
+    // wallet cannot derive keep the generate/paste pair they always had.
     m_derive_card->setVisible(false);
-    m_store_card->setVisible(false);
 
     connect(m_derive_radio, &QRadioButton::toggled, this, &OperatorKeyWidget::updateState);
-    connect(m_store_radio, &QRadioButton::toggled, this, &OperatorKeyWidget::updateState);
     connect(m_generate_radio, &QRadioButton::toggled, this, &OperatorKeyWidget::updateState);
     connect(m_existing_radio, &QRadioButton::toggled, this, &OperatorKeyWidget::updateState);
     connect(m_existing_edit, &QLineEdit::textChanged, this, &OperatorKeyWidget::updateState);
@@ -355,28 +337,12 @@ bool OperatorKeyWidget::needsDerivation() const
     return mode() == Mode::Derive && m_derived_public.isEmpty();
 }
 
-void OperatorKeyWidget::offerStoreInWallet(bool enabled, const QString& disabled_reason)
-{
-    m_store_card->setVisible(true);
-    m_store_radio->setEnabled(enabled);
-    // A disabled radio button swallows tooltips, so the card carries it as well.
-    m_store_card->setToolTip(enabled ? QString() : disabled_reason);
-    m_store_radio->setToolTip(enabled ? QString() : disabled_reason);
-    if (enabled) {
-        m_store_radio->setChecked(true);
-    } else if (m_store_radio->isChecked()) {
-        m_generate_radio->setChecked(true);
-    }
-    updateState();
-}
-
 void OperatorKeyWidget::updateState()
 {
     const Mode current{mode()};
     m_derive_body->setVisible(current == Mode::Derive);
     m_derive_pending->setVisible(m_derived_public.isEmpty());
     m_derive_key_box->setVisible(!m_derived_public.isEmpty());
-    m_store_body->setVisible(current == Mode::GenerateAndStore);
     m_generate_body->setVisible(current == Mode::GenerateOnly);
     m_existing_body->setVisible(current == Mode::Existing);
     m_existing_edit->setEnabled(current == Mode::Existing);
@@ -392,7 +358,6 @@ OperatorKeyWidget::Mode OperatorKeyWidget::mode() const
 {
     if (m_existing_radio->isChecked()) return Mode::Existing;
     if (m_derive_radio->isChecked()) return Mode::Derive;
-    if (m_store_radio->isChecked()) return Mode::GenerateAndStore;
     return Mode::GenerateOnly;
 }
 
@@ -401,7 +366,6 @@ QString OperatorKeyWidget::publicKeyHex() const
     switch (mode()) {
     case Mode::Derive:
         return m_derived_public;
-    case Mode::GenerateAndStore:
     case Mode::GenerateOnly:
         return m_generated_public;
     case Mode::Existing:
@@ -415,7 +379,6 @@ QString OperatorKeyWidget::secretHex() const
     switch (mode()) {
     case Mode::Derive:
         return m_derived_secret;
-    case Mode::GenerateAndStore:
     case Mode::GenerateOnly:
         return m_generated_secret;
     case Mode::Existing:

--- a/src/qt/masternodewidgets.cpp
+++ b/src/qt/masternodewidgets.cpp
@@ -13,10 +13,13 @@
 #include <util/strencodings.h>
 
 #include <qt/bitcoinunits.h>
+#include <qt/guiutil.h>
 #include <qt/optionsmodel.h>
 #include <qt/qvalidatedlineedit.h>
 #include <qt/walletmodel.h>
 
+#include <QButtonGroup>
+#include <QFrame>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QRadioButton>
@@ -69,6 +72,66 @@ bool isP2PKHorP2SHAddress(const QString& address)
 {
     const CTxDestination dest{DecodeDestination(address.trimmed().toStdString())};
     return std::holds_alternative<PKHash>(dest) || std::holds_alternative<ScriptHash>(dest);
+}
+
+QLabel* makeTitle(const QString& text, QWidget* parent, double point_size)
+{
+    auto* label{new QLabel(text, parent)};
+    label->setWordWrap(true);
+    GUIUtil::setFont({label}, GUIUtil::FontWeight::Bold, point_size);
+    return label;
+}
+
+QLabel* makeHint(const QString& text, QWidget* parent)
+{
+    auto* label{new QLabel(text, parent)};
+    label->setWordWrap(true);
+    label->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_SECONDARY));
+    return label;
+}
+
+QLabel* makeValue(const QString& text, QWidget* parent, bool monospace)
+{
+    auto* label{new QLabel(text, parent)};
+    label->setTextFormat(Qt::PlainText);
+    label->setWordWrap(true);
+    label->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    if (monospace) label->setFont(GUIUtil::fixedPitchFont());
+    return label;
+}
+
+QFrame* makeCard(QWidget* parent)
+{
+    auto* card{new QFrame(parent)};
+    card->setObjectName("mnCard");
+    // The id selector keeps the border off the card's children. general.css
+    // clears borders for plain frames, so the color comes from the theme's own
+    // widget border color instead of a new one.
+    card->setStyleSheet(QString("QFrame#mnCard { border: 1px solid %1; border-radius: 3px; }")
+                            .arg(GUIUtil::getThemedQColor(GUIUtil::ThemedColor::BORDER_WIDGET).name()));
+    return card;
+}
+
+OptionCard makeOptionCard(QWidget* parent, QWidget* header, const QString& hint)
+{
+    OptionCard ret;
+    ret.card = makeCard(parent);
+    auto* card_layout{new QVBoxLayout(ret.card)};
+    card_layout->setContentsMargins(CARD_PADDING, CARD_PADDING, CARD_PADDING, CARD_PADDING);
+    card_layout->setSpacing(TITLE_SPACING);
+    card_layout->addWidget(header);
+    if (!hint.isEmpty()) {
+        auto* hint_row{new QHBoxLayout()};
+        hint_row->setContentsMargins(BODY_INDENT, 0, 0, 0);
+        hint_row->addWidget(makeHint(hint, ret.card), /*stretch=*/1);
+        card_layout->addLayout(hint_row);
+    }
+    ret.body = new QWidget(ret.card);
+    ret.body_layout = new QVBoxLayout(ret.body);
+    ret.body_layout->setContentsMargins(BODY_INDENT, 0, 0, 0);
+    ret.body_layout->setSpacing(ROW_SPACING);
+    card_layout->addWidget(ret.body);
+    return ret;
 }
 
 } // namespace MasternodeWidgetUtil
@@ -138,6 +201,8 @@ QString FeeSourcePicker::selectedAddress() const
 OperatorKeyWidget::OperatorKeyWidget(QWidget* parent) :
     QWidget(parent)
 {
+    using namespace MasternodeWidgetUtil;
+
     // Generate the key pair up front so toggling the radios never discards a
     // key the user may already have seen.
     CBLSSecretKey secret_key;
@@ -145,38 +210,89 @@ OperatorKeyWidget::OperatorKeyWidget(QWidget* parent) :
     m_generated_secret = QString::fromStdString(secret_key.ToString(/*specificLegacyScheme=*/false));
     m_generated_public = QString::fromStdString(secret_key.GetPublicKey().ToString(/*specificLegacyScheme=*/false));
 
-    m_generate_radio = new QRadioButton(tr("Generate a new operator key (recommended)"), this);
+    // The key is 96 hex characters: it gets its own full-width line, otherwise it
+    // wraps against the edge of whatever sits beside it
+    const auto public_key_row = [this](QWidget* body) {
+        auto* column{new QVBoxLayout()};
+        column->setContentsMargins(0, 0, 0, 0);
+        column->setSpacing(TITLE_SPACING);
+        column->addWidget(makeHint(tr("Public key"), body));
+        column->addWidget(makeValue(m_generated_public, body, /*monospace=*/true));
+        return column;
+    };
+
+    m_store_radio = new QRadioButton(tr("Generate and save in this wallet"), this);
+    auto store_card{makeOptionCard(this, m_store_radio,
+                                   tr("The secret key is stored in this wallet, so the wallet backup covers it."))};
+    m_store_card = store_card.card;
+    m_store_body = store_card.body;
+    store_card.body_layout->addLayout(public_key_row(m_store_body));
+
+    m_generate_radio = new QRadioButton(tr("Generate without saving"), this);
     m_generate_radio->setChecked(true);
-    m_generated_label = new QLabel(m_generated_public, this);
-    m_generated_label->setTextInteractionFlags(Qt::TextSelectableByMouse);
-    m_generated_label->setWordWrap(true);
+    auto generate_card{makeOptionCard(this, m_generate_radio,
+                                      tr("The secret key is shown once after registering and kept nowhere else."))};
+    m_generate_body = generate_card.body;
+    generate_card.body_layout->addLayout(public_key_row(m_generate_body));
+
     m_existing_radio = new QRadioButton(tr("Use an existing operator public key"), this);
-    m_existing_edit = new QValidatedLineEdit(this);
+    auto existing_card{makeOptionCard(this, m_existing_radio,
+                                      tr("For a hosted node: the operator keeps the secret key and gives you the "
+                                         "public key."))};
+    m_existing_body = existing_card.body;
+    m_existing_edit = new QValidatedLineEdit(m_existing_body);
     m_existing_edit->setPlaceholderText(tr("Operator BLS public key (96 hexadecimal characters, basic scheme)"));
     m_existing_edit->setEnabled(false);
+    existing_card.body_layout->addWidget(m_existing_edit);
 
-    auto* layout = new QVBoxLayout(this);
+    // The radios live in separate cards, so auto-exclusivity by parent no
+    // longer applies and a button group has to keep them exclusive.
+    auto* group{new QButtonGroup(this)};
+    group->addButton(m_store_radio);
+    group->addButton(m_generate_radio);
+    group->addButton(m_existing_radio);
+
+    auto* layout{new QVBoxLayout(this)};
     layout->setContentsMargins(0, 0, 0, 0);
-    layout->addWidget(m_generate_radio);
-    auto* generated_row = new QHBoxLayout();
-    generated_row->addSpacing(24);
-    generated_row->addWidget(m_generated_label, /*stretch=*/1);
-    layout->addLayout(generated_row);
-    layout->addWidget(m_existing_radio);
-    auto* existing_row = new QHBoxLayout();
-    existing_row->addSpacing(24);
-    existing_row->addWidget(m_existing_edit, /*stretch=*/1);
-    layout->addLayout(existing_row);
+    layout->setSpacing(TITLE_SPACING);
+    layout->addWidget(m_store_card);
+    layout->addWidget(generate_card.card);
+    layout->addWidget(existing_card.card);
 
+    // Hidden until a caller commits to storing the secret; dialogs that cannot
+    // do that keep the generate/paste pair they always had.
+    m_store_card->setVisible(false);
+
+    connect(m_store_radio, &QRadioButton::toggled, this, &OperatorKeyWidget::updateState);
     connect(m_generate_radio, &QRadioButton::toggled, this, &OperatorKeyWidget::updateState);
+    connect(m_existing_radio, &QRadioButton::toggled, this, &OperatorKeyWidget::updateState);
     connect(m_existing_edit, &QLineEdit::textChanged, this, &OperatorKeyWidget::updateState);
+    updateState();
+}
+
+void OperatorKeyWidget::offerStoreInWallet(bool enabled, const QString& disabled_reason)
+{
+    m_store_card->setVisible(true);
+    m_store_radio->setEnabled(enabled);
+    // A disabled radio button swallows tooltips, so the card carries it as well.
+    m_store_card->setToolTip(enabled ? QString() : disabled_reason);
+    m_store_radio->setToolTip(enabled ? QString() : disabled_reason);
+    if (enabled) {
+        m_store_radio->setChecked(true);
+    } else if (m_store_radio->isChecked()) {
+        m_generate_radio->setChecked(true);
+    }
+    updateState();
 }
 
 void OperatorKeyWidget::updateState()
 {
-    const bool use_existing{m_existing_radio->isChecked()};
-    m_existing_edit->setEnabled(use_existing);
-    if (use_existing) {
+    const Mode current{mode()};
+    m_store_body->setVisible(current == Mode::GenerateAndStore);
+    m_generate_body->setVisible(current == Mode::GenerateOnly);
+    m_existing_body->setVisible(current == Mode::Existing);
+    m_existing_edit->setEnabled(current == Mode::Existing);
+    if (current == Mode::Existing) {
         const QString text{m_existing_edit->text().trimmed()};
         // Leave the neutral style while empty; only flag actual invalid input
         m_existing_edit->setValid(text.isEmpty() || isValid());
@@ -184,9 +300,16 @@ void OperatorKeyWidget::updateState()
     Q_EMIT changed();
 }
 
+OperatorKeyWidget::Mode OperatorKeyWidget::mode() const
+{
+    if (m_existing_radio->isChecked()) return Mode::Existing;
+    if (m_store_radio->isChecked()) return Mode::GenerateAndStore;
+    return Mode::GenerateOnly;
+}
+
 QString OperatorKeyWidget::publicKeyHex() const
 {
-    if (m_generate_radio->isChecked()) return m_generated_public;
+    if (hasGeneratedSecret()) return m_generated_public;
     return isValid() ? m_existing_edit->text().trimmed() : QString();
 }
 
@@ -197,12 +320,12 @@ QString OperatorKeyWidget::secretHex() const
 
 bool OperatorKeyWidget::hasGeneratedSecret() const
 {
-    return m_generate_radio->isChecked();
+    return mode() != Mode::Existing;
 }
 
 bool OperatorKeyWidget::isValid() const
 {
-    if (m_generate_radio->isChecked()) return true;
+    if (hasGeneratedSecret()) return true;
     CBLSPublicKey pubkey;
     return pubkey.SetHexStr(m_existing_edit->text().trimmed().toStdString(), /*specificLegacyScheme=*/false);
 }

--- a/src/qt/masternodewidgets.cpp
+++ b/src/qt/masternodewidgets.cpp
@@ -22,6 +22,7 @@
 #include <QFrame>
 #include <QHBoxLayout>
 #include <QLabel>
+#include <QPushButton>
 #include <QRadioButton>
 #include <QRegularExpression>
 #include <QSet>
@@ -98,6 +99,34 @@ QLabel* makeValue(const QString& text, QWidget* parent, bool monospace)
     label->setTextInteractionFlags(Qt::TextSelectableByMouse);
     if (monospace) label->setFont(GUIUtil::fixedPitchFont());
     return label;
+}
+
+QString chunked(const QString& text, int chunk_size)
+{
+    if (chunk_size <= 0) return text;
+    QString ret;
+    ret.reserve(text.size() + text.size() / chunk_size);
+    for (int pos = 0; pos < text.size(); pos += chunk_size) {
+        if (pos > 0) ret += QLatin1Char(' ');
+        ret += text.mid(pos, chunk_size);
+    }
+    return ret;
+}
+
+QWidget* makeCopyableValue(const QString& display, const QString& copy_text, QWidget* parent)
+{
+    auto* row_widget{new QWidget(parent)};
+    auto* row{new QHBoxLayout(row_widget)};
+    row->setContentsMargins(0, 0, 0, 0);
+    row->setSpacing(TITLE_SPACING);
+    auto* value{makeValue(display, row_widget, /*monospace=*/true)};
+    value->setToolTip(copy_text);
+    row->addWidget(value, /*stretch=*/1);
+    auto* copy{new QPushButton(QObject::tr("Copy"), row_widget)};
+    copy->setToolTip(QObject::tr("Copy to clipboard"));
+    QObject::connect(copy, &QPushButton::clicked, copy, [copy_text] { GUIUtil::setClipboard(copy_text); });
+    row->addWidget(copy, /*stretch=*/0, Qt::AlignTop);
+    return row_widget;
 }
 
 QFrame* makeCard(QWidget* parent)
@@ -217,9 +246,35 @@ OperatorKeyWidget::OperatorKeyWidget(QWidget* parent) :
         column->setContentsMargins(0, 0, 0, 0);
         column->setSpacing(TITLE_SPACING);
         column->addWidget(makeHint(tr("Public key"), body));
-        column->addWidget(makeValue(m_generated_public, body, /*monospace=*/true));
+        column->addWidget(makeValue(chunked(m_generated_public), body, /*monospace=*/true));
         return column;
     };
+
+    m_derive_radio = new QRadioButton(tr("Derive from this wallet's recovery phrase"), this);
+    auto derive_card{makeOptionCard(this, m_derive_radio,
+                                    tr("The secret key comes from this wallet's recovery phrase, so restoring that "
+                                       "phrase restores this key."))};
+    m_derive_card = derive_card.card;
+    m_derive_body = derive_card.body;
+    // Deriving needs an unlocked wallet, so the key only appears once the owning
+    // dialog has asked for it
+    m_derive_pending = makeHint(tr("The key is derived when you reach the review; this wallet may ask you to "
+                                   "unlock first."),
+                                m_derive_body);
+    derive_card.body_layout->addWidget(m_derive_pending);
+    m_derive_key_box = new QWidget(m_derive_body);
+    {
+        auto* column{new QVBoxLayout(m_derive_key_box)};
+        column->setContentsMargins(0, 0, 0, 0);
+        column->setSpacing(TITLE_SPACING);
+        column->addWidget(makeHint(tr("Public key"), m_derive_key_box));
+        m_derive_public_label = makeValue(QString(), m_derive_key_box, /*monospace=*/true);
+        column->addWidget(m_derive_public_label);
+        m_derive_path_label = makeHint(QString(), m_derive_key_box);
+        column->addWidget(m_derive_path_label);
+    }
+    m_derive_key_box->setVisible(false);
+    derive_card.body_layout->addWidget(m_derive_key_box);
 
     m_store_radio = new QRadioButton(tr("Generate and save in this wallet"), this);
     auto store_card{makeOptionCard(this, m_store_radio,
@@ -248,6 +303,7 @@ OperatorKeyWidget::OperatorKeyWidget(QWidget* parent) :
     // The radios live in separate cards, so auto-exclusivity by parent no
     // longer applies and a button group has to keep them exclusive.
     auto* group{new QButtonGroup(this)};
+    group->addButton(m_derive_radio);
     group->addButton(m_store_radio);
     group->addButton(m_generate_radio);
     group->addButton(m_existing_radio);
@@ -255,19 +311,48 @@ OperatorKeyWidget::OperatorKeyWidget(QWidget* parent) :
     auto* layout{new QVBoxLayout(this)};
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(TITLE_SPACING);
+    layout->addWidget(m_derive_card);
     layout->addWidget(m_store_card);
     layout->addWidget(generate_card.card);
     layout->addWidget(existing_card.card);
 
-    // Hidden until a caller commits to storing the secret; dialogs that cannot
-    // do that keep the generate/paste pair they always had.
+    // Both stay hidden until a caller commits to deriving or storing the secret;
+    // dialogs that can do neither keep the generate/paste pair they always had.
+    m_derive_card->setVisible(false);
     m_store_card->setVisible(false);
 
+    connect(m_derive_radio, &QRadioButton::toggled, this, &OperatorKeyWidget::updateState);
     connect(m_store_radio, &QRadioButton::toggled, this, &OperatorKeyWidget::updateState);
     connect(m_generate_radio, &QRadioButton::toggled, this, &OperatorKeyWidget::updateState);
     connect(m_existing_radio, &QRadioButton::toggled, this, &OperatorKeyWidget::updateState);
     connect(m_existing_edit, &QLineEdit::textChanged, this, &OperatorKeyWidget::updateState);
     updateState();
+}
+
+void OperatorKeyWidget::offerDerived()
+{
+    m_derive_card->setVisible(true);
+    m_derive_radio->setChecked(true);
+    updateState();
+}
+
+bool OperatorKeyWidget::setDerivedKey(const std::vector<unsigned char>& secret, const QString& path)
+{
+    const CBLSSecretKey key{secret};
+    if (!key.IsValid()) return false;
+    m_derived_secret = QString::fromStdString(key.ToString(/*specificLegacyScheme=*/false));
+    m_derived_public = QString::fromStdString(key.GetPublicKey().ToString(/*specificLegacyScheme=*/false));
+    m_derived_path = path;
+    m_derive_public_label->setText(MasternodeWidgetUtil::chunked(m_derived_public));
+    m_derive_path_label->setText(path.isEmpty() ? QString() : tr("Derivation path %1").arg(path));
+    m_derive_path_label->setVisible(!path.isEmpty());
+    updateState();
+    return true;
+}
+
+bool OperatorKeyWidget::needsDerivation() const
+{
+    return mode() == Mode::Derive && m_derived_public.isEmpty();
 }
 
 void OperatorKeyWidget::offerStoreInWallet(bool enabled, const QString& disabled_reason)
@@ -288,6 +373,9 @@ void OperatorKeyWidget::offerStoreInWallet(bool enabled, const QString& disabled
 void OperatorKeyWidget::updateState()
 {
     const Mode current{mode()};
+    m_derive_body->setVisible(current == Mode::Derive);
+    m_derive_pending->setVisible(m_derived_public.isEmpty());
+    m_derive_key_box->setVisible(!m_derived_public.isEmpty());
     m_store_body->setVisible(current == Mode::GenerateAndStore);
     m_generate_body->setVisible(current == Mode::GenerateOnly);
     m_existing_body->setVisible(current == Mode::Existing);
@@ -303,19 +391,37 @@ void OperatorKeyWidget::updateState()
 OperatorKeyWidget::Mode OperatorKeyWidget::mode() const
 {
     if (m_existing_radio->isChecked()) return Mode::Existing;
+    if (m_derive_radio->isChecked()) return Mode::Derive;
     if (m_store_radio->isChecked()) return Mode::GenerateAndStore;
     return Mode::GenerateOnly;
 }
 
 QString OperatorKeyWidget::publicKeyHex() const
 {
-    if (hasGeneratedSecret()) return m_generated_public;
-    return isValid() ? m_existing_edit->text().trimmed() : QString();
+    switch (mode()) {
+    case Mode::Derive:
+        return m_derived_public;
+    case Mode::GenerateAndStore:
+    case Mode::GenerateOnly:
+        return m_generated_public;
+    case Mode::Existing:
+        return isValid() ? m_existing_edit->text().trimmed() : QString();
+    }
+    return {};
 }
 
 QString OperatorKeyWidget::secretHex() const
 {
-    return hasGeneratedSecret() ? m_generated_secret : QString();
+    switch (mode()) {
+    case Mode::Derive:
+        return m_derived_secret;
+    case Mode::GenerateAndStore:
+    case Mode::GenerateOnly:
+        return m_generated_secret;
+    case Mode::Existing:
+        return {};
+    }
+    return {};
 }
 
 bool OperatorKeyWidget::hasGeneratedSecret() const
@@ -325,6 +431,8 @@ bool OperatorKeyWidget::hasGeneratedSecret() const
 
 bool OperatorKeyWidget::isValid() const
 {
+    // A derived key is only produced once the caller has an unlocked wallet, so
+    // the choice counts as valid before the key itself exists
     if (hasGeneratedSecret()) return true;
     CBLSPublicKey pubkey;
     return pubkey.SetHexStr(m_existing_edit->text().trimmed().toStdString(), /*specificLegacyScheme=*/false);

--- a/src/qt/masternodewidgets.cpp
+++ b/src/qt/masternodewidgets.cpp
@@ -26,13 +26,10 @@
 #include <QVariant>
 
 #include <algorithm>
+#include <map>
 #include <utility>
 #include <variant>
 #include <vector>
-
-namespace {
-constexpr int BALANCE_ROLE{Qt::UserRole + 1};
-} // anonymous namespace
 
 namespace MasternodeWidgetUtil {
 
@@ -101,14 +98,23 @@ void FeeSourcePicker::refresh()
     clear();
     if (m_wallet_model == nullptr) return;
 
-    std::vector<std::pair<QString, CAmount>> entries;
+    // Group each coin under its own scriptPubKey destination: the RPCs'
+    // FundSpecialTx only selects coins paying exactly the chosen address, while
+    // listCoins() groups change outputs under their parent non-change address,
+    // which would overstate what a protx call can actually spend.
+    std::map<CTxDestination, CAmount> balances;
     for (const auto& [dest, coins] : m_wallet_model->wallet().listCoins()) {
-        CAmount total{0};
         for (const auto& [outpoint, txout] : coins) {
             if (txout.is_spent || txout.depth_in_main_chain < 0) continue;
             if (m_wallet_model->wallet().isLockedCoin(outpoint)) continue;
-            total += txout.txout.nValue;
+            CTxDestination coin_dest;
+            if (!ExtractDestination(txout.txout.scriptPubKey, coin_dest)) continue;
+            balances[coin_dest] += txout.txout.nValue;
         }
+    }
+
+    std::vector<std::pair<QString, CAmount>> entries;
+    for (const auto& [dest, total] : balances) {
         if (total <= 0 || total < m_minimum_balance) continue;
         entries.emplace_back(QString::fromStdString(EncodeDestination(dest)), total);
     }
@@ -120,7 +126,6 @@ void FeeSourcePicker::refresh()
         addItem(QString("%1 (%2)").arg(address, BitcoinUnits::formatWithUnit(unit, balance, /*plussign=*/false,
                                                                              BitcoinUnits::SeparatorStyle::ALWAYS)),
                 address);
-        setItemData(count() - 1, static_cast<qlonglong>(balance), BALANCE_ROLE);
     }
     if (count() > 0) setCurrentIndex(0);
 }
@@ -128,12 +133,6 @@ void FeeSourcePicker::refresh()
 QString FeeSourcePicker::selectedAddress() const
 {
     return currentData().toString();
-}
-
-CAmount FeeSourcePicker::selectedBalance() const
-{
-    if (currentIndex() < 0) return 0;
-    return static_cast<CAmount>(itemData(currentIndex(), BALANCE_ROLE).toLongLong());
 }
 
 OperatorKeyWidget::OperatorKeyWidget(QWidget* parent) :

--- a/src/qt/masternodewidgets.h
+++ b/src/qt/masternodewidgets.h
@@ -12,6 +12,8 @@
 #include <QStringList>
 #include <QWidget>
 
+#include <vector>
+
 class QValidatedLineEdit;
 class WalletModel;
 
@@ -47,6 +49,14 @@ QLabel* makeTitle(const QString& text, QWidget* parent, double point_size = -1);
 QLabel* makeHint(const QString& text, QWidget* parent);
 //! Word-wrapped, selectable plain-text value; `monospace` for addresses, hashes and keys
 QLabel* makeValue(const QString& text, QWidget* parent, bool monospace = false);
+//! Group `text` into blocks of `chunk_size` characters separated by spaces. A BLS
+//! key is one 96-character word that a wrapping label refuses to break; grouped,
+//! it wraps between blocks and stays readable.
+QString chunked(const QString& text, int chunk_size = 12);
+//! Monospace value with a Copy button beside it. `display` is shown as given,
+//! `copy_text` is what the button puts on the clipboard, so a key can be shown
+//! in chunks and still be copied unbroken.
+QWidget* makeCopyableValue(const QString& display, const QString& copy_text, QWidget* parent);
 //! Frame grouping one choice or one section, named "mnCard" for theming
 QFrame* makeCard(QWidget* parent);
 
@@ -86,10 +96,11 @@ private:
     CAmount m_minimum_balance{0};
 };
 
-//! Operator key selection: generate a fresh BLS key pair (basic scheme) or
-//! paste an existing operator public key. The generated secret is kept only in
-//! memory; the owning dialog is responsible for storing it in the wallet or
-//! showing it to the user once.
+//! Operator key selection: derive a BLS key pair from the wallet's HD seed,
+//! generate a fresh one (basic scheme), or paste an existing operator public
+//! key. A derived or generated secret is kept only in memory here; the owning
+//! dialog is responsible for deriving it, storing it in the wallet, or showing
+//! it to the user once.
 class OperatorKeyWidget : public QWidget
 {
     Q_OBJECT
@@ -97,12 +108,20 @@ class OperatorKeyWidget : public QWidget
 public:
     //! Where the operator key comes from and what happens to its secret
     enum class Mode {
+        Derive,           //!< derived by the wallet from its HD seed; see setDerivedKey()
         GenerateAndStore, //!< generated here; the caller stores the secret in the wallet
         GenerateOnly,     //!< generated here; the secret exists only in this dialog
         Existing,         //!< an operator public key supplied by the user
     };
 
     explicit OperatorKeyWidget(QWidget* parent = nullptr);
+
+    //! Offer the "derive from this wallet's recovery phrase" choice and select
+    //! it. Deriving needs an unlocked wallet, so the key itself is not produced
+    //! here: the owning dialog derives it when the user is about to register and
+    //! hands it back through setDerivedKey(). Only callers doing that may call
+    //! this. Meant to be called once while setting the widget up.
+    void offerDerived();
 
     //! Offer the "generate and save in this wallet" choice and select it. Only
     //! callers that actually store secretHex() after a successful registration
@@ -111,15 +130,28 @@ public:
     //! `disabled_reason`. Meant to be called once while setting the widget up.
     void offerStoreInWallet(bool enabled, const QString& disabled_reason = QString());
 
+    //! Adopt the key the wallet derived: `secret` is its raw 32-byte BLS secret
+    //! and `path` the derivation path to show beside it. False when `secret` is
+    //! not a usable key, in which case the widget keeps waiting for one.
+    bool setDerivedKey(const std::vector<unsigned char>& secret, const QString& path);
+    //! True while Derive is selected and setDerivedKey() has not succeeded yet
+    bool needsDerivation() const;
+    //! Derivation path passed to setDerivedKey(); empty until then
+    QString derivationPath() const { return m_derived_path; }
+
     //! Currently selected mode
     Mode mode() const;
-    //! Selected operator public key in basic-scheme hex (empty when invalid)
+    //! Selected operator public key in basic-scheme hex (empty when invalid, and
+    //! while a derived key has not been handed back yet)
     QString publicKeyHex() const;
-    //! Generated secret key hex; empty when an existing public key is used
+    //! Derived or generated secret key hex; empty when an existing public key is
+    //! used, and while a derived key has not been handed back yet
     QString secretHex() const;
-    //! True when the user chose to generate a key inside this widget
+    //! True when this widget holds the operator secret (derived or generated),
+    //! rather than only the public key of a secret somebody else keeps
     bool hasGeneratedSecret() const;
-    //! True when publicKeyHex() would return a usable key
+    //! True when publicKeyHex() would return a usable key, or will once the
+    //! caller has derived it
     bool isValid() const;
 
 Q_SIGNALS:
@@ -129,14 +161,24 @@ private Q_SLOTS:
     void updateState();
 
 private:
+    QFrame* m_derive_card;
     QFrame* m_store_card;
+    QRadioButton* m_derive_radio;
     QRadioButton* m_store_radio;
     QRadioButton* m_generate_radio;
     QRadioButton* m_existing_radio;
+    QWidget* m_derive_body;
     QWidget* m_store_body;
     QWidget* m_generate_body;
     QWidget* m_existing_body;
+    QLabel* m_derive_pending;
+    QWidget* m_derive_key_box;
+    QLabel* m_derive_public_label;
+    QLabel* m_derive_path_label;
     QValidatedLineEdit* m_existing_edit;
+    QString m_derived_secret;
+    QString m_derived_public;
+    QString m_derived_path;
     QString m_generated_secret;
     QString m_generated_public;
 };

--- a/src/qt/masternodewidgets.h
+++ b/src/qt/masternodewidgets.h
@@ -50,7 +50,6 @@ public:
     void refresh();
 
     QString selectedAddress() const;
-    CAmount selectedBalance() const;
 
 private:
     WalletModel* m_wallet_model{nullptr};

--- a/src/qt/masternodewidgets.h
+++ b/src/qt/masternodewidgets.h
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_MASTERNODEWIDGETS_H
+#define BITCOIN_QT_MASTERNODEWIDGETS_H
+
+#include <consensus/amount.h>
+
+#include <QComboBox>
+#include <QString>
+#include <QStringList>
+#include <QWidget>
+
+class QValidatedLineEdit;
+class WalletModel;
+
+QT_BEGIN_NAMESPACE
+class QLabel;
+class QRadioButton;
+QT_END_NAMESPACE
+
+//! Free validation helpers shared by the masternode management dialogs
+namespace MasternodeWidgetUtil {
+//! Parse a comma/space separated list of "ADDR:PORT" entries. Entries without
+//! a port get the network's default P2P port. Returns the normalized entries,
+//! or an empty list with a non-empty `err` on the first invalid entry. An
+//! empty/whitespace-only input yields an empty list and no error.
+QStringList parseServiceList(const QString& input, QString& err);
+//! True when `address` decodes to a P2PKH destination on the current network
+bool isP2PKHAddress(const QString& address);
+//! True when `address` decodes to a P2PKH or P2SH destination on the current network
+bool isP2PKHorP2SHAddress(const QString& address);
+} // namespace MasternodeWidgetUtil
+
+//! Combo box listing the wallet's addresses with their spendable balance,
+//! largest first. Used to pick the fee source (or funding source) of a protx
+//! operation, defaulting to the address most likely able to pay.
+class FeeSourcePicker : public QComboBox
+{
+    Q_OBJECT
+
+public:
+    explicit FeeSourcePicker(QWidget* parent = nullptr);
+
+    void setWalletModel(WalletModel* wallet_model);
+    //! Hide addresses whose spendable balance is below `minimum` (default 0 = show all)
+    void setMinimumBalance(CAmount minimum);
+    //! Re-scan the wallet's coins and rebuild the list
+    void refresh();
+
+    QString selectedAddress() const;
+    CAmount selectedBalance() const;
+
+private:
+    WalletModel* m_wallet_model{nullptr};
+    CAmount m_minimum_balance{0};
+};
+
+//! Operator key selection: generate a fresh BLS key pair (basic scheme) or
+//! paste an existing operator public key. The generated secret is kept only in
+//! memory; the owning dialog is responsible for showing it to the user once.
+class OperatorKeyWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit OperatorKeyWidget(QWidget* parent = nullptr);
+
+    //! Selected operator public key in basic-scheme hex (empty when invalid)
+    QString publicKeyHex() const;
+    //! Generated secret key hex; empty when an existing public key is used
+    QString secretHex() const;
+    //! True when the user chose to generate a key inside this widget
+    bool hasGeneratedSecret() const;
+    //! True when publicKeyHex() would return a usable key
+    bool isValid() const;
+
+Q_SIGNALS:
+    void changed();
+
+private Q_SLOTS:
+    void updateState();
+
+private:
+    QRadioButton* m_generate_radio;
+    QRadioButton* m_existing_radio;
+    QLabel* m_generated_label;
+    QValidatedLineEdit* m_existing_edit;
+    QString m_generated_secret;
+    QString m_generated_public;
+};
+
+#endif // BITCOIN_QT_MASTERNODEWIDGETS_H

--- a/src/qt/masternodewidgets.h
+++ b/src/qt/masternodewidgets.h
@@ -99,8 +99,7 @@ private:
 //! Operator key selection: derive a BLS key pair from the wallet's HD seed,
 //! generate a fresh one (basic scheme), or paste an existing operator public
 //! key. A derived or generated secret is kept only in memory here; the owning
-//! dialog is responsible for deriving it, storing it in the wallet, or showing
-//! it to the user once.
+//! dialog is responsible for deriving it or for showing it to the user once.
 class OperatorKeyWidget : public QWidget
 {
     Q_OBJECT
@@ -108,10 +107,9 @@ class OperatorKeyWidget : public QWidget
 public:
     //! Where the operator key comes from and what happens to its secret
     enum class Mode {
-        Derive,           //!< derived by the wallet from its HD seed; see setDerivedKey()
-        GenerateAndStore, //!< generated here; the caller stores the secret in the wallet
-        GenerateOnly,     //!< generated here; the secret exists only in this dialog
-        Existing,         //!< an operator public key supplied by the user
+        Derive,       //!< derived by the wallet from its HD seed; see setDerivedKey()
+        GenerateOnly, //!< generated here; the secret exists only in this dialog
+        Existing,     //!< an operator public key supplied by the user
     };
 
     explicit OperatorKeyWidget(QWidget* parent = nullptr);
@@ -122,13 +120,6 @@ public:
     //! hands it back through setDerivedKey(). Only callers doing that may call
     //! this. Meant to be called once while setting the widget up.
     void offerDerived();
-
-    //! Offer the "generate and save in this wallet" choice and select it. Only
-    //! callers that actually store secretHex() after a successful registration
-    //! may enable it, so it stays hidden until this is called. `enabled` false
-    //! shows the choice but leaves it unselectable, explaining why through
-    //! `disabled_reason`. Meant to be called once while setting the widget up.
-    void offerStoreInWallet(bool enabled, const QString& disabled_reason = QString());
 
     //! Adopt the key the wallet derived: `secret` is its raw 32-byte BLS secret
     //! and `path` the derivation path to show beside it. False when `secret` is
@@ -162,13 +153,10 @@ private Q_SLOTS:
 
 private:
     QFrame* m_derive_card;
-    QFrame* m_store_card;
     QRadioButton* m_derive_radio;
-    QRadioButton* m_store_radio;
     QRadioButton* m_generate_radio;
     QRadioButton* m_existing_radio;
     QWidget* m_derive_body;
-    QWidget* m_store_body;
     QWidget* m_generate_body;
     QWidget* m_existing_body;
     QLabel* m_derive_pending;

--- a/src/qt/masternodewidgets.h
+++ b/src/qt/masternodewidgets.h
@@ -16,11 +16,13 @@ class QValidatedLineEdit;
 class WalletModel;
 
 QT_BEGIN_NAMESPACE
+class QFrame;
 class QLabel;
 class QRadioButton;
+class QVBoxLayout;
 QT_END_NAMESPACE
 
-//! Free validation helpers shared by the masternode management dialogs
+//! Free validation and layout helpers shared by the masternode management dialogs
 namespace MasternodeWidgetUtil {
 //! Parse a comma/space separated list of "ADDR:PORT" entries. Entries without
 //! a port get the network's default P2P port. Returns the normalized entries,
@@ -31,6 +33,34 @@ QStringList parseServiceList(const QString& input, QString& err);
 bool isP2PKHAddress(const QString& address);
 //! True when `address` decodes to a P2PKH or P2SH destination on the current network
 bool isP2PKHorP2SHAddress(const QString& address);
+
+//! Spacing tokens (px) keeping one vertical rhythm across the dialogs' pages
+constexpr int GROUP_SPACING{16}; //!< between top-level groups of a page
+constexpr int TITLE_SPACING{8};  //!< between a group's title and its body
+constexpr int ROW_SPACING{10};   //!< between rows inside a group
+constexpr int BODY_INDENT{26};   //!< indent of a body under its radio header
+constexpr int CARD_PADDING{12};  //!< a card's internal padding
+
+//! Bold label. A negative `point_size` keeps the theme's own size.
+QLabel* makeTitle(const QString& text, QWidget* parent, double point_size = -1);
+//! Dim, word-wrapped explanation
+QLabel* makeHint(const QString& text, QWidget* parent);
+//! Word-wrapped, selectable plain-text value; `monospace` for addresses, hashes and keys
+QLabel* makeValue(const QString& text, QWidget* parent, bool monospace = false);
+//! Frame grouping one choice or one section, named "mnCard" for theming
+QFrame* makeCard(QWidget* parent);
+
+//! A card presenting one choice: `header` (the radio button) sits on top, the
+//! optional `hint` below it, and `body` holds the controls that only matter
+//! while the choice is selected, so it can be hidden to collapse the card.
+struct OptionCard {
+    QFrame* card;
+    QWidget* body;
+    QVBoxLayout* body_layout;
+};
+//! Build an option card. `header` is re-parented into the card, so radio
+//! buttons of one page need a QButtonGroup to stay mutually exclusive.
+OptionCard makeOptionCard(QWidget* parent, QWidget* header, const QString& hint = QString());
 } // namespace MasternodeWidgetUtil
 
 //! Combo box listing the wallet's addresses with their spendable balance,
@@ -58,14 +88,31 @@ private:
 
 //! Operator key selection: generate a fresh BLS key pair (basic scheme) or
 //! paste an existing operator public key. The generated secret is kept only in
-//! memory; the owning dialog is responsible for showing it to the user once.
+//! memory; the owning dialog is responsible for storing it in the wallet or
+//! showing it to the user once.
 class OperatorKeyWidget : public QWidget
 {
     Q_OBJECT
 
 public:
+    //! Where the operator key comes from and what happens to its secret
+    enum class Mode {
+        GenerateAndStore, //!< generated here; the caller stores the secret in the wallet
+        GenerateOnly,     //!< generated here; the secret exists only in this dialog
+        Existing,         //!< an operator public key supplied by the user
+    };
+
     explicit OperatorKeyWidget(QWidget* parent = nullptr);
 
+    //! Offer the "generate and save in this wallet" choice and select it. Only
+    //! callers that actually store secretHex() after a successful registration
+    //! may enable it, so it stays hidden until this is called. `enabled` false
+    //! shows the choice but leaves it unselectable, explaining why through
+    //! `disabled_reason`. Meant to be called once while setting the widget up.
+    void offerStoreInWallet(bool enabled, const QString& disabled_reason = QString());
+
+    //! Currently selected mode
+    Mode mode() const;
     //! Selected operator public key in basic-scheme hex (empty when invalid)
     QString publicKeyHex() const;
     //! Generated secret key hex; empty when an existing public key is used
@@ -82,9 +129,13 @@ private Q_SLOTS:
     void updateState();
 
 private:
+    QFrame* m_store_card;
+    QRadioButton* m_store_radio;
     QRadioButton* m_generate_radio;
     QRadioButton* m_existing_radio;
-    QLabel* m_generated_label;
+    QWidget* m_store_body;
+    QWidget* m_generate_body;
+    QWidget* m_existing_body;
     QValidatedLineEdit* m_existing_edit;
     QString m_generated_secret;
     QString m_generated_public;

--- a/src/qt/masternodewizard.cpp
+++ b/src/qt/masternodewizard.cpp
@@ -1,0 +1,1107 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/masternodewizard.h>
+
+#include <chainparams.h>
+#include <evo/dmn_types.h>
+#include <interfaces/node.h>
+#include <interfaces/wallet.h>
+#include <key_io.h>
+#include <primitives/transaction.h>
+#include <util/strencodings.h>
+
+#include <qt/bitcoinunits.h>
+#include <qt/guiutil.h>
+#include <qt/masternodewidgets.h>
+#include <qt/optionsmodel.h>
+#include <qt/qvalidatedlineedit.h>
+#include <qt/walletmodel.h>
+
+#include <QComboBox>
+#include <QDoubleSpinBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMessageBox>
+#include <QPlainTextEdit>
+#include <QPushButton>
+#include <QRadioButton>
+#include <QSpinBox>
+#include <QStackedWidget>
+#include <QVBoxLayout>
+
+#include <univalue.h>
+
+namespace {
+//! Headroom on top of the collateral the funding address must hold for fees
+constexpr CAmount FEE_MARGIN{100000};
+//! Combo item role holding the collateral output index
+constexpr int VOUT_ROLE{Qt::UserRole + 1};
+
+QLabel* MakeTitle(const QString& text, QWidget* parent)
+{
+    auto* label{new QLabel(text, parent)};
+    GUIUtil::setFont({label}, GUIUtil::FontWeight::Bold, 14);
+    return label;
+}
+
+QLabel* MakeHint(const QString& text, QWidget* parent)
+{
+    auto* label{new QLabel(text, parent)};
+    label->setWordWrap(true);
+    return label;
+}
+
+QString FormatAmount(const WalletModel* wallet_model, CAmount amount)
+{
+    const auto unit{wallet_model && wallet_model->getOptionsModel() ?
+                        wallet_model->getOptionsModel()->getDisplayUnit() :
+                        BitcoinUnits::Unit::DASH};
+    return BitcoinUnits::formatWithUnit(unit, amount, /*plussign=*/false, BitcoinUnits::SeparatorStyle::ALWAYS);
+}
+} // anonymous namespace
+
+//! Keeps the wallet unlocked on the GUI thread while a ProTxSender call is in
+//! flight. UnlockContext is neither copyable nor movable, so it is constructed
+//! in place from requestUnlock()'s prvalue.
+struct RegisterMasternodeWizard::UnlockHolder
+{
+    WalletModel::UnlockContext ctx;
+    explicit UnlockHolder(WalletModel& wallet_model) :
+        ctx(wallet_model.requestUnlock()) {}
+};
+
+RegisterMasternodeWizard::RegisterMasternodeWizard(interfaces::Node& node, WalletModel* walletModel, QWidget* parent) :
+    QDialog(parent),
+    m_node(node),
+    m_walletModel(walletModel),
+    m_sender(node, this)
+{
+    setWindowTitle(tr("Register Masternode"));
+
+    m_pages = new QStackedWidget(this);
+    // Insertion order must match the Page enum: the enum value doubles as the
+    // stack index.
+    m_pages->insertWidget(PageType, createTypePage());
+    m_pages->insertWidget(PageCollateral, createCollateralPage());
+    m_pages->insertWidget(PageService, createServicePage());
+    m_pages->insertWidget(PageKeys, createKeysPage());
+    m_pages->insertWidget(PagePayout, createPayoutPage());
+    m_pages->insertWidget(PagePlatform, createPlatformPage());
+    m_pages->insertWidget(PageFee, createFeePage());
+    m_pages->insertWidget(PageReview, createReviewPage());
+    m_pages->insertWidget(PageSign, createSignPage());
+    m_pages->insertWidget(PageResult, createResultPage());
+
+    m_error_label = new QLabel(this);
+    m_error_label->setWordWrap(true);
+    m_error_label->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
+    m_error_label->setVisible(false);
+
+    m_back_button = new QPushButton(tr("Back"), this);
+    m_next_button = new QPushButton(tr("Next"), this);
+    m_next_button->setDefault(true);
+    m_cancel_button = new QPushButton(tr("Cancel"), this);
+
+    auto* buttons{new QHBoxLayout()};
+    buttons->addWidget(m_back_button);
+    buttons->addStretch();
+    buttons->addWidget(m_cancel_button);
+    buttons->addWidget(m_next_button);
+
+    auto* layout{new QVBoxLayout(this)};
+    layout->addWidget(m_pages, /*stretch=*/1);
+    layout->addWidget(m_error_label);
+    layout->addLayout(buttons);
+
+    connect(m_back_button, &QPushButton::clicked, this, &RegisterMasternodeWizard::onBack);
+    connect(m_next_button, &QPushButton::clicked, this, &RegisterMasternodeWizard::onNext);
+    connect(m_cancel_button, &QPushButton::clicked, this, &RegisterMasternodeWizard::reject);
+    connect(&m_sender, &ProTxSender::finished, this, &RegisterMasternodeWizard::onRpcFinished);
+
+    rebuildOrder();
+    enterPage(PageType);
+
+    GUIUtil::disableMacFocusRect(this);
+    GUIUtil::updateFonts();
+    setMinimumSize(700, 560);
+}
+
+RegisterMasternodeWizard::~RegisterMasternodeWizard() = default;
+
+QWidget* RegisterMasternodeWizard::createTypePage()
+{
+    auto* page{new QWidget(this)};
+    auto* layout{new QVBoxLayout(page)};
+    layout->addWidget(MakeTitle(tr("Masternode type"), page));
+
+    m_type_regular = new QRadioButton(
+        tr("Masternode — %1 collateral").arg(FormatAmount(m_walletModel, GetMnType(MnType::Regular).collat_amount)),
+        page);
+    m_type_regular->setChecked(true);
+    layout->addWidget(m_type_regular);
+    layout->addWidget(MakeHint(tr("Provides Core network services and earns regular masternode rewards."), page));
+
+    m_type_evo = new QRadioButton(
+        tr("Evonode — %1 collateral").arg(FormatAmount(m_walletModel, GetMnType(MnType::Evo).collat_amount)), page);
+    layout->addWidget(m_type_evo);
+    layout->addWidget(MakeHint(tr("Additionally hosts Dash Platform, has four times the voting weight and earns a "
+                                  "larger share of rewards. Requires a Platform node ID and extra services."),
+                               page));
+    layout->addStretch();
+
+    connect(m_type_regular, &QRadioButton::toggled, this, [this] {
+        rebuildOrder();
+        refreshCollateralCandidates();
+    });
+    return page;
+}
+
+QWidget* RegisterMasternodeWizard::createCollateralPage()
+{
+    auto* page{new QWidget(this)};
+    auto* layout{new QVBoxLayout(page)};
+    layout->addWidget(MakeTitle(tr("Collateral"), page));
+
+    m_col_fund = new QRadioButton(tr("Send collateral from this wallet to a new address"), page);
+    m_col_fund->setChecked(true);
+    layout->addWidget(m_col_fund);
+    m_col_fund_box = new QWidget(page);
+    {
+        auto* box{new QVBoxLayout(m_col_fund_box)};
+        box->setContentsMargins(24, 0, 0, 0);
+        box->addWidget(MakeHint(tr("A single transaction funds the collateral and registers the masternode."),
+                                m_col_fund_box));
+        auto* row{new QHBoxLayout()};
+        m_col_address = new QValidatedLineEdit(m_col_fund_box);
+        GUIUtil::setupAddressWidget(m_col_address, this);
+        row->addWidget(m_col_address, /*stretch=*/1);
+        auto* fresh{new QPushButton(tr("Use new address"), m_col_fund_box)};
+        connect(fresh, &QPushButton::clicked, this, [this] {
+            QString err;
+            const QString addr{freshAddress(err)};
+            if (addr.isEmpty()) {
+                showError(err);
+            } else {
+                m_col_address->setText(addr);
+            }
+        });
+        row->addWidget(fresh);
+        box->addLayout(row);
+    }
+    layout->addWidget(m_col_fund_box);
+
+    m_col_wallet = new QRadioButton(tr("Use an existing collateral output of this wallet"), page);
+    layout->addWidget(m_col_wallet);
+    m_col_wallet_box = new QWidget(page);
+    {
+        auto* box{new QVBoxLayout(m_col_wallet_box)};
+        box->setContentsMargins(24, 0, 0, 0);
+        box->addWidget(MakeHint(tr("Unspent outputs of exactly the collateral amount, with at least one "
+                                   "confirmation and not used by another masternode."),
+                                m_col_wallet_box));
+        m_col_utxo_combo = new QComboBox(m_col_wallet_box);
+        m_col_utxo_combo->setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLengthWithIcon);
+        m_col_utxo_combo->setMinimumContentsLength(40);
+        box->addWidget(m_col_utxo_combo);
+        m_col_utxo_none = MakeHint(tr("No suitable output found in this wallet."), m_col_wallet_box);
+        m_col_utxo_none->setVisible(false);
+        box->addWidget(m_col_utxo_none);
+    }
+    layout->addWidget(m_col_wallet_box);
+
+    m_col_external = new QRadioButton(tr("Reference an external collateral (e.g. hardware wallet)"), page);
+    layout->addWidget(m_col_external);
+    m_col_external_box = new QWidget(page);
+    {
+        auto* box{new QVBoxLayout(m_col_external_box)};
+        box->setContentsMargins(24, 0, 0, 0);
+        box->addWidget(MakeHint(tr("The collateral must be a confirmed P2PKH output of exactly the collateral "
+                                   "amount. After review you will be asked to sign a message with the collateral "
+                                   "key outside this wallet."),
+                                m_col_external_box));
+        auto* row{new QHBoxLayout()};
+        m_col_txid = new QLineEdit(m_col_external_box);
+        m_col_txid->setPlaceholderText(tr("Collateral transaction id (64 hexadecimal characters)"));
+        m_col_txid->setMaxLength(64);
+        row->addWidget(m_col_txid, /*stretch=*/1);
+        m_col_vout = new QSpinBox(m_col_external_box);
+        m_col_vout->setRange(0, 99999);
+        m_col_vout->setToolTip(tr("Output index"));
+        row->addWidget(m_col_vout);
+        box->addLayout(row);
+    }
+    layout->addWidget(m_col_external_box);
+    layout->addStretch();
+
+    const auto update_boxes = [this] {
+        m_col_fund_box->setVisible(m_col_fund->isChecked());
+        m_col_wallet_box->setVisible(m_col_wallet->isChecked());
+        m_col_external_box->setVisible(m_col_external->isChecked());
+        if (m_col_wallet->isChecked()) refreshCollateralCandidates();
+        rebuildOrder();
+    };
+    connect(m_col_fund, &QRadioButton::toggled, this, update_boxes);
+    connect(m_col_wallet, &QRadioButton::toggled, this, update_boxes);
+    connect(m_col_external, &QRadioButton::toggled, this, update_boxes);
+    update_boxes();
+    return page;
+}
+
+QWidget* RegisterMasternodeWizard::createServicePage()
+{
+    auto* page{new QWidget(this)};
+    auto* layout{new QVBoxLayout(page)};
+    layout->addWidget(MakeTitle(tr("Service addresses"), page));
+    layout->addWidget(MakeHint(tr("Public addresses your masternode will serve the Core P2P network on, separated "
+                                  "by commas or spaces. Each entry must be unique on the network."),
+                               page));
+    m_service_edit = new QLineEdit(page);
+    m_service_edit->setPlaceholderText(QString("1.2.3.4:%1").arg(Params().GetDefaultPort()));
+    layout->addWidget(m_service_edit);
+    layout->addWidget(MakeHint(tr("May be left empty; the masternode then stays inactive until you send a service "
+                                  "update with an address."),
+                               page));
+    layout->addStretch();
+    return page;
+}
+
+QWidget* RegisterMasternodeWizard::createKeysPage()
+{
+    auto* page{new QWidget(this)};
+    auto* layout{new QVBoxLayout(page)};
+    layout->addWidget(MakeTitle(tr("Keys"), page));
+
+    layout->addWidget(MakeHint(tr("Owner address (P2PKH). Controls this masternode; its key signs payout and "
+                                  "voting updates. Kept in this wallet by default."),
+                               page));
+    auto* owner_row{new QHBoxLayout()};
+    m_owner_edit = new QValidatedLineEdit(page);
+    GUIUtil::setupAddressWidget(m_owner_edit, this);
+    owner_row->addWidget(m_owner_edit, /*stretch=*/1);
+    auto* owner_fresh{new QPushButton(tr("Use new address"), page)};
+    connect(owner_fresh, &QPushButton::clicked, this, [this] {
+        QString err;
+        const QString addr{freshAddress(err)};
+        if (addr.isEmpty()) {
+            showError(err);
+        } else {
+            m_owner_edit->setText(addr);
+        }
+    });
+    owner_row->addWidget(owner_fresh);
+    layout->addLayout(owner_row);
+
+    layout->addWidget(MakeHint(tr("Voting address (P2PKH). May be delegated; leave empty to vote with the owner "
+                                  "key."),
+                               page));
+    m_voting_edit = new QValidatedLineEdit(page);
+    GUIUtil::setupAddressWidget(m_voting_edit, this);
+    m_voting_edit->setPlaceholderText(tr("Leave empty to use the owner address"));
+    layout->addWidget(m_voting_edit);
+
+    layout->addWidget(MakeHint(tr("Operator key (BLS). The operator runs the masternode server; only the public "
+                                  "key is registered on-chain."),
+                               page));
+    m_operator_widget = new OperatorKeyWidget(page);
+    layout->addWidget(m_operator_widget);
+    layout->addStretch();
+    return page;
+}
+
+QWidget* RegisterMasternodeWizard::createPayoutPage()
+{
+    auto* page{new QWidget(this)};
+    auto* layout{new QVBoxLayout(page)};
+    layout->addWidget(MakeTitle(tr("Payout"), page));
+
+    layout->addWidget(MakeHint(tr("Address receiving this masternode's block rewards (P2PKH or P2SH)."), page));
+    auto* payout_row{new QHBoxLayout()};
+    m_payout_edit = new QValidatedLineEdit(page);
+    GUIUtil::setupAddressWidget(m_payout_edit, this);
+    payout_row->addWidget(m_payout_edit, /*stretch=*/1);
+    auto* payout_fresh{new QPushButton(tr("Use new address"), page)};
+    connect(payout_fresh, &QPushButton::clicked, this, [this] {
+        QString err;
+        const QString addr{freshAddress(err)};
+        if (addr.isEmpty()) {
+            showError(err);
+        } else {
+            m_payout_edit->setText(addr);
+        }
+    });
+    payout_row->addWidget(payout_fresh);
+    layout->addLayout(payout_row);
+
+    layout->addWidget(MakeHint(tr("Share of the reward promised to the operator:"), page));
+    m_operator_reward = new QDoubleSpinBox(page);
+    m_operator_reward->setRange(0.0, 100.0);
+    m_operator_reward->setDecimals(2);
+    m_operator_reward->setSuffix(QString::fromUtf8(" %"));
+    layout->addWidget(m_operator_reward);
+    m_reward_warning = MakeHint(tr("The operator will permanently receive this share of all rewards of this "
+                                   "masternode. Leave it at 0 unless you have an agreement with your operator."),
+                                page);
+    m_reward_warning->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
+    m_reward_warning->setVisible(false);
+    layout->addWidget(m_reward_warning);
+    connect(m_operator_reward, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this,
+            [this](double value) { m_reward_warning->setVisible(value > 0.0); });
+    layout->addStretch();
+    return page;
+}
+
+QWidget* RegisterMasternodeWizard::createPlatformPage()
+{
+    auto* page{new QWidget(this)};
+    auto* layout{new QVBoxLayout(page)};
+    layout->addWidget(MakeTitle(tr("Platform services"), page));
+
+    layout->addWidget(MakeHint(tr("Platform node ID, derived from the Platform P2P public key (40 hexadecimal "
+                                  "characters)."),
+                               page));
+    m_platform_nodeid = new QLineEdit(page);
+    m_platform_nodeid->setMaxLength(40);
+    m_platform_nodeid->setPlaceholderText(QString("f2dbd9b0a1f541a7c44d34a58674d0262f5feca5"));
+    layout->addWidget(m_platform_nodeid);
+
+    m_platform_addr_box = new QWidget(page);
+    {
+        auto* box{new QVBoxLayout(m_platform_addr_box)};
+        box->setContentsMargins(0, 0, 0, 0);
+        box->addWidget(MakeHint(tr("Platform P2P addresses (ADDR:PORT, separated by commas or spaces):"),
+                                m_platform_addr_box));
+        m_platform_p2p = new QLineEdit(m_platform_addr_box);
+        m_platform_p2p->setPlaceholderText(QString("1.2.3.4:26656"));
+        box->addWidget(m_platform_p2p);
+        box->addWidget(MakeHint(tr("Platform HTTPS API addresses (ADDR:PORT, separated by commas or spaces):"),
+                                m_platform_addr_box));
+        m_platform_https = new QLineEdit(m_platform_addr_box);
+        m_platform_https->setPlaceholderText(QString("1.2.3.4:443"));
+        box->addWidget(m_platform_https);
+    }
+    layout->addWidget(m_platform_addr_box);
+
+    m_platform_port_box = new QWidget(page);
+    {
+        auto* box{new QVBoxLayout(m_platform_port_box)};
+        box->setContentsMargins(0, 0, 0, 0);
+        box->addWidget(MakeHint(tr("Before v24 activation only the Platform ports can be registered; they apply to "
+                                   "the first service address."),
+                                m_platform_port_box));
+        auto* row{new QHBoxLayout()};
+        row->addWidget(new QLabel(tr("Platform P2P port:"), m_platform_port_box));
+        m_platform_p2p_port = new QSpinBox(m_platform_port_box);
+        m_platform_p2p_port->setRange(1, 65535);
+        m_platform_p2p_port->setValue(26656);
+        row->addWidget(m_platform_p2p_port);
+        row->addWidget(new QLabel(tr("Platform HTTPS port:"), m_platform_port_box));
+        m_platform_https_port = new QSpinBox(m_platform_port_box);
+        m_platform_https_port->setRange(1, 65535);
+        m_platform_https_port->setValue(443);
+        row->addWidget(m_platform_https_port);
+        row->addStretch();
+        box->addLayout(row);
+    }
+    layout->addWidget(m_platform_port_box);
+    layout->addStretch();
+    return page;
+}
+
+QWidget* RegisterMasternodeWizard::createFeePage()
+{
+    auto* page{new QWidget(this)};
+    auto* layout{new QVBoxLayout(page)};
+    layout->addWidget(MakeTitle(tr("Fee source"), page));
+    m_fee_explain = MakeHint(QString(), page);
+    layout->addWidget(m_fee_explain);
+    m_fee_picker = new FeeSourcePicker(page);
+    m_fee_picker->setWalletModel(m_walletModel);
+    layout->addWidget(m_fee_picker);
+    layout->addStretch();
+    return page;
+}
+
+QWidget* RegisterMasternodeWizard::createReviewPage()
+{
+    auto* page{new QWidget(this)};
+    auto* layout{new QVBoxLayout(page)};
+    layout->addWidget(MakeTitle(tr("Review"), page));
+    m_review_label = new QLabel(page);
+    m_review_label->setWordWrap(true);
+    m_review_label->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    layout->addWidget(m_review_label);
+    layout->addStretch();
+    return page;
+}
+
+QWidget* RegisterMasternodeWizard::createSignPage()
+{
+    auto* page{new QWidget(this)};
+    auto* layout{new QVBoxLayout(page)};
+    layout->addWidget(MakeTitle(tr("Prove collateral ownership"), page));
+    m_sign_address_label = MakeHint(QString(), page);
+    layout->addWidget(m_sign_address_label);
+    layout->addWidget(MakeHint(tr("Sign the following message with the collateral key (for example with your "
+                                  "hardware wallet's sign-message feature), then paste the base64 signature "
+                                  "below."),
+                               page));
+    m_sign_message = new QPlainTextEdit(page);
+    m_sign_message->setReadOnly(true);
+    m_sign_message->setMaximumHeight(90);
+    layout->addWidget(m_sign_message);
+    auto* copy_row{new QHBoxLayout()};
+    auto* copy_button{new QPushButton(tr("Copy message"), page)};
+    connect(copy_button, &QPushButton::clicked, this,
+            [this] { GUIUtil::setClipboard(m_sign_message->toPlainText()); });
+    copy_row->addWidget(copy_button);
+    copy_row->addStretch();
+    layout->addLayout(copy_row);
+    m_sig_edit = new QPlainTextEdit(page);
+    m_sig_edit->setPlaceholderText(tr("Paste the base64 signature here"));
+    m_sig_edit->setMaximumHeight(90);
+    layout->addWidget(m_sig_edit);
+    layout->addStretch();
+    return page;
+}
+
+QWidget* RegisterMasternodeWizard::createResultPage()
+{
+    auto* page{new QWidget(this)};
+    auto* layout{new QVBoxLayout(page)};
+    layout->addWidget(MakeTitle(tr("Masternode registered"), page));
+    m_result_label = new QLabel(page);
+    m_result_label->setWordWrap(true);
+    m_result_label->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    layout->addWidget(m_result_label);
+
+    m_secret_box = new QWidget(page);
+    {
+        auto* box{new QVBoxLayout(m_secret_box)};
+        box->setContentsMargins(0, 12, 0, 0);
+        auto* warn{MakeHint(tr("Operator secret key — save it now. It is not stored anywhere and will never be "
+                               "shown again."),
+                            m_secret_box)};
+        warn->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
+        box->addWidget(warn);
+        m_secret_edit = new QLineEdit(m_secret_box);
+        m_secret_edit->setReadOnly(true);
+        box->addWidget(m_secret_edit);
+        box->addWidget(MakeHint(tr("Add this line to dash.conf on your masternode server:"), m_secret_box));
+        auto* conf_row{new QHBoxLayout()};
+        m_conf_line_edit = new QLineEdit(m_secret_box);
+        m_conf_line_edit->setReadOnly(true);
+        conf_row->addWidget(m_conf_line_edit, /*stretch=*/1);
+        auto* copy_conf{new QPushButton(tr("Copy"), m_secret_box)};
+        connect(copy_conf, &QPushButton::clicked, this,
+                [this] { GUIUtil::setClipboard(m_conf_line_edit->text()); });
+        conf_row->addWidget(copy_conf);
+        box->addLayout(conf_row);
+        box->addWidget(MakeHint(tr("Type the last 4 characters of the secret key to confirm you saved it:"),
+                                m_secret_box));
+        m_confirm_edit = new QLineEdit(m_secret_box);
+        m_confirm_edit->setMaxLength(4);
+        m_confirm_edit->setMaximumWidth(120);
+        connect(m_confirm_edit, &QLineEdit::textChanged, this, &RegisterMasternodeWizard::updateButtons);
+        box->addWidget(m_confirm_edit);
+    }
+    layout->addWidget(m_secret_box);
+
+    m_next_steps = new QLabel(page);
+    m_next_steps->setWordWrap(true);
+    layout->addWidget(m_next_steps);
+    layout->addStretch();
+    return page;
+}
+
+bool RegisterMasternodeWizard::isEvo() const
+{
+    return m_type_evo->isChecked();
+}
+
+bool RegisterMasternodeWizard::isExternalCollateral() const
+{
+    return m_col_external->isChecked();
+}
+
+bool RegisterMasternodeWizard::isFundCollateral() const
+{
+    return m_col_fund->isChecked();
+}
+
+QString RegisterMasternodeWizard::collateralAddress() const
+{
+    return isFundCollateral() ? m_col_address->text().trimmed() : QString();
+}
+
+QString RegisterMasternodeWizard::ownerAddress() const
+{
+    return m_owner_edit->text().trimmed();
+}
+
+QString RegisterMasternodeWizard::votingAddress() const
+{
+    return m_voting_edit->text().trimmed();
+}
+
+QString RegisterMasternodeWizard::freshAddress(QString& err) const
+{
+    err.clear();
+    if (m_walletModel == nullptr) {
+        err = tr("No wallet is available.");
+        return {};
+    }
+    auto dest{m_walletModel->wallet().getNewDestination(/*label=*/"")};
+    if (!dest) {
+        err = tr("Could not generate a new address: %1")
+                  .arg(QString::fromStdString(util::ErrorString(dest).translated));
+        return {};
+    }
+    return QString::fromStdString(EncodeDestination(*dest));
+}
+
+CAmount RegisterMasternodeWizard::collateralAmount() const
+{
+    return GetMnType(isEvo() ? MnType::Evo : MnType::Regular).collat_amount;
+}
+
+void RegisterMasternodeWizard::rebuildOrder()
+{
+    m_order = {PageType, PageCollateral, PageService, PageKeys, PagePayout};
+    if (isEvo()) m_order << PagePlatform;
+    m_order << PageFee << PageReview;
+    if (isExternalCollateral()) m_order << PageSign;
+    m_order << PageResult;
+    if (m_pos >= m_order.size()) m_pos = m_order.size() - 1;
+}
+
+void RegisterMasternodeWizard::goToPage(Page page)
+{
+    const int pos{m_order.indexOf(page)};
+    if (pos < 0) return;
+    m_pos = pos;
+    enterPage(page);
+}
+
+void RegisterMasternodeWizard::enterPage(Page page)
+{
+    m_pages->setCurrentIndex(page);
+    showError(QString());
+    switch (page) {
+    case PageCollateral:
+        if (m_col_address->text().isEmpty() && m_walletModel != nullptr) {
+            QString err;
+            const QString addr{freshAddress(err)};
+            if (!addr.isEmpty()) m_col_address->setText(addr);
+        }
+        refreshCollateralCandidates();
+        break;
+    case PageKeys:
+        if (m_owner_edit->text().isEmpty() && m_walletModel != nullptr) {
+            QString err;
+            const QString addr{freshAddress(err)};
+            if (!addr.isEmpty()) m_owner_edit->setText(addr);
+        }
+        break;
+    case PagePayout:
+        if (m_payout_edit->text().isEmpty() && m_walletModel != nullptr) {
+            QString err;
+            const QString addr{freshAddress(err)};
+            if (!addr.isEmpty()) m_payout_edit->setText(addr);
+        }
+        break;
+    case PagePlatform: {
+        const bool v3{m_node.isV24Active()};
+        m_platform_addr_box->setVisible(v3);
+        m_platform_port_box->setVisible(!v3);
+        break;
+    }
+    case PageFee: {
+        const CAmount required{isFundCollateral() ? collateralAmount() + FEE_MARGIN : FEE_MARGIN};
+        m_fee_picker->setMinimumBalance(required);
+        m_fee_picker->refresh();
+        if (isFundCollateral()) {
+            m_fee_explain->setText(tr("The selected address funds the %1 collateral plus the transaction fee, so "
+                                      "it must hold at least %2. Change returns to the same address.")
+                                       .arg(FormatAmount(m_walletModel, collateralAmount()),
+                                            FormatAmount(m_walletModel, required)));
+        } else {
+            m_fee_explain->setText(tr("The selected address pays the transaction fee."));
+        }
+        break;
+    }
+    case PageReview:
+        populateReview();
+        break;
+    default:
+        break;
+    }
+    updateButtons();
+}
+
+bool RegisterMasternodeWizard::validatePage(Page page, QString& err)
+{
+    err.clear();
+    switch (page) {
+    case PageCollateral:
+        if (isFundCollateral()) {
+            if (!MasternodeWidgetUtil::isP2PKHorP2SHAddress(collateralAddress())) {
+                err = tr("Enter a valid collateral address (P2PKH or P2SH).");
+            }
+        } else if (m_col_wallet->isChecked()) {
+            if (m_col_utxo_combo->currentIndex() < 0) {
+                err = tr("This wallet has no unspent output of exactly %1. Fund the collateral from the wallet "
+                         "instead.")
+                          .arg(FormatAmount(m_walletModel, collateralAmount()));
+            }
+        } else {
+            const QString txid{m_col_txid->text().trimmed()};
+            if (txid.length() != 64 || !IsHex(txid.toStdString())) {
+                err = tr("Enter the collateral transaction id as 64 hexadecimal characters.");
+            }
+        }
+        break;
+    case PageService: {
+        QString parse_err;
+        const QStringList list{MasternodeWidgetUtil::parseServiceList(m_service_edit->text(), parse_err)};
+        if (!parse_err.isEmpty()) {
+            err = parse_err;
+        } else if (list.isEmpty() && isEvo() && !m_node.isV24Active()) {
+            err = tr("Evonodes need at least one service address to carry the Platform ports before v24 "
+                     "activation.");
+        }
+        break;
+    }
+    case PageKeys:
+        if (!MasternodeWidgetUtil::isP2PKHAddress(ownerAddress())) {
+            err = tr("Enter a valid owner address (P2PKH).");
+        } else if (isFundCollateral() && ownerAddress() == collateralAddress()) {
+            err = tr("The owner address must differ from the collateral address.");
+        } else if (!votingAddress().isEmpty() && !MasternodeWidgetUtil::isP2PKHAddress(votingAddress())) {
+            err = tr("Enter a valid voting address (P2PKH), or leave it empty to use the owner address.");
+        } else if (!m_operator_widget->isValid()) {
+            err = tr("Enter a valid operator BLS public key (96 hexadecimal characters, basic scheme).");
+        }
+        break;
+    case PagePayout: {
+        const QString payout{m_payout_edit->text().trimmed()};
+        if (!MasternodeWidgetUtil::isP2PKHorP2SHAddress(payout)) {
+            err = tr("Enter a valid payout address (P2PKH or P2SH).");
+        } else if (isFundCollateral() && payout == collateralAddress()) {
+            err = tr("The payout address must differ from the collateral address.");
+        }
+        break;
+    }
+    case PagePlatform: {
+        const QString nodeid{m_platform_nodeid->text().trimmed()};
+        if (nodeid.length() != 40 || !IsHex(nodeid.toStdString())) {
+            err = tr("Enter the Platform node ID as 40 hexadecimal characters.");
+            break;
+        }
+        if (m_node.isV24Active()) {
+            QString parse_err;
+            const QStringList p2p{MasternodeWidgetUtil::parseServiceList(m_platform_p2p->text(), parse_err)};
+            if (!parse_err.isEmpty()) {
+                err = tr("Platform P2P: %1").arg(parse_err);
+                break;
+            }
+            const QStringList https{MasternodeWidgetUtil::parseServiceList(m_platform_https->text(), parse_err)};
+            if (!parse_err.isEmpty()) {
+                err = tr("Platform HTTPS: %1").arg(parse_err);
+                break;
+            }
+            QString service_err;
+            const bool has_service{!MasternodeWidgetUtil::parseServiceList(m_service_edit->text(), service_err).isEmpty()};
+            if (has_service && (p2p.isEmpty() || https.isEmpty())) {
+                err = tr("Enter at least one Platform P2P and one Platform HTTPS address, or clear the service "
+                         "addresses to set everything later with a service update.");
+            }
+        }
+        break;
+    }
+    case PageFee:
+        if (m_fee_picker->currentIndex() < 0) {
+            const CAmount required{isFundCollateral() ? collateralAmount() + FEE_MARGIN : FEE_MARGIN};
+            err = tr("No wallet address holds at least %1.").arg(FormatAmount(m_walletModel, required));
+        }
+        break;
+    case PageSign: {
+        const QString sig{m_sig_edit->toPlainText().simplified().remove(' ')};
+        if (sig.isEmpty() || !DecodeBase64(sig.toStdString()).has_value()) {
+            err = tr("Paste the base64-encoded signature of the message above, made with the collateral key.");
+        }
+        break;
+    }
+    default:
+        break;
+    }
+    return err.isEmpty();
+}
+
+void RegisterMasternodeWizard::onNext()
+{
+    if (m_busy) return;
+    const Page current{m_order[m_pos]};
+    QString err;
+    if (!validatePage(current, err)) {
+        showError(err);
+        return;
+    }
+    showError(QString());
+    if (current == PageReview) {
+        startRegistration();
+    } else if (current == PageSign) {
+        startSubmit();
+    } else if (current == PageResult) {
+        accept();
+    } else {
+        ++m_pos;
+        enterPage(m_order[m_pos]);
+    }
+}
+
+void RegisterMasternodeWizard::onBack()
+{
+    if (m_busy || m_pos == 0) return;
+    --m_pos;
+    enterPage(m_order[m_pos]);
+}
+
+void RegisterMasternodeWizard::updateButtons()
+{
+    const Page current{m_order[m_pos]};
+    m_back_button->setVisible(current != PageType && current != PageResult);
+    // After register_prepare the transaction is fixed; going back would
+    // silently invalidate the message being signed.
+    m_back_button->setEnabled(!m_busy && current != PageSign);
+    m_cancel_button->setVisible(current != PageResult);
+    m_cancel_button->setEnabled(!m_busy);
+
+    if (!m_busy) {
+        QString next_text{tr("Next")};
+        if (current == PageReview) {
+            next_text = isExternalCollateral() ? tr("Prepare") : tr("Register");
+        } else if (current == PageSign) {
+            next_text = tr("Submit");
+        } else if (current == PageResult) {
+            next_text = tr("Finish");
+        }
+        m_next_button->setText(next_text);
+    }
+
+    bool enabled{!m_busy};
+    QString tooltip;
+    if (m_walletModel == nullptr) {
+        enabled = false;
+        tooltip = tr("No wallet is available. Masternode registration requires a wallet.");
+    } else if (m_walletModel->wallet().privateKeysDisabled()) {
+        enabled = false;
+        tooltip = tr("This wallet is watch-only. Masternode registration requires a wallet that can sign "
+                     "transactions.");
+    } else if (current == PageResult && m_operator_widget->hasGeneratedSecret()) {
+        const QString expected{m_operator_widget->secretHex().right(4)};
+        if (m_confirm_edit->text().trimmed().compare(expected, Qt::CaseInsensitive) != 0) {
+            enabled = false;
+            tooltip = tr("Confirm you saved the operator secret key by typing its last 4 characters.");
+        }
+    }
+    m_next_button->setEnabled(enabled);
+    m_next_button->setToolTip(tooltip);
+}
+
+void RegisterMasternodeWizard::setBusy(bool busy, const QString& busy_text)
+{
+    m_busy = busy;
+    if (busy) {
+        m_next_button->setText(busy_text.isEmpty() ? tr("Working…") : busy_text);
+    }
+    updateButtons();
+}
+
+void RegisterMasternodeWizard::showError(const QString& message)
+{
+    m_error_label->setText(message);
+    m_error_label->setVisible(!message.isEmpty());
+}
+
+void RegisterMasternodeWizard::refreshCollateralCandidates()
+{
+    m_col_utxo_combo->clear();
+    if (m_walletModel == nullptr) {
+        m_col_utxo_none->setVisible(true);
+        return;
+    }
+    const CAmount collateral{collateralAmount()};
+    for (const auto& [dest, coins] : m_walletModel->wallet().listCoins()) {
+        const QString address{QString::fromStdString(EncodeDestination(dest))};
+        for (const auto& [outpoint, txout] : coins) {
+            if (txout.txout.nValue != collateral || txout.is_spent || txout.depth_in_main_chain < 1) continue;
+            if (m_walletModel->wallet().isLockedCoin(outpoint)) continue;
+            const QString txid{QString::fromStdString(outpoint.hash.ToString())};
+            m_col_utxo_combo->addItem(QString("%1:%2 (%3)").arg(txid).arg(outpoint.n).arg(address), txid);
+            m_col_utxo_combo->setItemData(m_col_utxo_combo->count() - 1, static_cast<int>(outpoint.n), VOUT_ROLE);
+        }
+    }
+    m_col_utxo_none->setVisible(m_col_utxo_combo->count() == 0);
+}
+
+void RegisterMasternodeWizard::populateReview()
+{
+    QStringList rows;
+    const auto row = [&rows](const QString& key, const QString& value) {
+        rows << QString("<b>%1</b> %2").arg(key, value.toHtmlEscaped());
+    };
+
+    row(tr("Type:"), isEvo() ? tr("Evonode") : tr("Masternode"));
+    if (isFundCollateral()) {
+        row(tr("Collateral:"), tr("send %1 to %2")
+                                   .arg(FormatAmount(m_walletModel, collateralAmount()), collateralAddress()));
+    } else if (m_col_wallet->isChecked()) {
+        row(tr("Collateral:"), m_col_utxo_combo->currentText());
+    } else {
+        row(tr("Collateral:"),
+            QString("%1:%2").arg(m_col_txid->text().trimmed()).arg(m_col_vout->value()));
+    }
+    QString parse_err;
+    const QStringList services{MasternodeWidgetUtil::parseServiceList(m_service_edit->text(), parse_err)};
+    row(tr("Service:"), services.isEmpty() ? tr("(none — set later with a service update)") : services.join(", "));
+    row(tr("Owner address:"), ownerAddress());
+    row(tr("Voting address:"),
+        votingAddress().isEmpty() ? tr("%1 (owner)").arg(ownerAddress()) : votingAddress());
+    row(tr("Operator key:"), m_operator_widget->hasGeneratedSecret() ?
+                                 tr("%1 (newly generated)").arg(m_operator_widget->publicKeyHex()) :
+                                 m_operator_widget->publicKeyHex());
+    row(tr("Payout address:"), m_payout_edit->text().trimmed());
+    row(tr("Operator reward:"), QString("%1%").arg(QString::number(m_operator_reward->value(), 'f', 2)));
+    if (isEvo()) {
+        row(tr("Platform node ID:"), m_platform_nodeid->text().trimmed());
+        if (m_node.isV24Active()) {
+            QString platform_err;
+            row(tr("Platform P2P:"),
+                MasternodeWidgetUtil::parseServiceList(m_platform_p2p->text(), platform_err).join(", "));
+            row(tr("Platform HTTPS:"),
+                MasternodeWidgetUtil::parseServiceList(m_platform_https->text(), platform_err).join(", "));
+        } else {
+            row(tr("Platform ports:"), QString("%1 (P2P), %2 (HTTPS)")
+                                           .arg(m_platform_p2p_port->value())
+                                           .arg(m_platform_https_port->value()));
+        }
+    }
+    row(isFundCollateral() ? tr("Funding address:") : tr("Fee source:"), m_fee_picker->selectedAddress());
+
+    QString footer;
+    if (isExternalCollateral()) {
+        footer = tr("Clicking Prepare creates the unsigned transaction and a message you must sign with the "
+                    "collateral key. Nothing is broadcast yet.");
+    } else {
+        footer = tr("Clicking Register may ask to unlock the wallet, then broadcasts the transaction.");
+    }
+    m_review_label->setText(rows.join("<br>") + "<br><br>" + footer.toHtmlEscaped());
+}
+
+UniValue RegisterMasternodeWizard::buildRegisterParams() const
+{
+    UniValue params(UniValue::VOBJ);
+    if (isFundCollateral()) {
+        params.pushKV("collateralAddress", collateralAddress().toStdString());
+    } else if (m_col_wallet->isChecked()) {
+        params.pushKV("collateralHash", m_col_utxo_combo->currentData().toString().toStdString());
+        params.pushKV("collateralIndex",
+                      m_col_utxo_combo->itemData(m_col_utxo_combo->currentIndex(), VOUT_ROLE).toInt());
+    } else {
+        params.pushKV("collateralHash", m_col_txid->text().trimmed().toStdString());
+        params.pushKV("collateralIndex", m_col_vout->value());
+    }
+
+    QString parse_err;
+    UniValue core_addrs(UniValue::VARR);
+    for (const QString& entry : MasternodeWidgetUtil::parseServiceList(m_service_edit->text(), parse_err)) {
+        core_addrs.push_back(entry.toStdString());
+    }
+    params.pushKV("coreP2PAddrs", core_addrs);
+    params.pushKV("ownerAddress", ownerAddress().toStdString());
+    params.pushKV("operatorPubKey", m_operator_widget->publicKeyHex().toStdString());
+    params.pushKV("votingAddress", votingAddress().toStdString());
+    params.pushKV("operatorReward", QString::number(m_operator_reward->value(), 'f', 2).toStdString());
+    params.pushKV("payoutAddress", m_payout_edit->text().trimmed().toStdString());
+    if (isEvo()) {
+        params.pushKV("platformNodeID", m_platform_nodeid->text().trimmed().toStdString());
+        if (m_node.isV24Active()) {
+            UniValue p2p_addrs(UniValue::VARR);
+            for (const QString& entry : MasternodeWidgetUtil::parseServiceList(m_platform_p2p->text(), parse_err)) {
+                p2p_addrs.push_back(entry.toStdString());
+            }
+            UniValue https_addrs(UniValue::VARR);
+            for (const QString& entry :
+                 MasternodeWidgetUtil::parseServiceList(m_platform_https->text(), parse_err)) {
+                https_addrs.push_back(entry.toStdString());
+            }
+            params.pushKV("platformP2PAddrs", p2p_addrs);
+            params.pushKV("platformHTTPSAddrs", https_addrs);
+        } else {
+            params.pushKV("platformP2PAddrs", m_platform_p2p_port->value());
+            params.pushKV("platformHTTPSAddrs", m_platform_https_port->value());
+        }
+    }
+    if (isFundCollateral()) {
+        params.pushKV("fundAddress", m_fee_picker->selectedAddress().toStdString());
+    } else {
+        params.pushKV("feeSourceAddress", m_fee_picker->selectedAddress().toStdString());
+    }
+    if (!isExternalCollateral()) {
+        params.pushKV("submit", true);
+    }
+    return params;
+}
+
+void RegisterMasternodeWizard::startRegistration()
+{
+    if (m_walletModel == nullptr) return;
+    m_unlock = std::make_unique<UnlockHolder>(*m_walletModel);
+    if (!m_unlock->ctx.isValid()) {
+        m_unlock.reset();
+        return;
+    }
+
+    QString method;
+    if (isFundCollateral()) {
+        method = isEvo() ? "protx register_fund_evo" : "protx register_fund";
+    } else if (isExternalCollateral()) {
+        method = isEvo() ? "protx register_prepare_evo" : "protx register_prepare";
+    } else {
+        method = isEvo() ? "protx register_evo" : "protx register";
+    }
+    m_stage = isExternalCollateral() ? Stage::Prepare : Stage::Register;
+    setBusy(true, isExternalCollateral() ? tr("Preparing…") : tr("Registering…"));
+    if (!m_sender.execute(method, buildRegisterParams(), m_walletModel)) {
+        m_stage = Stage::None;
+        m_unlock.reset();
+        setBusy(false);
+    }
+}
+
+void RegisterMasternodeWizard::startSubmit()
+{
+    if (m_walletModel == nullptr) return;
+    m_unlock = std::make_unique<UnlockHolder>(*m_walletModel);
+    if (!m_unlock->ctx.isValid()) {
+        m_unlock.reset();
+        return;
+    }
+
+    UniValue params(UniValue::VOBJ);
+    params.pushKV("tx", m_prepared_tx.toStdString());
+    params.pushKV("sig", m_sig_edit->toPlainText().simplified().remove(' ').toStdString());
+    m_stage = Stage::Submit;
+    setBusy(true, tr("Submitting…"));
+    if (!m_sender.execute("protx register_submit", params, m_walletModel)) {
+        m_stage = Stage::None;
+        m_unlock.reset();
+        setBusy(false);
+    }
+}
+
+void RegisterMasternodeWizard::onRpcFinished(const ProTxResult& result)
+{
+    const Stage stage{m_stage};
+    m_stage = Stage::None;
+    m_unlock.reset();
+    setBusy(false);
+
+    if (!result.ok) {
+        QMessageBox::critical(this, tr("Registration failed"), result.message);
+        return;
+    }
+
+    switch (stage) {
+    case Stage::Register:
+    case Stage::Submit: {
+        const QString txid{result.value.isStr() ? QString::fromStdString(result.value.get_str()) :
+                                                  QString::fromStdString(result.value.write())};
+        populateResult(txid);
+        goToPage(PageResult);
+        break;
+    }
+    case Stage::Prepare: {
+        const UniValue& tx{result.value.find_value("tx")};
+        const UniValue& address{result.value.find_value("collateralAddress")};
+        const UniValue& message{result.value.find_value("signMessage")};
+        if (!result.value.isObject() || !tx.isStr() || !address.isStr() || !message.isStr()) {
+            showError(tr("Unexpected reply to the prepare request."));
+            return;
+        }
+        m_prepared_tx = QString::fromStdString(tx.get_str());
+        m_sign_address_label->setText(
+            tr("Collateral address holding the key: %1").arg(QString::fromStdString(address.get_str())));
+        m_sign_message->setPlainText(QString::fromStdString(message.get_str()));
+        goToPage(PageSign);
+        break;
+    }
+    case Stage::None:
+        break;
+    }
+}
+
+void RegisterMasternodeWizard::populateResult(const QString& pro_tx_hash)
+{
+    m_registered = true;
+    m_result_label->setText(tr("The provider registration transaction was sent to the network.") + "<br><br>" +
+                            tr("Provider transaction hash:") + "<br><b>" + pro_tx_hash.toHtmlEscaped() + "</b>");
+
+    const bool generated{m_operator_widget->hasGeneratedSecret()};
+    m_secret_box->setVisible(generated);
+    if (generated) {
+        m_secret_edit->setText(m_operator_widget->secretHex());
+        m_conf_line_edit->setText(QString("masternodeblsprivkey=%1").arg(m_operator_widget->secretHex()));
+    }
+
+    QStringList steps;
+    steps << tr("Next steps:");
+    if (generated) {
+        steps << tr("1. Add the line above to dash.conf on your masternode server and restart dashd there.");
+    } else {
+        steps << tr("1. Configure your masternode server with the BLS secret key matching the operator public key "
+                    "you provided.");
+    }
+    steps << tr("2. Make sure the service address and port are reachable from the internet.");
+    if (isEvo()) {
+        steps << tr("3. Provision the Dash Platform services (Tenderdash and Drive) with the Platform node key "
+                    "matching the node ID you registered.");
+        steps << tr("4. The evonode becomes active once the registration is confirmed and the first update is "
+                    "signed by the operator.");
+    } else {
+        steps << tr("3. The masternode becomes active once the registration is confirmed on the network.");
+    }
+    m_next_steps->setText(steps.join("<br>"));
+}
+
+void RegisterMasternodeWizard::reject()
+{
+    if (m_busy) return;
+    if (m_registered) {
+        if (m_operator_widget->hasGeneratedSecret()) {
+            const QString expected{m_operator_widget->secretHex().right(4)};
+            if (m_confirm_edit->text().trimmed().compare(expected, Qt::CaseInsensitive) != 0 &&
+                QMessageBox::warning(this, tr("Operator secret not confirmed"),
+                                     tr("You have not confirmed saving the operator secret key. Without it your "
+                                        "masternode cannot operate. Close anyway?"),
+                                     QMessageBox::Yes | QMessageBox::No, QMessageBox::No) != QMessageBox::Yes) {
+                return;
+            }
+        }
+        QDialog::accept();
+        return;
+    }
+    if (!m_prepared_tx.isEmpty()) {
+        if (QMessageBox::warning(this, tr("Discard prepared registration?"),
+                                 tr("The prepared registration will be discarded. If the collateral or fee inputs "
+                                    "belong to this wallet they stay locked; unlock them via coin control if you "
+                                    "do not intend to retry."),
+                                 QMessageBox::Yes | QMessageBox::No, QMessageBox::No) != QMessageBox::Yes) {
+            return;
+        }
+    }
+    QDialog::reject();
+}

--- a/src/qt/masternodewizard.cpp
+++ b/src/qt/masternodewizard.cpp
@@ -40,7 +40,9 @@
 
 #include <univalue.h>
 
+#include <string>
 #include <variant>
+#include <vector>
 
 namespace {
 using MasternodeWidgetUtil::BODY_INDENT;
@@ -373,11 +375,18 @@ QWidget* RegisterMasternodeWizard::createKeysPage()
                                        page));
     m_operator_widget = new OperatorKeyWidget(page);
     if (m_walletModel != nullptr) {
-        const bool can_store{m_walletModel->wallet().canStoreMasternodeOperatorKey()};
-        m_operator_widget->offerStoreInWallet(
-            can_store, can_store ? QString() :
-                                   tr("This wallet cannot store an operator key, so the secret key can only be "
-                                      "shown once."));
+        // Only the best choice this wallet can make is offered; the ones it
+        // cannot make would be dead options. When it can make none, the store
+        // choice stays visible but disabled to explain why.
+        if (m_walletModel->wallet().canDeriveMasternodeOperatorKey()) {
+            m_operator_widget->offerDerived();
+        } else {
+            const bool can_store{m_walletModel->wallet().canStoreMasternodeOperatorKey()};
+            m_operator_widget->offerStoreInWallet(
+                can_store, can_store ? QString() :
+                                       tr("This wallet can neither derive an operator key from its recovery phrase "
+                                          "nor store one, so the secret key can only be shown once."));
+        }
     }
     operator_block->addWidget(m_operator_widget);
     layout->addStretch();
@@ -607,6 +616,12 @@ QWidget* RegisterMasternodeWizard::createResultPage()
         conf_row->addWidget(copy_conf);
         box->addLayout(conf_row);
 
+        // Where to find the key again, for the cases where the wallet keeps it
+        m_secret_recall = MakeHint(tr("You can see it again later from the Masternodes tab: right-click the "
+                                      "masternode and choose Show Operator Key."),
+                                   m_secret_box);
+        box->addWidget(m_secret_recall);
+
         // Only worth asking for when the key exists nowhere else
         m_confirm_box = new QWidget(m_secret_box);
         auto* confirm_layout{new QVBoxLayout(m_confirm_box)};
@@ -692,10 +707,15 @@ CAmount RegisterMasternodeWizard::collateralAmount() const
     return GetMnType(isEvo() ? MnType::Evo : MnType::Regular).collat_amount;
 }
 
+bool RegisterMasternodeWizard::secretGateRequired() const
+{
+    // A key the wallet derives or stores can be looked up again, so only a secret
+    // that exists nowhere but on the result page is worth gating on
+    return m_operator_widget->hasGeneratedSecret() && !m_operator_key_derived && !m_operator_key_saved;
+}
+
 bool RegisterMasternodeWizard::secretConfirmed() const
 {
-    // A key the wallet stored needs no hand-copy confirmation
-    if (m_operator_key_saved) return true;
     return m_confirm_edit->text().trimmed().compare(m_operator_widget->secretHex().right(4),
                                                     Qt::CaseInsensitive) == 0;
 }
@@ -722,6 +742,9 @@ void RegisterMasternodeWizard::enterPage(Page page)
 {
     m_pages->setCurrentIndex(page);
     showError(QString());
+    // Only the review holds an unlock of its own, to derive the operator key and
+    // hand it straight to the registration; leaving the page gives it up again
+    if (page != PageReview) m_unlock.reset();
     switch (page) {
     case PageCollateral:
         if (m_col_address->text().isEmpty() && m_walletModel != nullptr) {
@@ -766,6 +789,9 @@ void RegisterMasternodeWizard::enterPage(Page page)
         break;
     }
     case PageReview:
+        // Derive before the summary is built, so the review shows the key that
+        // will actually be registered
+        ensureOperatorKey();
         populateReview();
         break;
     default:
@@ -887,6 +913,17 @@ void RegisterMasternodeWizard::onNext()
     }
     showError(QString());
     if (current == PageReview) {
+        // Retry a derivation that failed on entering the page: the user may have
+        // unlocked the wallet since, and registering without the key must not
+        // happen at all
+        const bool was_pending{m_operator_widget->needsDerivation()};
+        if (!ensureOperatorKey()) return;
+        if (was_pending) {
+            // The summary was built without the key; nothing gets registered
+            // before it has been shown here
+            populateReview();
+            return;
+        }
         startRegistration();
     } else if (current == PageSign) {
         startSubmit();
@@ -936,7 +973,7 @@ void RegisterMasternodeWizard::updateButtons()
         enabled = false;
         tooltip = tr("This wallet is watch-only. Masternode registration requires a wallet that can sign "
                      "transactions.");
-    } else if (current == PageResult && m_operator_widget->hasGeneratedSecret() && !secretConfirmed()) {
+    } else if (current == PageResult && secretGateRequired() && !secretConfirmed()) {
         enabled = false;
         tooltip = tr("Confirm you saved the operator secret key by typing its last 4 characters.");
     }
@@ -1042,22 +1079,14 @@ void RegisterMasternodeWizard::populateReview()
         section->addWidget(makeValue(value, section_card, monospace), r, 1);
     };
     // A BLS key is one 96-character word, which a wrapping label refuses to break.
-    // A read-only plain text view wraps anywhere and still copies the exact key.
-    const auto long_row = [&section, &section_card](const QString& key, const QString& value) {
+    // Shown in chunks it wraps like the other values, and the Copy button hands
+    // out the unbroken key.
+    const auto key_row = [&section, &section_card](const QString& key, const QString& value) {
         const int r{section->rowCount()};
         section->addWidget(MakeHint(key, section_card), r, 0, Qt::AlignLeft | Qt::AlignTop);
-        auto* field{new QPlainTextEdit(value, section_card)};
-        field->setReadOnly(true);
-        field->setFrameShape(QFrame::NoFrame);
-        field->setFont(GUIUtil::fixedPitchFont());
-        // It is a value, not an input: the theme's field border would say otherwise
-        field->setStyleSheet("QPlainTextEdit { background: transparent; border: none; }");
-        field->setFocusPolicy(Qt::ClickFocus);
-        field->setWordWrapMode(QTextOption::WrapAnywhere);
-        field->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-        field->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-        field->setFixedHeight(2 * QFontMetrics(field->font()).lineSpacing() + ROW_SPACING);
-        section->addWidget(field, r, 1);
+        section->addWidget(MasternodeWidgetUtil::makeCopyableValue(MasternodeWidgetUtil::chunked(value), value,
+                                                                   section_card),
+                           r, 1);
     };
 
     // Rebuilt on every entry to the page: the user may have gone back and edited.
@@ -1110,7 +1139,12 @@ void RegisterMasternodeWizard::populateReview()
     row(tr("Owner"), ownerAddress(), /*monospace=*/true);
     row(tr("Voting"), votingAddress().isEmpty() ? tr("Same as owner") : votingAddress(),
         !votingAddress().isEmpty());
-    long_row(tr("Operator"), m_operator_widget->publicKeyHex());
+    const QString operator_key{m_operator_widget->publicKeyHex()};
+    if (operator_key.isEmpty()) {
+        row(tr("Operator"), tr("Not derived yet — see the message below"));
+    } else {
+        key_row(tr("Operator"), operator_key);
+    }
     row(QString(), operatorKeyProvenance());
 
     begin_section(tr("Payout"));
@@ -1133,6 +1167,11 @@ void RegisterMasternodeWizard::populateReview()
 QString RegisterMasternodeWizard::operatorKeyProvenance() const
 {
     switch (m_operator_widget->mode()) {
+    case OperatorKeyWidget::Mode::Derive:
+        return m_operator_widget->derivationPath().isEmpty() ?
+                   tr("Derived from this wallet's recovery phrase") :
+                   tr("Derived from this wallet's recovery phrase (path %1)")
+                       .arg(m_operator_widget->derivationPath());
     case OperatorKeyWidget::Mode::GenerateAndStore:
         return tr("Newly generated, saved in this wallet");
     case OperatorKeyWidget::Mode::GenerateOnly:
@@ -1198,10 +1237,42 @@ UniValue RegisterMasternodeWizard::buildRegisterParams() const
     return params;
 }
 
+bool RegisterMasternodeWizard::ensureOperatorKey()
+{
+    if (m_walletModel == nullptr || !m_operator_widget->needsDerivation()) return true;
+
+    // Held on until the registration reuses it or the user leaves the review, so
+    // one derivation plus one registration ask for the passphrase once
+    if (!m_unlock) m_unlock = std::make_unique<UnlockHolder>(*m_walletModel);
+    if (!m_unlock->ctx.isValid()) {
+        m_unlock.reset();
+        showError(tr("Deriving the operator key needs this wallet unlocked. Unlock it and continue, or go back and "
+                     "choose another way to get an operator key."));
+        return false;
+    }
+
+    std::vector<unsigned char> secret;
+    std::string path;
+    std::string error;
+    if (!m_walletModel->wallet().deriveMasternodeOperatorKey(secret, path, error)) {
+        showError(tr("This wallet could not derive an operator key: %1. Go back and choose another way to get "
+                     "one.")
+                      .arg(QString::fromStdString(error)));
+        return false;
+    }
+    if (!m_operator_widget->setDerivedKey(secret, QString::fromStdString(path))) {
+        showError(tr("This wallet derived an unusable operator key. Go back and choose another way to get one."));
+        return false;
+    }
+    m_operator_key_derived = true;
+    return true;
+}
+
 void RegisterMasternodeWizard::startRegistration()
 {
     if (m_walletModel == nullptr) return;
-    m_unlock = std::make_unique<UnlockHolder>(*m_walletModel);
+    // ensureOperatorKey() may already hold the unlock this call needs
+    if (!m_unlock) m_unlock = std::make_unique<UnlockHolder>(*m_walletModel);
     if (!m_unlock->ctx.isValid()) {
         m_unlock.reset();
         return;
@@ -1321,7 +1392,19 @@ void RegisterMasternodeWizard::populateResult(const QString& pro_tx_hash)
     if (generated) {
         m_secret_edit->setText(m_operator_widget->secretHex());
         m_conf_line_edit->setText(QString("masternodeblsprivkey=%1").arg(m_operator_widget->secretHex()));
-        if (m_operator_key_saved) {
+        // Both fields are longer than they are wide: show their start, not their tail
+        m_secret_edit->setCursorPosition(0);
+        m_conf_line_edit->setCursorPosition(0);
+        if (m_operator_key_derived) {
+            const QString path{m_operator_widget->derivationPath()};
+            m_secret_note->setText(path.isEmpty() ?
+                                       tr("Derived from this wallet's recovery phrase. Restoring that phrase "
+                                          "restores this key.") :
+                                       tr("Derived from this wallet's recovery phrase (path %1). Restoring that "
+                                          "phrase restores this key.")
+                                           .arg(path));
+            m_secret_note->setStyleSheet(QString());
+        } else if (m_operator_key_saved) {
             m_secret_note->setText(tr("Saved in this wallet — include it in your wallet backup. Your masternode "
                                       "server still needs the line below."));
             m_secret_note->setStyleSheet(QString());
@@ -1334,13 +1417,15 @@ void RegisterMasternodeWizard::populateResult(const QString& pro_tx_hash)
             m_secret_note->setText(tr("Save it now — it is not kept anywhere and will never be shown again."));
             m_secret_note->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
         }
-        // The confirmation gate only earns its friction when the key exists
-        // nowhere but on this screen
-        m_confirm_box->setVisible(!m_operator_key_saved);
+        // Both only apply while the wallet actually keeps the key: the show-once
+        // case cannot promise a later look, and it is the only one whose friction
+        // buys anything
+        m_secret_recall->setVisible(!secretGateRequired());
+        m_confirm_box->setVisible(secretGateRequired());
     }
 
+    // The card already carries the "Next steps" heading
     QStringList steps;
-    steps << tr("Next steps:");
     if (generated) {
         steps << tr("1. Add the line above to dash.conf on your masternode server and restart dashd there.");
     } else {
@@ -1363,7 +1448,7 @@ void RegisterMasternodeWizard::reject()
 {
     if (m_busy) return;
     if (m_registered) {
-        if (m_operator_widget->hasGeneratedSecret() && !secretConfirmed() &&
+        if (secretGateRequired() && !secretConfirmed() &&
             QMessageBox::warning(this, tr("Operator secret not confirmed"),
                                  tr("You have not confirmed saving the operator secret key. Without it your "
                                     "masternode cannot operate. Close anyway?"),

--- a/src/qt/masternodewizard.cpp
+++ b/src/qt/masternodewizard.cpp
@@ -20,14 +20,19 @@
 #include <qt/qvalidatedlineedit.h>
 #include <qt/walletmodel.h>
 
+#include <QButtonGroup>
 #include <QComboBox>
 #include <QDoubleSpinBox>
+#include <QFrame>
+#include <QGridLayout>
 #include <QHBoxLayout>
 #include <QLabel>
+#include <QLayoutItem>
 #include <QLineEdit>
 #include <QMessageBox>
 #include <QPlainTextEdit>
 #include <QPushButton>
+#include <QScrollArea>
 #include <QRadioButton>
 #include <QSpinBox>
 #include <QStackedWidget>
@@ -38,23 +43,56 @@
 #include <variant>
 
 namespace {
+using MasternodeWidgetUtil::BODY_INDENT;
+using MasternodeWidgetUtil::CARD_PADDING;
+using MasternodeWidgetUtil::GROUP_SPACING;
+using MasternodeWidgetUtil::ROW_SPACING;
+using MasternodeWidgetUtil::TITLE_SPACING;
+using MasternodeWidgetUtil::makeCard;
+using MasternodeWidgetUtil::makeOptionCard;
+using MasternodeWidgetUtil::makeValue;
+
 //! Headroom on top of the collateral the funding address must hold for fees
 constexpr CAmount FEE_MARGIN{100000};
 //! Combo item role holding the collateral output index
 constexpr int VOUT_ROLE{Qt::UserRole + 1};
+//! Point size of a page heading
+constexpr double PAGE_TITLE_SIZE{14};
 
 QLabel* MakeTitle(const QString& text, QWidget* parent)
 {
-    auto* label{new QLabel(text, parent)};
-    GUIUtil::setFont({label}, GUIUtil::FontWeight::Bold, 14);
-    return label;
+    return MasternodeWidgetUtil::makeTitle(text, parent, PAGE_TITLE_SIZE);
+}
+
+//! Heading of one block inside a page, in the page's own text size
+QLabel* MakeLabel(const QString& text, QWidget* parent)
+{
+    return MasternodeWidgetUtil::makeTitle(text, parent);
 }
 
 QLabel* MakeHint(const QString& text, QWidget* parent)
 {
-    auto* label{new QLabel(text, parent)};
-    label->setWordWrap(true);
-    return label;
+    return MasternodeWidgetUtil::makeHint(text, parent);
+}
+
+//! Vertical layout of a wizard page: the dialog supplies the margins, the page
+//! only keeps the rhythm between its groups.
+QVBoxLayout* MakePageLayout(QWidget* page)
+{
+    auto* layout{new QVBoxLayout(page)};
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(GROUP_SPACING);
+    return layout;
+}
+
+//! One group inside a page: label, hint and controls sit closer together than
+//! the groups themselves do.
+QVBoxLayout* MakeBlock(QVBoxLayout* page_layout)
+{
+    auto* block{new QVBoxLayout()};
+    block->setSpacing(TITLE_SPACING);
+    page_layout->addLayout(block);
+    return block;
 }
 
 QString FormatAmount(const WalletModel* wallet_model, CAmount amount)
@@ -114,7 +152,11 @@ RegisterMasternodeWizard::RegisterMasternodeWizard(interfaces::Node& node, Walle
     buttons->addWidget(m_cancel_button);
     buttons->addWidget(m_next_button);
 
+    // The dialog owns the page margins; the pages themselves use none so the
+    // two do not add up.
     auto* layout{new QVBoxLayout(this)};
+    layout->setContentsMargins(24, 12, 24, 12);
+    layout->setSpacing(GROUP_SPACING);
     layout->addWidget(m_pages, /*stretch=*/1);
     layout->addWidget(m_error_label);
     layout->addLayout(buttons);
@@ -137,23 +179,30 @@ RegisterMasternodeWizard::~RegisterMasternodeWizard() = default;
 QWidget* RegisterMasternodeWizard::createTypePage()
 {
     auto* page{new QWidget(this)};
-    auto* layout{new QVBoxLayout(page)};
+    auto* layout{MakePageLayout(page)};
     layout->addWidget(MakeTitle(tr("Masternode type"), page));
 
     m_type_regular = new QRadioButton(
         tr("Masternode — %1 collateral").arg(FormatAmount(m_walletModel, GetMnType(MnType::Regular).collat_amount)),
         page);
     m_type_regular->setChecked(true);
-    layout->addWidget(m_type_regular);
-    layout->addWidget(MakeHint(tr("Provides Core network services and earns regular masternode rewards."), page));
+    auto regular_card{makeOptionCard(page, m_type_regular,
+                                     tr("Provides Core network services and earns regular masternode rewards."))};
+    regular_card.body->setVisible(false);
+    layout->addWidget(regular_card.card);
 
     m_type_evo = new QRadioButton(
         tr("Evonode — %1 collateral").arg(FormatAmount(m_walletModel, GetMnType(MnType::Evo).collat_amount)), page);
-    layout->addWidget(m_type_evo);
-    layout->addWidget(MakeHint(tr("Additionally hosts Dash Platform, has four times the voting weight and earns a "
-                                  "larger share of rewards. Requires a Platform node ID and extra services."),
-                               page));
+    auto evo_card{makeOptionCard(page, m_type_evo,
+                                 tr("Additionally hosts Dash Platform, has four times the voting weight and earns a "
+                                    "larger share of rewards. Requires a Platform node ID and extra services."))};
+    evo_card.body->setVisible(false);
+    layout->addWidget(evo_card.card);
     layout->addStretch();
+
+    auto* group{new QButtonGroup(page)};
+    group->addButton(m_type_regular);
+    group->addButton(m_type_evo);
 
     connect(m_type_regular, &QRadioButton::toggled, this, [this] {
         rebuildOrder();
@@ -165,18 +214,15 @@ QWidget* RegisterMasternodeWizard::createTypePage()
 QWidget* RegisterMasternodeWizard::createCollateralPage()
 {
     auto* page{new QWidget(this)};
-    auto* layout{new QVBoxLayout(page)};
+    auto* layout{MakePageLayout(page)};
     layout->addWidget(MakeTitle(tr("Collateral"), page));
 
     m_col_fund = new QRadioButton(tr("Send collateral from this wallet to a new address"), page);
     m_col_fund->setChecked(true);
-    layout->addWidget(m_col_fund);
-    m_col_fund_box = new QWidget(page);
+    auto fund_card{makeOptionCard(page, m_col_fund,
+                                  tr("A single transaction funds the collateral and registers the masternode."))};
+    m_col_fund_box = fund_card.body;
     {
-        auto* box{new QVBoxLayout(m_col_fund_box)};
-        box->setContentsMargins(24, 0, 0, 0);
-        box->addWidget(MakeHint(tr("A single transaction funds the collateral and registers the masternode."),
-                                m_col_fund_box));
         auto* row{new QHBoxLayout()};
         m_col_address = new QValidatedLineEdit(m_col_fund_box);
         GUIUtil::setupAddressWidget(m_col_address, this);
@@ -192,39 +238,38 @@ QWidget* RegisterMasternodeWizard::createCollateralPage()
             }
         });
         row->addWidget(fresh);
-        box->addLayout(row);
+        fund_card.body_layout->addLayout(row);
     }
-    layout->addWidget(m_col_fund_box);
+    layout->addWidget(fund_card.card);
 
     m_col_wallet = new QRadioButton(tr("Use an existing collateral output of this wallet"), page);
-    layout->addWidget(m_col_wallet);
-    m_col_wallet_box = new QWidget(page);
+    auto wallet_card{makeOptionCard(page, m_col_wallet,
+                                    tr("An unspent P2PKH output of exactly the collateral amount, confirmed and not "
+                                       "used by another masternode."))};
+    m_col_wallet_box = wallet_card.body;
     {
-        auto* box{new QVBoxLayout(m_col_wallet_box)};
-        box->setContentsMargins(24, 0, 0, 0);
-        box->addWidget(MakeHint(tr("Unspent P2PKH outputs of exactly the collateral amount, with at least one "
-                                   "confirmation and not used by another masternode."),
-                                m_col_wallet_box));
         m_col_utxo_combo = new QComboBox(m_col_wallet_box);
         m_col_utxo_combo->setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLengthWithIcon);
         m_col_utxo_combo->setMinimumContentsLength(40);
-        box->addWidget(m_col_utxo_combo);
-        m_col_utxo_none = MakeHint(tr("No suitable output found in this wallet."), m_col_wallet_box);
+        wallet_card.body_layout->addWidget(m_col_utxo_combo);
+        // Empty state of the card: the exact requirement, filled in with the
+        // type's collateral amount by refreshCollateralCandidates().
+        m_col_utxo_none = MakeHint(QString(), m_col_wallet_box);
         m_col_utxo_none->setVisible(false);
-        box->addWidget(m_col_utxo_none);
+        wallet_card.body_layout->addWidget(m_col_utxo_none);
     }
-    layout->addWidget(m_col_wallet_box);
+    layout->addWidget(wallet_card.card);
 
     m_col_external = new QRadioButton(tr("Reference an external collateral (e.g. hardware wallet)"), page);
-    layout->addWidget(m_col_external);
-    m_col_external_box = new QWidget(page);
+    auto external_card{makeOptionCard(page, m_col_external,
+                                      tr("A confirmed P2PKH output of exactly the collateral amount, held outside "
+                                         "this wallet."))};
+    m_col_external_box = external_card.body;
     {
-        auto* box{new QVBoxLayout(m_col_external_box)};
-        box->setContentsMargins(24, 0, 0, 0);
-        box->addWidget(MakeHint(tr("The collateral must be a confirmed P2PKH output of exactly the collateral "
-                                   "amount. After review you will be asked to sign a message with the collateral "
-                                   "key outside this wallet."),
-                                m_col_external_box));
+        external_card.body_layout->addWidget(
+            MakeHint(tr("After review you will be asked to sign a message with the collateral key outside this "
+                        "wallet."),
+                     m_col_external_box));
         auto* row{new QHBoxLayout()};
         m_col_txid = new QLineEdit(m_col_external_box);
         m_col_txid->setPlaceholderText(tr("Collateral transaction id (64 hexadecimal characters)"));
@@ -234,10 +279,15 @@ QWidget* RegisterMasternodeWizard::createCollateralPage()
         m_col_vout->setRange(0, 99999);
         m_col_vout->setToolTip(tr("Output index"));
         row->addWidget(m_col_vout);
-        box->addLayout(row);
+        external_card.body_layout->addLayout(row);
     }
-    layout->addWidget(m_col_external_box);
+    layout->addWidget(external_card.card);
     layout->addStretch();
+
+    auto* group{new QButtonGroup(page)};
+    group->addButton(m_col_fund);
+    group->addButton(m_col_wallet);
+    group->addButton(m_col_external);
 
     const auto update_boxes = [this] {
         m_col_fund_box->setVisible(m_col_fund->isChecked());
@@ -256,17 +306,18 @@ QWidget* RegisterMasternodeWizard::createCollateralPage()
 QWidget* RegisterMasternodeWizard::createServicePage()
 {
     auto* page{new QWidget(this)};
-    auto* layout{new QVBoxLayout(page)};
+    auto* layout{MakePageLayout(page)};
     layout->addWidget(MakeTitle(tr("Service addresses"), page));
-    layout->addWidget(MakeHint(tr("Public addresses your masternode will serve the Core P2P network on, separated "
-                                  "by commas or spaces. Each entry must be unique on the network."),
-                               page));
+    auto* block{MakeBlock(layout)};
+    block->addWidget(MakeHint(tr("Public addresses your masternode will serve the Core P2P network on, separated "
+                                 "by commas or spaces. Each entry must be unique on the network."),
+                              page));
     m_service_edit = new QLineEdit(page);
     m_service_edit->setPlaceholderText(QString("1.2.3.4:%1").arg(Params().GetDefaultPort()));
-    layout->addWidget(m_service_edit);
-    layout->addWidget(MakeHint(tr("May be left empty; the masternode then stays inactive until you send a service "
-                                  "update with an address."),
-                               page));
+    block->addWidget(m_service_edit);
+    block->addWidget(MakeHint(tr("May be left empty; the masternode then stays inactive until you send a service "
+                                 "update with an address."),
+                              page));
     layout->addStretch();
     return page;
 }
@@ -274,42 +325,61 @@ QWidget* RegisterMasternodeWizard::createServicePage()
 QWidget* RegisterMasternodeWizard::createKeysPage()
 {
     auto* page{new QWidget(this)};
-    auto* layout{new QVBoxLayout(page)};
+    auto* layout{MakePageLayout(page)};
     layout->addWidget(MakeTitle(tr("Keys"), page));
 
-    layout->addWidget(MakeHint(tr("Owner address (P2PKH). Controls this masternode; its key signs payout and "
-                                  "voting updates. Kept in this wallet by default."),
-                               page));
-    auto* owner_row{new QHBoxLayout()};
-    m_owner_edit = new QValidatedLineEdit(page);
-    GUIUtil::setupAddressWidget(m_owner_edit, this);
-    owner_row->addWidget(m_owner_edit, /*stretch=*/1);
-    auto* owner_fresh{new QPushButton(tr("Use new address"), page)};
-    connect(owner_fresh, &QPushButton::clicked, this, [this] {
-        QString err;
-        const QString addr{freshAddress(err)};
-        if (addr.isEmpty()) {
-            showError(err);
-        } else {
-            m_owner_edit->setText(addr);
-        }
-    });
-    owner_row->addWidget(owner_fresh);
-    layout->addLayout(owner_row);
+    // Owner and voting address rows share the "fill in a fresh wallet address"
+    // button, differing only in the field they write to.
+    const auto address_row = [this, page](QValidatedLineEdit*& edit) {
+        auto* row{new QHBoxLayout()};
+        edit = new QValidatedLineEdit(page);
+        GUIUtil::setupAddressWidget(edit, this);
+        row->addWidget(edit, /*stretch=*/1);
+        auto* fresh{new QPushButton(tr("Use new address"), page)};
+        QValidatedLineEdit* const target{edit};
+        connect(fresh, &QPushButton::clicked, this, [this, target] {
+            QString err;
+            const QString addr{freshAddress(err)};
+            if (addr.isEmpty()) {
+                showError(err);
+            } else {
+                target->setText(addr);
+            }
+        });
+        row->addWidget(fresh);
+        return row;
+    };
 
-    layout->addWidget(MakeHint(tr("Voting address (P2PKH). May be delegated; leave empty to vote with the owner "
-                                  "key."),
-                               page));
-    m_voting_edit = new QValidatedLineEdit(page);
-    GUIUtil::setupAddressWidget(m_voting_edit, this);
+    auto* owner_block{MakeBlock(layout)};
+    owner_block->addWidget(MakeLabel(tr("Owner address"), page));
+    owner_block->addWidget(MakeHint(tr("Controls this masternode (P2PKH): its key signs payout and voting "
+                                       "updates."),
+                                    page));
+    owner_block->addLayout(address_row(m_owner_edit));
+
+    auto* voting_block{MakeBlock(layout)};
+    voting_block->addWidget(MakeLabel(tr("Voting address"), page));
+    voting_block->addWidget(MakeHint(tr("May be delegated (P2PKH). Leave empty to vote with the owner key."), page));
+    voting_block->addLayout(address_row(m_voting_edit));
     m_voting_edit->setPlaceholderText(tr("Leave empty to use the owner address"));
-    layout->addWidget(m_voting_edit);
+    voting_block->addWidget(MakeHint(tr("Both keys are derived from this wallet's HD seed, so its backup covers "
+                                        "them."),
+                                     page));
 
-    layout->addWidget(MakeHint(tr("Operator key (BLS). The operator runs the masternode server; only the public "
-                                  "key is registered on-chain."),
-                               page));
+    auto* operator_block{MakeBlock(layout)};
+    operator_block->addWidget(MakeLabel(tr("Operator key"), page));
+    operator_block->addWidget(MakeHint(tr("The operator runs the masternode server (BLS); only the public key is "
+                                          "registered on-chain."),
+                                       page));
     m_operator_widget = new OperatorKeyWidget(page);
-    layout->addWidget(m_operator_widget);
+    if (m_walletModel != nullptr) {
+        const bool can_store{m_walletModel->wallet().canStoreMasternodeOperatorKey()};
+        m_operator_widget->offerStoreInWallet(
+            can_store, can_store ? QString() :
+                                   tr("This wallet cannot store an operator key, so the secret key can only be "
+                                      "shown once."));
+    }
+    operator_block->addWidget(m_operator_widget);
     layout->addStretch();
     return page;
 }
@@ -317,10 +387,12 @@ QWidget* RegisterMasternodeWizard::createKeysPage()
 QWidget* RegisterMasternodeWizard::createPayoutPage()
 {
     auto* page{new QWidget(this)};
-    auto* layout{new QVBoxLayout(page)};
+    auto* layout{MakePageLayout(page)};
     layout->addWidget(MakeTitle(tr("Payout"), page));
 
-    layout->addWidget(MakeHint(tr("Address receiving this masternode's block rewards (P2PKH or P2SH)."), page));
+    auto* payout_block{MakeBlock(layout)};
+    payout_block->addWidget(MakeLabel(tr("Payout address"), page));
+    payout_block->addWidget(MakeHint(tr("Receives this masternode's block rewards (P2PKH or P2SH)."), page));
     auto* payout_row{new QHBoxLayout()};
     m_payout_edit = new QValidatedLineEdit(page);
     GUIUtil::setupAddressWidget(m_payout_edit, this);
@@ -336,20 +408,25 @@ QWidget* RegisterMasternodeWizard::createPayoutPage()
         }
     });
     payout_row->addWidget(payout_fresh);
-    layout->addLayout(payout_row);
+    payout_block->addLayout(payout_row);
 
-    layout->addWidget(MakeHint(tr("Share of the reward promised to the operator:"), page));
+    auto* reward_block{MakeBlock(layout)};
+    reward_block->addWidget(MakeLabel(tr("Operator reward"), page));
+    reward_block->addWidget(MakeHint(tr("Share of the reward promised to the operator."), page));
     m_operator_reward = new QDoubleSpinBox(page);
     m_operator_reward->setRange(0.0, 100.0);
     m_operator_reward->setDecimals(2);
     m_operator_reward->setSuffix(QString::fromUtf8(" %"));
-    layout->addWidget(m_operator_reward);
+    auto* reward_row{new QHBoxLayout()};
+    reward_row->addWidget(m_operator_reward);
+    reward_row->addStretch();
+    reward_block->addLayout(reward_row);
     m_reward_warning = MakeHint(tr("The operator will permanently receive this share of all rewards of this "
                                    "masternode. Leave it at 0 unless you have an agreement with your operator."),
                                 page);
     m_reward_warning->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
     m_reward_warning->setVisible(false);
-    layout->addWidget(m_reward_warning);
+    reward_block->addWidget(m_reward_warning);
     connect(m_operator_reward, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this,
             [this](double value) { m_reward_warning->setVisible(value > 0.0); });
     layout->addStretch();
@@ -359,56 +436,56 @@ QWidget* RegisterMasternodeWizard::createPayoutPage()
 QWidget* RegisterMasternodeWizard::createPlatformPage()
 {
     auto* page{new QWidget(this)};
-    auto* layout{new QVBoxLayout(page)};
+    auto* layout{MakePageLayout(page)};
     layout->addWidget(MakeTitle(tr("Platform services"), page));
 
-    layout->addWidget(MakeHint(tr("Platform node ID, derived from the Platform P2P public key (40 hexadecimal "
-                                  "characters)."),
-                               page));
+    auto* nodeid_block{MakeBlock(layout)};
+    nodeid_block->addWidget(MakeLabel(tr("Platform node ID"), page));
+    nodeid_block->addWidget(MakeHint(tr("Derived from the Platform P2P public key (40 hexadecimal characters)."),
+                                     page));
     m_platform_nodeid = new QLineEdit(page);
     m_platform_nodeid->setMaxLength(40);
     m_platform_nodeid->setPlaceholderText(QString("f2dbd9b0a1f541a7c44d34a58674d0262f5feca5"));
-    layout->addWidget(m_platform_nodeid);
+    nodeid_block->addWidget(m_platform_nodeid);
 
-    m_platform_addr_box = new QWidget(page);
+    // Only one of the two cards is ever shown: which one depends on whether v24
+    // is active, and with it on the ProTx version the node will build.
     {
-        auto* box{new QVBoxLayout(m_platform_addr_box)};
-        box->setContentsMargins(0, 0, 0, 0);
-        box->addWidget(MakeHint(tr("Platform P2P addresses (ADDR:PORT, separated by commas or spaces):"),
-                                m_platform_addr_box));
-        m_platform_p2p = new QLineEdit(m_platform_addr_box);
+        auto card{makeOptionCard(page, MakeLabel(tr("Platform addresses"), page),
+                                 tr("ADDR:PORT entries, separated by commas or spaces."))};
+        m_platform_addr_box = card.card;
+        card.body_layout->addWidget(MakeHint(tr("Platform P2P:"), m_platform_addr_box));
+        m_platform_p2p = new QLineEdit(card.body);
         m_platform_p2p->setPlaceholderText(QString("1.2.3.4:26656"));
-        box->addWidget(m_platform_p2p);
-        box->addWidget(MakeHint(tr("Platform HTTPS API addresses (ADDR:PORT, separated by commas or spaces):"),
-                                m_platform_addr_box));
-        m_platform_https = new QLineEdit(m_platform_addr_box);
+        card.body_layout->addWidget(m_platform_p2p);
+        card.body_layout->addWidget(MakeHint(tr("Platform HTTPS API:"), m_platform_addr_box));
+        m_platform_https = new QLineEdit(card.body);
         m_platform_https->setPlaceholderText(QString("1.2.3.4:443"));
-        box->addWidget(m_platform_https);
+        card.body_layout->addWidget(m_platform_https);
+        layout->addWidget(m_platform_addr_box);
     }
-    layout->addWidget(m_platform_addr_box);
 
-    m_platform_port_box = new QWidget(page);
     {
-        auto* box{new QVBoxLayout(m_platform_port_box)};
-        box->setContentsMargins(0, 0, 0, 0);
-        box->addWidget(MakeHint(tr("Before v24 activation only the Platform ports can be registered; they apply to "
-                                   "the first service address."),
-                                m_platform_port_box));
+        auto card{makeOptionCard(page, MakeLabel(tr("Platform ports"), page),
+                                 tr("Before v24 activation only the Platform ports can be registered; they apply "
+                                    "to the first service address."))};
+        m_platform_port_box = card.card;
         auto* row{new QHBoxLayout()};
-        row->addWidget(new QLabel(tr("Platform P2P port:"), m_platform_port_box));
-        m_platform_p2p_port = new QSpinBox(m_platform_port_box);
+        row->addWidget(new QLabel(tr("Platform P2P port:"), card.body));
+        m_platform_p2p_port = new QSpinBox(card.body);
         m_platform_p2p_port->setRange(1, 65535);
         m_platform_p2p_port->setValue(26656);
         row->addWidget(m_platform_p2p_port);
-        row->addWidget(new QLabel(tr("Platform HTTPS port:"), m_platform_port_box));
-        m_platform_https_port = new QSpinBox(m_platform_port_box);
+        row->addSpacing(GROUP_SPACING);
+        row->addWidget(new QLabel(tr("Platform HTTPS port:"), card.body));
+        m_platform_https_port = new QSpinBox(card.body);
         m_platform_https_port->setRange(1, 65535);
         m_platform_https_port->setValue(443);
         row->addWidget(m_platform_https_port);
         row->addStretch();
-        box->addLayout(row);
+        card.body_layout->addLayout(row);
+        layout->addWidget(m_platform_port_box);
     }
-    layout->addWidget(m_platform_port_box);
     layout->addStretch();
     return page;
 }
@@ -416,13 +493,14 @@ QWidget* RegisterMasternodeWizard::createPlatformPage()
 QWidget* RegisterMasternodeWizard::createFeePage()
 {
     auto* page{new QWidget(this)};
-    auto* layout{new QVBoxLayout(page)};
+    auto* layout{MakePageLayout(page)};
     layout->addWidget(MakeTitle(tr("Fee source"), page));
+    auto* block{MakeBlock(layout)};
     m_fee_explain = MakeHint(QString(), page);
-    layout->addWidget(m_fee_explain);
+    block->addWidget(m_fee_explain);
     m_fee_picker = new FeeSourcePicker(page);
     m_fee_picker->setWalletModel(m_walletModel);
-    layout->addWidget(m_fee_picker);
+    block->addWidget(m_fee_picker);
     layout->addStretch();
     return page;
 }
@@ -430,42 +508,54 @@ QWidget* RegisterMasternodeWizard::createFeePage()
 QWidget* RegisterMasternodeWizard::createReviewPage()
 {
     auto* page{new QWidget(this)};
-    auto* layout{new QVBoxLayout(page)};
+    auto* layout{MakePageLayout(page)};
     layout->addWidget(MakeTitle(tr("Review"), page));
-    m_review_label = new QLabel(page);
-    m_review_label->setWordWrap(true);
-    m_review_label->setTextInteractionFlags(Qt::TextSelectableByMouse);
-    layout->addWidget(m_review_label);
-    layout->addStretch();
+    // An evonode summary is a third longer than a masternode one, so the review
+    // scrolls instead of squeezing its cards
+    auto* scroll{new QScrollArea(page)};
+    scroll->setWidgetResizable(true);
+    scroll->setFrameShape(QFrame::NoFrame);
+    scroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    m_review_container = new QWidget(scroll);
+    m_review_layout = new QVBoxLayout(m_review_container);
+    m_review_layout->setContentsMargins(0, 0, 0, 0);
+    m_review_layout->setSpacing(GROUP_SPACING);
+    m_review_layout->addStretch();
+    scroll->setWidget(m_review_container);
+    layout->addWidget(scroll, /*stretch=*/1);
     return page;
 }
 
 QWidget* RegisterMasternodeWizard::createSignPage()
 {
     auto* page{new QWidget(this)};
-    auto* layout{new QVBoxLayout(page)};
+    auto* layout{MakePageLayout(page)};
     layout->addWidget(MakeTitle(tr("Prove collateral ownership"), page));
+    auto* message_block{MakeBlock(layout)};
     m_sign_address_label = MakeHint(QString(), page);
-    layout->addWidget(m_sign_address_label);
-    layout->addWidget(MakeHint(tr("Sign the following message with the collateral key (for example with your "
-                                  "hardware wallet's sign-message feature), then paste the base64 signature "
-                                  "below."),
-                               page));
+    message_block->addWidget(m_sign_address_label);
+    message_block->addWidget(MakeHint(tr("Sign the following message with the collateral key (for example with "
+                                         "your hardware wallet's sign-message feature), then paste the base64 "
+                                         "signature below."),
+                                      page));
     m_sign_message = new QPlainTextEdit(page);
     m_sign_message->setReadOnly(true);
     m_sign_message->setMaximumHeight(90);
-    layout->addWidget(m_sign_message);
+    message_block->addWidget(m_sign_message);
     auto* copy_row{new QHBoxLayout()};
     auto* copy_button{new QPushButton(tr("Copy message"), page)};
     connect(copy_button, &QPushButton::clicked, this,
             [this] { GUIUtil::setClipboard(m_sign_message->toPlainText()); });
     copy_row->addWidget(copy_button);
     copy_row->addStretch();
-    layout->addLayout(copy_row);
+    message_block->addLayout(copy_row);
+
+    auto* signature_block{MakeBlock(layout)};
+    signature_block->addWidget(MakeLabel(tr("Signature"), page));
     m_sig_edit = new QPlainTextEdit(page);
     m_sig_edit->setPlaceholderText(tr("Paste the base64 signature here"));
     m_sig_edit->setMaximumHeight(90);
-    layout->addWidget(m_sig_edit);
+    signature_block->addWidget(m_sig_edit);
     layout->addStretch();
     return page;
 }
@@ -473,48 +563,80 @@ QWidget* RegisterMasternodeWizard::createSignPage()
 QWidget* RegisterMasternodeWizard::createResultPage()
 {
     auto* page{new QWidget(this)};
-    auto* layout{new QVBoxLayout(page)};
+    auto* layout{MakePageLayout(page)};
     layout->addWidget(MakeTitle(tr("Masternode registered"), page));
-    m_result_label = new QLabel(page);
-    m_result_label->setWordWrap(true);
-    m_result_label->setTextInteractionFlags(Qt::TextSelectableByMouse);
-    layout->addWidget(m_result_label);
 
-    m_secret_box = new QWidget(page);
+    // What happened
+    {
+        auto* card{makeCard(page)};
+        auto* box{new QVBoxLayout(card)};
+        box->setContentsMargins(CARD_PADDING, CARD_PADDING, CARD_PADDING, CARD_PADDING);
+        box->setSpacing(TITLE_SPACING);
+        m_result_label = MakeHint(QString(), card);
+        box->addWidget(m_result_label);
+        box->addWidget(MakeLabel(tr("Provider transaction hash"), card));
+        m_result_hash = makeValue(QString(), card, /*monospace=*/true);
+        box->addWidget(m_result_hash);
+        m_result_tx_note = MakeHint(QString(), card);
+        box->addWidget(m_result_tx_note);
+        layout->addWidget(card);
+    }
+
+    // Operator secret key, only shown when this dialog generated one
+    m_secret_box = makeCard(page);
     {
         auto* box{new QVBoxLayout(m_secret_box)};
-        box->setContentsMargins(0, 12, 0, 0);
-        auto* warn{MakeHint(tr("Operator secret key — save it now. It is not stored anywhere and will never be "
-                               "shown again."),
-                            m_secret_box)};
-        warn->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
-        box->addWidget(warn);
+        box->setContentsMargins(CARD_PADDING, CARD_PADDING, CARD_PADDING, CARD_PADDING);
+        box->setSpacing(TITLE_SPACING);
+        box->addWidget(MakeLabel(tr("Operator secret key"), m_secret_box));
+        m_secret_note = MakeHint(QString(), m_secret_box);
+        box->addWidget(m_secret_note);
         m_secret_edit = new QLineEdit(m_secret_box);
         m_secret_edit->setReadOnly(true);
+        m_secret_edit->setFont(GUIUtil::fixedPitchFont());
         box->addWidget(m_secret_edit);
         box->addWidget(MakeHint(tr("Add this line to dash.conf on your masternode server:"), m_secret_box));
         auto* conf_row{new QHBoxLayout()};
         m_conf_line_edit = new QLineEdit(m_secret_box);
         m_conf_line_edit->setReadOnly(true);
+        m_conf_line_edit->setFont(GUIUtil::fixedPitchFont());
         conf_row->addWidget(m_conf_line_edit, /*stretch=*/1);
         auto* copy_conf{new QPushButton(tr("Copy"), m_secret_box)};
         connect(copy_conf, &QPushButton::clicked, this,
                 [this] { GUIUtil::setClipboard(m_conf_line_edit->text()); });
         conf_row->addWidget(copy_conf);
         box->addLayout(conf_row);
-        box->addWidget(MakeHint(tr("Type the last 4 characters of the secret key to confirm you saved it:"),
-                                m_secret_box));
-        m_confirm_edit = new QLineEdit(m_secret_box);
+
+        // Only worth asking for when the key exists nowhere else
+        m_confirm_box = new QWidget(m_secret_box);
+        auto* confirm_layout{new QVBoxLayout(m_confirm_box)};
+        confirm_layout->setContentsMargins(0, 0, 0, 0);
+        confirm_layout->setSpacing(TITLE_SPACING);
+        confirm_layout->addWidget(MakeHint(tr("Type the last 4 characters of the secret key to confirm you saved "
+                                              "it:"),
+                                           m_confirm_box));
+        m_confirm_edit = new QLineEdit(m_confirm_box);
         m_confirm_edit->setMaxLength(4);
         m_confirm_edit->setMaximumWidth(120);
         connect(m_confirm_edit, &QLineEdit::textChanged, this, &RegisterMasternodeWizard::updateButtons);
-        box->addWidget(m_confirm_edit);
+        confirm_layout->addWidget(m_confirm_edit);
+        box->addWidget(m_confirm_box);
     }
     layout->addWidget(m_secret_box);
 
-    m_next_steps = new QLabel(page);
-    m_next_steps->setWordWrap(true);
-    layout->addWidget(m_next_steps);
+    // What to do next
+    {
+        auto* card{makeCard(page)};
+        auto* box{new QVBoxLayout(card)};
+        box->setContentsMargins(CARD_PADDING, CARD_PADDING, CARD_PADDING, CARD_PADDING);
+        box->setSpacing(TITLE_SPACING);
+        box->addWidget(MakeLabel(tr("Next steps"), card));
+        m_next_steps = new QLabel(card);
+        m_next_steps->setWordWrap(true);
+        m_next_steps->setTextInteractionFlags(Qt::TextSelectableByMouse);
+        box->addWidget(m_next_steps);
+        layout->addWidget(card);
+    }
     layout->addStretch();
     return page;
 }
@@ -572,6 +694,8 @@ CAmount RegisterMasternodeWizard::collateralAmount() const
 
 bool RegisterMasternodeWizard::secretConfirmed() const
 {
+    // A key the wallet stored needs no hand-copy confirmation
+    if (m_operator_key_saved) return true;
     return m_confirm_edit->text().trimmed().compare(m_operator_widget->secretHex().right(4),
                                                     Qt::CaseInsensitive) == 0;
 }
@@ -860,61 +984,163 @@ void RegisterMasternodeWizard::refreshCollateralCandidates()
             m_col_utxo_combo->setItemData(m_col_utxo_combo->count() - 1, static_cast<int>(outpoint.n), VOUT_ROLE);
         }
     }
-    m_col_utxo_none->setVisible(m_col_utxo_combo->count() == 0);
+    // An empty combo box says nothing; show the reason instead
+    const bool have_candidates{m_col_utxo_combo->count() > 0};
+    m_col_utxo_combo->setVisible(have_candidates);
+    m_col_utxo_none->setVisible(!have_candidates);
+    m_col_utxo_none->setText(tr("This wallet has no unspent output of exactly %1 with a confirmation. Send the "
+                                "collateral from this wallet instead, or reference one held elsewhere.")
+                                 .arg(FormatAmount(m_walletModel, collateralAmount())));
+}
+
+int RegisterMasternodeWizard::reviewLabelWidth(const QWidget* card) const
+{
+    // The widest label decides the column, so every card shares one alignment
+    static const QStringList labels{tr("Type"),        tr("Service"),        tr("Platform node ID"),
+                                    tr("Platform P2P"), tr("Platform HTTPS"), tr("Platform ports"),
+                                    tr("Amount"),      tr("Destination"),    tr("Output"),
+                                    tr("Source"),      tr("Owner"),          tr("Voting"),
+                                    tr("Operator"),    tr("Address"),        tr("Operator share"),
+                                    tr("Funding address"), tr("Fee source")};
+    const QFontMetrics metrics{card->font()};
+    int width{0};
+    for (const QString& label : labels) {
+        width = std::max(width, metrics.horizontalAdvance(label));
+    }
+    return width;
 }
 
 void RegisterMasternodeWizard::populateReview()
 {
-    QStringList rows;
-    const auto row = [&rows](const QString& key, const QString& value) {
-        rows << QString("<b>%1</b> %2").arg(key, value.toHtmlEscaped());
+    // The sections mirror the wizard's own pages, so a wrong value can be traced
+    // back to the page that set it
+    // Two columns: a label column just wide enough for its text, and the value
+    // column taking the rest, so every row lines up down the card
+    QGridLayout* section{nullptr};
+    QWidget* section_card{nullptr};
+    const auto begin_section = [this, &section, &section_card](const QString& title) {
+        // makeCard() hands back a bare frame; the card owns the layout we build here
+        auto* card{makeCard(m_review_container)};
+        section_card = card;
+        auto* card_layout{new QVBoxLayout(card)};
+        card_layout->setContentsMargins(CARD_PADDING, CARD_PADDING, CARD_PADDING, CARD_PADDING);
+        card_layout->setSpacing(TITLE_SPACING);
+        card_layout->addWidget(MakeLabel(title, card));
+        section = new QGridLayout();
+        section->setContentsMargins(0, 0, 0, 0);
+        section->setHorizontalSpacing(GROUP_SPACING);
+        section->setVerticalSpacing(ROW_SPACING);
+        section->setColumnStretch(1, 1);
+        // One label width for every card, so the values line up down the page
+        section->setColumnMinimumWidth(0, reviewLabelWidth(card));
+        card_layout->addLayout(section);
+        m_review_layout->insertWidget(m_review_layout->count() - 1, card);
+    };
+    const auto row = [&section, &section_card](const QString& key, const QString& value, bool monospace = false) {
+        const int r{section->rowCount()};
+        section->addWidget(MakeHint(key, section_card), r, 0, Qt::AlignLeft | Qt::AlignTop);
+        section->addWidget(makeValue(value, section_card, monospace), r, 1);
+    };
+    // A BLS key is one 96-character word, which a wrapping label refuses to break.
+    // A read-only plain text view wraps anywhere and still copies the exact key.
+    const auto long_row = [&section, &section_card](const QString& key, const QString& value) {
+        const int r{section->rowCount()};
+        section->addWidget(MakeHint(key, section_card), r, 0, Qt::AlignLeft | Qt::AlignTop);
+        auto* field{new QPlainTextEdit(value, section_card)};
+        field->setReadOnly(true);
+        field->setFrameShape(QFrame::NoFrame);
+        field->setFont(GUIUtil::fixedPitchFont());
+        // It is a value, not an input: the theme's field border would say otherwise
+        field->setStyleSheet("QPlainTextEdit { background: transparent; border: none; }");
+        field->setFocusPolicy(Qt::ClickFocus);
+        field->setWordWrapMode(QTextOption::WrapAnywhere);
+        field->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+        field->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+        field->setFixedHeight(2 * QFontMetrics(field->font()).lineSpacing() + ROW_SPACING);
+        section->addWidget(field, r, 1);
     };
 
-    row(tr("Type:"), isEvo() ? tr("Evonode") : tr("Masternode"));
-    if (isFundCollateral()) {
-        row(tr("Collateral:"), tr("send %1 to %2")
-                                   .arg(FormatAmount(m_walletModel, collateralAmount()), collateralAddress()));
-    } else if (m_col_wallet->isChecked()) {
-        row(tr("Collateral:"), m_col_utxo_combo->currentText());
-    } else {
-        row(tr("Collateral:"),
-            QString("%1:%2").arg(m_col_txid->text().trimmed()).arg(m_col_vout->value()));
+    // Rebuilt on every entry to the page: the user may have gone back and edited.
+    // The trailing stretch stays; only the cards are replaced.
+    while (m_review_layout->count() > 1) {
+        QLayoutItem* item{m_review_layout->takeAt(0)};
+        delete item->widget();
+        delete item;
     }
+
+    begin_section(tr("Node"));
+    row(tr("Type"), isEvo() ? tr("Evonode") : tr("Masternode"));
     QString parse_err;
     const QStringList services{MasternodeWidgetUtil::parseServiceList(m_service_edit->text(), parse_err)};
-    row(tr("Service:"), services.isEmpty() ? tr("(none — set later with a service update)") : services.join(", "));
-    row(tr("Owner address:"), ownerAddress());
-    row(tr("Voting address:"),
-        votingAddress().isEmpty() ? tr("%1 (owner)").arg(ownerAddress()) : votingAddress());
-    row(tr("Operator key:"), m_operator_widget->hasGeneratedSecret() ?
-                                 tr("%1 (newly generated)").arg(m_operator_widget->publicKeyHex()) :
-                                 m_operator_widget->publicKeyHex());
-    row(tr("Payout address:"), m_payout_edit->text().trimmed());
-    row(tr("Operator reward:"), QString("%1%").arg(QString::number(m_operator_reward->value(), 'f', 2)));
+    row(tr("Service"), services.isEmpty() ? tr("Not set — the node stays inactive until you send a service update") :
+                                            services.join(", "),
+        !services.isEmpty());
     if (isEvo()) {
-        row(tr("Platform node ID:"), m_platform_nodeid->text().trimmed());
+        row(tr("Platform node ID"), m_platform_nodeid->text().trimmed(), /*monospace=*/true);
         if (m_node.isV24Active()) {
             QString platform_err;
-            row(tr("Platform P2P:"),
-                MasternodeWidgetUtil::parseServiceList(m_platform_p2p->text(), platform_err).join(", "));
-            row(tr("Platform HTTPS:"),
-                MasternodeWidgetUtil::parseServiceList(m_platform_https->text(), platform_err).join(", "));
+            row(tr("Platform P2P"),
+                MasternodeWidgetUtil::parseServiceList(m_platform_p2p->text(), platform_err).join(", "),
+                /*monospace=*/true);
+            row(tr("Platform HTTPS"),
+                MasternodeWidgetUtil::parseServiceList(m_platform_https->text(), platform_err).join(", "),
+                /*monospace=*/true);
         } else {
-            row(tr("Platform ports:"), QString("%1 (P2P), %2 (HTTPS)")
-                                           .arg(m_platform_p2p_port->value())
-                                           .arg(m_platform_https_port->value()));
+            row(tr("Platform ports"), tr("%1 peer-to-peer, %2 HTTPS")
+                                          .arg(m_platform_p2p_port->value())
+                                          .arg(m_platform_https_port->value()));
         }
     }
-    row(isFundCollateral() ? tr("Funding address:") : tr("Fee source:"), m_fee_picker->selectedAddress());
 
-    QString footer;
-    if (isExternalCollateral()) {
-        footer = tr("Clicking Prepare creates the unsigned transaction and a message you must sign with the "
-                    "collateral key. Nothing is broadcast yet.");
+    begin_section(tr("Collateral"));
+    row(tr("Amount"), FormatAmount(m_walletModel, collateralAmount()));
+    if (isFundCollateral()) {
+        row(tr("Destination"), collateralAddress(), /*monospace=*/true);
+        row(tr("Source"), tr("This wallet sends it as part of the registration"));
+    } else if (m_col_wallet->isChecked()) {
+        row(tr("Output"), m_col_utxo_combo->currentText(), /*monospace=*/true);
+        row(tr("Source"), tr("An output this wallet already holds"));
     } else {
-        footer = tr("Clicking Register may ask to unlock the wallet, then broadcasts the transaction.");
+        row(tr("Output"), QString("%1:%2").arg(m_col_txid->text().trimmed()).arg(m_col_vout->value()),
+            /*monospace=*/true);
+        row(tr("Source"), tr("Held outside this wallet — you will sign a message with its key"));
     }
-    m_review_label->setText(rows.join("<br>") + "<br><br>" + footer.toHtmlEscaped());
+
+    begin_section(tr("Keys"));
+    row(tr("Owner"), ownerAddress(), /*monospace=*/true);
+    row(tr("Voting"), votingAddress().isEmpty() ? tr("Same as owner") : votingAddress(),
+        !votingAddress().isEmpty());
+    long_row(tr("Operator"), m_operator_widget->publicKeyHex());
+    row(QString(), operatorKeyProvenance());
+
+    begin_section(tr("Payout"));
+    row(tr("Address"), m_payout_edit->text().trimmed(), /*monospace=*/true);
+    row(tr("Operator share"), QString("%1%").arg(QString::number(m_operator_reward->value(), 'f', 2)));
+
+    begin_section(tr("Funding"));
+    row(isFundCollateral() ? tr("Funding address") : tr("Fee source"), m_fee_picker->selectedAddress(),
+        /*monospace=*/true);
+
+    m_review_layout->insertWidget(
+        m_review_layout->count() - 1,
+        MakeHint(isExternalCollateral() ?
+                     tr("Preparing creates the unsigned transaction and the message to sign with the collateral "
+                        "key. Nothing is broadcast yet.") :
+                     tr("Registering broadcasts a transaction from this wallet. You may be asked to unlock it."),
+                 m_review_container));
+}
+
+QString RegisterMasternodeWizard::operatorKeyProvenance() const
+{
+    switch (m_operator_widget->mode()) {
+    case OperatorKeyWidget::Mode::GenerateAndStore:
+        return tr("Newly generated, saved in this wallet");
+    case OperatorKeyWidget::Mode::GenerateOnly:
+        return tr("Newly generated, shown once after registration");
+    case OperatorKeyWidget::Mode::Existing:
+        return tr("Supplied by whoever runs the node");
+    }
+    return {};
 }
 
 UniValue RegisterMasternodeWizard::buildRegisterParams() const
@@ -1023,6 +1249,9 @@ void RegisterMasternodeWizard::onRpcFinished(const ProTxResult& result)
 {
     const Stage stage{m_stage};
     m_stage = Stage::None;
+    const bool registered{result.ok && (stage == Stage::Register || stage == Stage::Submit)};
+    // Store the operator secret while the registration still holds the unlock
+    if (registered) saveOperatorKeyIfChosen();
     m_unlock.reset();
     setBusy(false);
 
@@ -1060,17 +1289,54 @@ void RegisterMasternodeWizard::onRpcFinished(const ProTxResult& result)
     }
 }
 
+void RegisterMasternodeWizard::saveOperatorKeyIfChosen()
+{
+    m_operator_key_saved = false;
+    if (m_walletModel == nullptr || m_operator_widget->mode() != OperatorKeyWidget::Mode::GenerateAndStore) {
+        return;
+    }
+    const std::vector<unsigned char> secret{
+        ParseHex(m_operator_widget->secretHex().toStdString())};
+    std::string error;
+    if (m_walletModel->wallet().addMasternodeOperatorKey(secret, error)) {
+        m_operator_key_saved = true;
+    } else {
+        // Never claim the key was saved: the result page falls back to the
+        // show-once presentation and the user still has the secret on screen
+        m_operator_save_error = QString::fromStdString(error);
+    }
+}
+
 void RegisterMasternodeWizard::populateResult(const QString& pro_tx_hash)
 {
     m_registered = true;
-    m_result_label->setText(tr("The provider registration transaction was sent to the network.") + "<br><br>" +
-                            tr("Provider transaction hash:") + "<br><b>" + pro_tx_hash.toHtmlEscaped() + "</b>");
+    m_result_label->setText(tr("The registration transaction was sent to the network."));
+    m_result_hash->setText(pro_tx_hash);
+    m_result_tx_note->setText(tr("It is in this wallet now and appears under Transactions as a masternode "
+                                 "registration. The collateral stays in the wallet but is locked while the "
+                                 "masternode is registered."));
 
     const bool generated{m_operator_widget->hasGeneratedSecret()};
     m_secret_box->setVisible(generated);
     if (generated) {
         m_secret_edit->setText(m_operator_widget->secretHex());
         m_conf_line_edit->setText(QString("masternodeblsprivkey=%1").arg(m_operator_widget->secretHex()));
+        if (m_operator_key_saved) {
+            m_secret_note->setText(tr("Saved in this wallet — include it in your wallet backup. Your masternode "
+                                      "server still needs the line below."));
+            m_secret_note->setStyleSheet(QString());
+        } else if (!m_operator_save_error.isEmpty()) {
+            m_secret_note->setText(tr("This wallet could not store the key (%1), so save it now — it is not kept "
+                                      "anywhere and will never be shown again.")
+                                       .arg(m_operator_save_error));
+            m_secret_note->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
+        } else {
+            m_secret_note->setText(tr("Save it now — it is not kept anywhere and will never be shown again."));
+            m_secret_note->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
+        }
+        // The confirmation gate only earns its friction when the key exists
+        // nowhere but on this screen
+        m_confirm_box->setVisible(!m_operator_key_saved);
     }
 
     QStringList steps;

--- a/src/qt/masternodewizard.cpp
+++ b/src/qt/masternodewizard.cpp
@@ -374,19 +374,15 @@ QWidget* RegisterMasternodeWizard::createKeysPage()
                                           "registered on-chain."),
                                        page));
     m_operator_widget = new OperatorKeyWidget(page);
-    if (m_walletModel != nullptr) {
-        // Only the best choice this wallet can make is offered; the ones it
-        // cannot make would be dead options. When it can make none, the store
-        // choice stays visible but disabled to explain why.
-        if (m_walletModel->wallet().canDeriveMasternodeOperatorKey()) {
-            m_operator_widget->offerDerived();
-        } else {
-            const bool can_store{m_walletModel->wallet().canStoreMasternodeOperatorKey()};
-            m_operator_widget->offerStoreInWallet(
-                can_store, can_store ? QString() :
-                                       tr("This wallet can neither derive an operator key from its recovery phrase "
-                                          "nor store one, so the secret key can only be shown once."));
-        }
+    // Deriving is only offered to wallets that can do it; the others fall back to
+    // the generate/paste pair, which the hint explains before the choices appear.
+    if (m_walletModel != nullptr && m_walletModel->wallet().canDeriveMasternodeOperatorKey()) {
+        m_operator_widget->offerDerived();
+    } else {
+        operator_block->addWidget(MakeHint(tr("This wallet cannot derive an operator key from a recovery phrase, so "
+                                              "a generated secret key is shown once after registering and you have "
+                                              "to save it yourself."),
+                                           page));
     }
     operator_block->addWidget(m_operator_widget);
     layout->addStretch();
@@ -709,9 +705,9 @@ CAmount RegisterMasternodeWizard::collateralAmount() const
 
 bool RegisterMasternodeWizard::secretGateRequired() const
 {
-    // A key the wallet derives or stores can be looked up again, so only a secret
-    // that exists nowhere but on the result page is worth gating on
-    return m_operator_widget->hasGeneratedSecret() && !m_operator_key_derived && !m_operator_key_saved;
+    // A derived key can be looked up again, so only a secret that exists nowhere
+    // but on the result page is worth gating on
+    return m_operator_widget->hasGeneratedSecret() && !m_operator_key_derived;
 }
 
 bool RegisterMasternodeWizard::secretConfirmed() const
@@ -1169,13 +1165,12 @@ QString RegisterMasternodeWizard::operatorKeyProvenance() const
     switch (m_operator_widget->mode()) {
     case OperatorKeyWidget::Mode::Derive:
         return m_operator_widget->derivationPath().isEmpty() ?
-                   tr("Derived from this wallet's recovery phrase") :
-                   tr("Derived from this wallet's recovery phrase (path %1)")
+                   tr("Comes from this wallet's recovery phrase and can be seen again from the Masternodes tab") :
+                   tr("Comes from this wallet's recovery phrase (path %1) and can be seen again from the "
+                      "Masternodes tab")
                        .arg(m_operator_widget->derivationPath());
-    case OperatorKeyWidget::Mode::GenerateAndStore:
-        return tr("Newly generated, saved in this wallet");
     case OperatorKeyWidget::Mode::GenerateOnly:
-        return tr("Newly generated, shown once after registration");
+        return tr("Newly generated, shown once after registration and kept nowhere else");
     case OperatorKeyWidget::Mode::Existing:
         return tr("Supplied by whoever runs the node");
     }
@@ -1251,10 +1246,21 @@ bool RegisterMasternodeWizard::ensureOperatorKey()
         return false;
     }
 
+    // Every operator key already registered on-chain, so a wallet restored from
+    // its recovery phrase does not hand out a key another masternode is using
+    std::vector<std::vector<unsigned char>> in_use;
+    if (const auto mn_list{m_node.evo().getListAtChainTip().first}) {
+        mn_list->forEachMN(/*only_valid=*/false, [&in_use](const interfaces::MnEntryCPtr& dmn) {
+            if (!dmn) return;
+            auto pubkey{dmn->getOperatorPubKeyBytes()};
+            if (!pubkey.empty()) in_use.push_back(std::move(pubkey));
+        });
+    }
+
     std::vector<unsigned char> secret;
     std::string path;
     std::string error;
-    if (!m_walletModel->wallet().deriveMasternodeOperatorKey(secret, path, error)) {
+    if (!m_walletModel->wallet().deriveMasternodeOperatorKey(in_use, secret, path, error)) {
         showError(tr("This wallet could not derive an operator key: %1. Go back and choose another way to get "
                      "one.")
                       .arg(QString::fromStdString(error)));
@@ -1320,9 +1326,6 @@ void RegisterMasternodeWizard::onRpcFinished(const ProTxResult& result)
 {
     const Stage stage{m_stage};
     m_stage = Stage::None;
-    const bool registered{result.ok && (stage == Stage::Register || stage == Stage::Submit)};
-    // Store the operator secret while the registration still holds the unlock
-    if (registered) saveOperatorKeyIfChosen();
     m_unlock.reset();
     setBusy(false);
 
@@ -1360,24 +1363,6 @@ void RegisterMasternodeWizard::onRpcFinished(const ProTxResult& result)
     }
 }
 
-void RegisterMasternodeWizard::saveOperatorKeyIfChosen()
-{
-    m_operator_key_saved = false;
-    if (m_walletModel == nullptr || m_operator_widget->mode() != OperatorKeyWidget::Mode::GenerateAndStore) {
-        return;
-    }
-    const std::vector<unsigned char> secret{
-        ParseHex(m_operator_widget->secretHex().toStdString())};
-    std::string error;
-    if (m_walletModel->wallet().addMasternodeOperatorKey(secret, error)) {
-        m_operator_key_saved = true;
-    } else {
-        // Never claim the key was saved: the result page falls back to the
-        // show-once presentation and the user still has the secret on screen
-        m_operator_save_error = QString::fromStdString(error);
-    }
-}
-
 void RegisterMasternodeWizard::populateResult(const QString& pro_tx_hash)
 {
     m_registered = true;
@@ -1404,22 +1389,13 @@ void RegisterMasternodeWizard::populateResult(const QString& pro_tx_hash)
                                           "phrase restores this key.")
                                            .arg(path));
             m_secret_note->setStyleSheet(QString());
-        } else if (m_operator_key_saved) {
-            m_secret_note->setText(tr("Saved in this wallet — include it in your wallet backup. Your masternode "
-                                      "server still needs the line below."));
-            m_secret_note->setStyleSheet(QString());
-        } else if (!m_operator_save_error.isEmpty()) {
-            m_secret_note->setText(tr("This wallet could not store the key (%1), so save it now — it is not kept "
-                                      "anywhere and will never be shown again.")
-                                       .arg(m_operator_save_error));
-            m_secret_note->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
         } else {
-            m_secret_note->setText(tr("Save it now — it is not kept anywhere and will never be shown again."));
+            m_secret_note->setText(tr("Save it now — it is kept nowhere else and will never be shown again."));
             m_secret_note->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
         }
-        // Both only apply while the wallet actually keeps the key: the show-once
-        // case cannot promise a later look, and it is the only one whose friction
-        // buys anything
+        // Both only apply while the wallet can produce the key again: the
+        // show-once case cannot promise a later look, and it is the only one
+        // whose friction buys anything
         m_secret_recall->setVisible(!secretGateRequired());
         m_confirm_box->setVisible(secretGateRequired());
     }

--- a/src/qt/masternodewizard.cpp
+++ b/src/qt/masternodewizard.cpp
@@ -10,6 +10,7 @@
 #include <interfaces/wallet.h>
 #include <key_io.h>
 #include <primitives/transaction.h>
+#include <script/standard.h>
 #include <util/strencodings.h>
 
 #include <qt/bitcoinunits.h>
@@ -33,6 +34,8 @@
 #include <QVBoxLayout>
 
 #include <univalue.h>
+
+#include <variant>
 
 namespace {
 //! Headroom on top of the collateral the funding address must hold for fees
@@ -199,7 +202,7 @@ QWidget* RegisterMasternodeWizard::createCollateralPage()
     {
         auto* box{new QVBoxLayout(m_col_wallet_box)};
         box->setContentsMargins(24, 0, 0, 0);
-        box->addWidget(MakeHint(tr("Unspent outputs of exactly the collateral amount, with at least one "
+        box->addWidget(MakeHint(tr("Unspent P2PKH outputs of exactly the collateral amount, with at least one "
                                    "confirmation and not used by another masternode."),
                                 m_col_wallet_box));
         m_col_utxo_combo = new QComboBox(m_col_wallet_box);
@@ -567,6 +570,12 @@ CAmount RegisterMasternodeWizard::collateralAmount() const
     return GetMnType(isEvo() ? MnType::Evo : MnType::Regular).collat_amount;
 }
 
+bool RegisterMasternodeWizard::secretConfirmed() const
+{
+    return m_confirm_edit->text().trimmed().compare(m_operator_widget->secretHex().right(4),
+                                                    Qt::CaseInsensitive) == 0;
+}
+
 void RegisterMasternodeWizard::rebuildOrder()
 {
     m_order = {PageType, PageCollateral, PageService, PageKeys, PagePayout};
@@ -714,7 +723,10 @@ bool RegisterMasternodeWizard::validatePage(Page page, QString& err)
             }
             QString service_err;
             const bool has_service{!MasternodeWidgetUtil::parseServiceList(m_service_edit->text(), service_err).isEmpty()};
-            if (has_service && (p2p.isEmpty() || https.isEmpty())) {
+            if (p2p.isEmpty() != https.isEmpty()) {
+                err = tr("Enter both a Platform P2P and a Platform HTTPS address; one cannot be registered "
+                         "without the other.");
+            } else if (has_service && p2p.isEmpty()) {
                 err = tr("Enter at least one Platform P2P and one Platform HTTPS address, or clear the service "
                          "addresses to set everything later with a service update.");
             }
@@ -800,12 +812,9 @@ void RegisterMasternodeWizard::updateButtons()
         enabled = false;
         tooltip = tr("This wallet is watch-only. Masternode registration requires a wallet that can sign "
                      "transactions.");
-    } else if (current == PageResult && m_operator_widget->hasGeneratedSecret()) {
-        const QString expected{m_operator_widget->secretHex().right(4)};
-        if (m_confirm_edit->text().trimmed().compare(expected, Qt::CaseInsensitive) != 0) {
-            enabled = false;
-            tooltip = tr("Confirm you saved the operator secret key by typing its last 4 characters.");
-        }
+    } else if (current == PageResult && m_operator_widget->hasGeneratedSecret() && !secretConfirmed()) {
+        enabled = false;
+        tooltip = tr("Confirm you saved the operator secret key by typing its last 4 characters.");
     }
     m_next_button->setEnabled(enabled);
     m_next_button->setToolTip(tooltip);
@@ -835,10 +844,17 @@ void RegisterMasternodeWizard::refreshCollateralCandidates()
     }
     const CAmount collateral{collateralAmount()};
     for (const auto& [dest, coins] : m_walletModel->wallet().listCoins()) {
-        const QString address{QString::fromStdString(EncodeDestination(dest))};
         for (const auto& [outpoint, txout] : coins) {
             if (txout.txout.nValue != collateral || txout.is_spent || txout.depth_in_main_chain < 1) continue;
             if (m_walletModel->wallet().isLockedCoin(outpoint)) continue;
+            // protx register only accepts P2PKH collaterals; check the coin's own
+            // script, as listCoins() groups change under the parent's address
+            CTxDestination coin_dest;
+            if (!ExtractDestination(txout.txout.scriptPubKey, coin_dest) ||
+                !std::holds_alternative<PKHash>(coin_dest)) {
+                continue;
+            }
+            const QString address{QString::fromStdString(EncodeDestination(coin_dest))};
             const QString txid{QString::fromStdString(outpoint.hash.ToString())};
             m_col_utxo_combo->addItem(QString("%1:%2 (%3)").arg(txid).arg(outpoint.n).arg(address), txid);
             m_col_utxo_combo->setItemData(m_col_utxo_combo->count() - 1, static_cast<int>(outpoint.n), VOUT_ROLE);
@@ -1081,24 +1097,21 @@ void RegisterMasternodeWizard::reject()
 {
     if (m_busy) return;
     if (m_registered) {
-        if (m_operator_widget->hasGeneratedSecret()) {
-            const QString expected{m_operator_widget->secretHex().right(4)};
-            if (m_confirm_edit->text().trimmed().compare(expected, Qt::CaseInsensitive) != 0 &&
-                QMessageBox::warning(this, tr("Operator secret not confirmed"),
-                                     tr("You have not confirmed saving the operator secret key. Without it your "
-                                        "masternode cannot operate. Close anyway?"),
-                                     QMessageBox::Yes | QMessageBox::No, QMessageBox::No) != QMessageBox::Yes) {
-                return;
-            }
+        if (m_operator_widget->hasGeneratedSecret() && !secretConfirmed() &&
+            QMessageBox::warning(this, tr("Operator secret not confirmed"),
+                                 tr("You have not confirmed saving the operator secret key. Without it your "
+                                    "masternode cannot operate. Close anyway?"),
+                                 QMessageBox::Yes | QMessageBox::No, QMessageBox::No) != QMessageBox::Yes) {
+            return;
         }
         QDialog::accept();
         return;
     }
     if (!m_prepared_tx.isEmpty()) {
         if (QMessageBox::warning(this, tr("Discard prepared registration?"),
-                                 tr("The prepared registration will be discarded. If the collateral or fee inputs "
-                                    "belong to this wallet they stay locked; unlock them via coin control if you "
-                                    "do not intend to retry."),
+                                 tr("The prepared registration will be discarded. If the collateral belongs to "
+                                    "this wallet it stays locked; unlock it via coin control if you do not intend "
+                                    "to retry."),
                                  QMessageBox::Yes | QMessageBox::No, QMessageBox::No) != QMessageBox::Yes) {
             return;
         }

--- a/src/qt/masternodewizard.h
+++ b/src/qt/masternodewizard.h
@@ -1,0 +1,187 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_MASTERNODEWIZARD_H
+#define BITCOIN_QT_MASTERNODEWIZARD_H
+
+#include <consensus/amount.h>
+#include <qt/protxsender.h>
+
+#include <QDialog>
+#include <QString>
+#include <QVector>
+
+#include <memory>
+
+class FeeSourcePicker;
+class OperatorKeyWidget;
+class QValidatedLineEdit;
+class WalletModel;
+
+namespace interfaces {
+class Node;
+} // namespace interfaces
+
+QT_BEGIN_NAMESPACE
+class QComboBox;
+class QDoubleSpinBox;
+class QLabel;
+class QLineEdit;
+class QPlainTextEdit;
+class QPushButton;
+class QRadioButton;
+class QSpinBox;
+class QStackedWidget;
+QT_END_NAMESPACE
+
+//! Multi-page dialog registering a masternode or evonode: collects collateral,
+//! service, key, payout and fee-source details, then issues the matching
+//! "protx register_*" RPC through ProTxSender. Supports funding the collateral
+//! from the wallet, referencing an exact-denomination UTXO already in the
+//! wallet, and the external-collateral flow (register_prepare, out-of-band
+//! signMessage signature, register_submit).
+class RegisterMasternodeWizard : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit RegisterMasternodeWizard(interfaces::Node& node, WalletModel* walletModel, QWidget* parent = nullptr);
+    ~RegisterMasternodeWizard() override;
+
+public Q_SLOTS:
+    void reject() override;
+
+private Q_SLOTS:
+    void onNext();
+    void onBack();
+    void onRpcFinished(const ProTxResult& result);
+
+private:
+    enum Page : int {
+        PageType = 0,
+        PageCollateral,
+        PageService,
+        PageKeys,
+        PagePayout,
+        PagePlatform,
+        PageFee,
+        PageReview,
+        PageSign,
+        PageResult,
+    };
+    //! Which RPC the in-flight ProTxSender call belongs to
+    enum class Stage {
+        None,
+        Register, //!< register_fund[_evo] / register[_evo], returns a txid
+        Prepare,  //!< register_prepare[_evo], returns {tx, collateralAddress, signMessage}
+        Submit,   //!< register_submit, returns a txid
+    };
+
+    QWidget* createTypePage();
+    QWidget* createCollateralPage();
+    QWidget* createServicePage();
+    QWidget* createKeysPage();
+    QWidget* createPayoutPage();
+    QWidget* createPlatformPage();
+    QWidget* createFeePage();
+    QWidget* createReviewPage();
+    QWidget* createSignPage();
+    QWidget* createResultPage();
+
+    bool isEvo() const;
+    bool isExternalCollateral() const;
+    bool isFundCollateral() const;
+    QString collateralAddress() const;
+    QString ownerAddress() const;
+    QString votingAddress() const;
+    QString freshAddress(QString& err) const;
+    CAmount collateralAmount() const;
+
+    void rebuildOrder();
+    void goToPage(Page page);
+    void enterPage(Page page);
+    bool validatePage(Page page, QString& err);
+    void updateButtons();
+    void setBusy(bool busy, const QString& busy_text = QString());
+    void showError(const QString& message);
+
+    void refreshCollateralCandidates();
+    void populateReview();
+    void populateResult(const QString& pro_tx_hash);
+    UniValue buildRegisterParams() const;
+    void startRegistration();
+    void startSubmit();
+
+    interfaces::Node& m_node;
+    WalletModel* const m_walletModel;
+    ProTxSender m_sender;
+    Stage m_stage{Stage::None};
+    struct UnlockHolder;
+    std::unique_ptr<UnlockHolder> m_unlock;
+
+    QVector<Page> m_order;
+    int m_pos{0};
+    bool m_busy{false};
+    bool m_registered{false};
+
+    QStackedWidget* m_pages;
+    QLabel* m_error_label;
+    QPushButton* m_back_button;
+    QPushButton* m_next_button;
+    QPushButton* m_cancel_button;
+
+    // Type page
+    QRadioButton* m_type_regular;
+    QRadioButton* m_type_evo;
+    // Collateral page
+    QRadioButton* m_col_fund;
+    QRadioButton* m_col_wallet;
+    QRadioButton* m_col_external;
+    QWidget* m_col_fund_box;
+    QWidget* m_col_wallet_box;
+    QWidget* m_col_external_box;
+    QValidatedLineEdit* m_col_address;
+    QComboBox* m_col_utxo_combo;
+    QLabel* m_col_utxo_none;
+    QLineEdit* m_col_txid;
+    QSpinBox* m_col_vout;
+    // Service page
+    QLineEdit* m_service_edit;
+    // Keys page
+    QValidatedLineEdit* m_owner_edit;
+    QValidatedLineEdit* m_voting_edit;
+    OperatorKeyWidget* m_operator_widget;
+    // Payout page
+    QValidatedLineEdit* m_payout_edit;
+    QDoubleSpinBox* m_operator_reward;
+    QLabel* m_reward_warning;
+    // Platform page. Pre-v24 ProTxs only store bare platform ports; the
+    // ADDR:PORT list form requires a version 3 ProTx (v24 active).
+    QLineEdit* m_platform_nodeid;
+    QWidget* m_platform_addr_box;
+    QLineEdit* m_platform_p2p;
+    QLineEdit* m_platform_https;
+    QWidget* m_platform_port_box;
+    QSpinBox* m_platform_p2p_port;
+    QSpinBox* m_platform_https_port;
+    // Fee page
+    FeeSourcePicker* m_fee_picker;
+    QLabel* m_fee_explain;
+    // Review page
+    QLabel* m_review_label;
+    // Sign page (external collateral)
+    QLabel* m_sign_address_label;
+    QPlainTextEdit* m_sign_message;
+    QPlainTextEdit* m_sig_edit;
+    QString m_prepared_tx;
+    // Result page
+    QLabel* m_result_label;
+    QWidget* m_secret_box;
+    QLineEdit* m_secret_edit;
+    QLineEdit* m_conf_line_edit;
+    QLineEdit* m_confirm_edit;
+    QLabel* m_next_steps;
+};
+
+#endif // BITCOIN_QT_MASTERNODEWIZARD_H

--- a/src/qt/masternodewizard.h
+++ b/src/qt/masternodewizard.h
@@ -113,6 +113,11 @@ private:
     void showError(const QString& message);
 
     void refreshCollateralCandidates();
+    //! Derive the operator key when that mode is selected and it has not been
+    //! derived yet, holding the unlock the registration will reuse. Reports the
+    //! reason in the error label and returns false when the wallet stayed locked
+    //! or could not derive, so the caller can let the user pick another mode.
+    bool ensureOperatorKey();
     //! Store the generated operator secret in the wallet when that mode is
     //! selected. Call while the wallet is still unlocked by the registration.
     void saveOperatorKeyIfChosen();
@@ -137,12 +142,12 @@ private:
     int m_pos{0};
     bool m_busy{false};
     bool m_registered{false};
+    //! Whether the operator secret was derived from this wallet's HD seed
+    bool m_operator_key_derived{false};
     //! Whether addMasternodeOperatorKey() stored the generated secret
     bool m_operator_key_saved{false};
     //! Why storing the generated secret failed, empty when it did not fail
     QString m_operator_save_error;
-    //! Why storing the generated secret failed; empty when it was not attempted
-    QString m_operator_store_error;
 
     QStackedWidget* m_pages;
     QLabel* m_error_label;
@@ -202,6 +207,7 @@ private:
     QLabel* m_result_tx_note;
     QWidget* m_secret_box;
     QLabel* m_secret_note;
+    QLabel* m_secret_recall;
     QLineEdit* m_secret_edit;
     QLineEdit* m_conf_line_edit;
     QWidget* m_confirm_box;

--- a/src/qt/masternodewizard.h
+++ b/src/qt/masternodewizard.h
@@ -118,13 +118,11 @@ private:
     //! reason in the error label and returns false when the wallet stayed locked
     //! or could not derive, so the caller can let the user pick another mode.
     bool ensureOperatorKey();
-    //! Store the generated operator secret in the wallet when that mode is
-    //! selected. Call while the wallet is still unlocked by the registration.
-    void saveOperatorKeyIfChosen();
     void populateReview();
     //! Width of the review's label column, shared by every section
     int reviewLabelWidth(const QWidget* card) const;
-    //! One line saying where the operator key comes from and where it will live
+    //! One line saying where the operator key comes from and whether it can be
+    //! seen again
     QString operatorKeyProvenance() const;
     void populateResult(const QString& pro_tx_hash);
     UniValue buildRegisterParams() const;
@@ -144,10 +142,6 @@ private:
     bool m_registered{false};
     //! Whether the operator secret was derived from this wallet's HD seed
     bool m_operator_key_derived{false};
-    //! Whether addMasternodeOperatorKey() stored the generated secret
-    bool m_operator_key_saved{false};
-    //! Why storing the generated secret failed, empty when it did not fail
-    QString m_operator_save_error;
 
     QStackedWidget* m_pages;
     QLabel* m_error_label;

--- a/src/qt/masternodewizard.h
+++ b/src/qt/masternodewizard.h
@@ -97,6 +97,8 @@ private:
     QString votingAddress() const;
     QString freshAddress(QString& err) const;
     CAmount collateralAmount() const;
+    //! True when the user typed the generated operator secret's last 4 characters
+    bool secretConfirmed() const;
 
     void rebuildOrder();
     void goToPage(Page page);

--- a/src/qt/masternodewizard.h
+++ b/src/qt/masternodewizard.h
@@ -33,6 +33,7 @@ class QPushButton;
 class QRadioButton;
 class QSpinBox;
 class QStackedWidget;
+class QVBoxLayout;
 QT_END_NAMESPACE
 
 //! Multi-page dialog registering a masternode or evonode: collects collateral,
@@ -99,6 +100,9 @@ private:
     CAmount collateralAmount() const;
     //! True when the user typed the generated operator secret's last 4 characters
     bool secretConfirmed() const;
+    //! True while the generated operator secret exists nowhere but this dialog,
+    //! which is the only case worth gating the last page on
+    bool secretGateRequired() const;
 
     void rebuildOrder();
     void goToPage(Page page);
@@ -109,7 +113,14 @@ private:
     void showError(const QString& message);
 
     void refreshCollateralCandidates();
+    //! Store the generated operator secret in the wallet when that mode is
+    //! selected. Call while the wallet is still unlocked by the registration.
+    void saveOperatorKeyIfChosen();
     void populateReview();
+    //! Width of the review's label column, shared by every section
+    int reviewLabelWidth(const QWidget* card) const;
+    //! One line saying where the operator key comes from and where it will live
+    QString operatorKeyProvenance() const;
     void populateResult(const QString& pro_tx_hash);
     UniValue buildRegisterParams() const;
     void startRegistration();
@@ -126,6 +137,12 @@ private:
     int m_pos{0};
     bool m_busy{false};
     bool m_registered{false};
+    //! Whether addMasternodeOperatorKey() stored the generated secret
+    bool m_operator_key_saved{false};
+    //! Why storing the generated secret failed, empty when it did not fail
+    QString m_operator_save_error;
+    //! Why storing the generated secret failed; empty when it was not attempted
+    QString m_operator_store_error;
 
     QStackedWidget* m_pages;
     QLabel* m_error_label;
@@ -170,8 +187,10 @@ private:
     // Fee page
     FeeSourcePicker* m_fee_picker;
     QLabel* m_fee_explain;
-    // Review page
-    QLabel* m_review_label;
+    // Review page. The sections are rebuilt on every entry, so the layout owns
+    // the rows rather than a single rich-text label.
+    QWidget* m_review_container;
+    QVBoxLayout* m_review_layout;
     // Sign page (external collateral)
     QLabel* m_sign_address_label;
     QPlainTextEdit* m_sign_message;
@@ -179,9 +198,13 @@ private:
     QString m_prepared_tx;
     // Result page
     QLabel* m_result_label;
+    QLabel* m_result_hash;
+    QLabel* m_result_tx_note;
     QWidget* m_secret_box;
+    QLabel* m_secret_note;
     QLineEdit* m_secret_edit;
     QLineEdit* m_conf_line_edit;
+    QWidget* m_confirm_box;
     QLineEdit* m_confirm_edit;
     QLabel* m_next_steps;
 };

--- a/src/qt/mnsharesession.cpp
+++ b/src/qt/mnsharesession.cpp
@@ -1,0 +1,948 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/mnsharesession.h>
+
+#include <arith_uint256.h>
+#include <chainparams.h>
+#include <core_io.h>
+#include <evo/dmn_types.h>
+#include <evo/providertx.h>
+#include <evo/specialtx.h>
+#include <key_io.h>
+#include <messagesigner.h>
+#include <primitives/transaction.h>
+#include <random.h>
+#include <script/standard.h>
+#include <uint256.h>
+#include <util/strencodings.h>
+
+#include <QCoreApplication>
+
+#include <algorithm>
+#include <limits>
+#include <map>
+#include <optional>
+#include <utility>
+#include <variant>
+
+namespace {
+
+constexpr const char* ENVELOPE_TYPE{"dash-shared-mn-session"};
+constexpr int ENVELOPE_VERSION{1};
+
+QString Tr(const char* text)
+{
+    return QCoreApplication::translate("MnShareSession", text);
+}
+
+QString Tr(const char* text, const char* disambiguation, int n)
+{
+    return QCoreApplication::translate("MnShareSession", text, disambiguation, n);
+}
+
+//! Untranslated stage keys used in the envelope JSON
+const char* StageKey(MnShareSession::Stage stage)
+{
+    switch (stage) {
+    case MnShareSession::Stage::Draft: return "draft";
+    case MnShareSession::Stage::Frozen: return "frozen";
+    case MnShareSession::Stage::Signing: return "signing";
+    case MnShareSession::Stage::Combined: return "combined";
+    case MnShareSession::Stage::FundingSigned: return "fundingSigned";
+    case MnShareSession::Stage::Broadcast: return "broadcast";
+    }
+    return "draft";
+}
+
+std::optional<MnShareSession::Stage> StageFromKey(const std::string& key)
+{
+    for (const auto stage : {MnShareSession::Stage::Draft, MnShareSession::Stage::Frozen,
+                             MnShareSession::Stage::Signing, MnShareSession::Stage::Combined,
+                             MnShareSession::Stage::FundingSigned, MnShareSession::Stage::Broadcast}) {
+        if (key == StageKey(stage)) return stage;
+    }
+    return std::nullopt;
+}
+
+//! Format duffs as a DASH amount without floating point
+QString FormatDash(CAmount amount)
+{
+    const bool negative{amount < 0};
+    if (negative) amount = -amount;
+    QString ret = QString::number(static_cast<qlonglong>(amount / COIN));
+    if (const CAmount frac{amount % COIN}; frac != 0) {
+        QString frac_str = QStringLiteral("%1").arg(static_cast<qlonglong>(frac), 8, 10, QLatin1Char('0'));
+        while (frac_str.endsWith(QLatin1Char('0'))) {
+            frac_str.chop(1);
+        }
+        ret += QLatin1Char('.') + frac_str;
+    }
+    return negative ? QLatin1Char('-') + ret : ret;
+}
+
+bool IsTxidHex(const QString& txid)
+{
+    return txid.size() == 64 && IsHex(txid.toStdString());
+}
+
+//! Decode a frozen shared registration (funding tx + CProRegTx payload with a
+//! share table) from the envelope's protx hex
+bool DecodeSharedProTx(const QString& protx_hex, CMutableTransaction& tx, CProRegTx& payload, QString& error)
+{
+    if (!DecodeHexTx(tx, protx_hex.toStdString())) {
+        error = Tr("The session's prepared transaction is not valid transaction hex.");
+        return false;
+    }
+    // assert_type=false: a malformed file must produce an error, not a debug abort
+    auto opt_payload = GetTxPayload<CProRegTx>(tx, /*assert_type=*/false);
+    if (!opt_payload || !opt_payload->IsShared()) {
+        error = Tr("The session's prepared transaction is not a shared masternode registration.");
+        return false;
+    }
+    payload = std::move(*opt_payload);
+    return true;
+}
+
+} // anonymous namespace
+
+MnShareSession::MnShareSession()
+    : m_network{QString::fromStdString(Params().NetworkIDString())},
+      m_session_id{QString::fromStdString(GetRandHash().ToString())}
+{
+}
+
+QString MnShareSession::StageName(Stage stage)
+{
+    switch (stage) {
+    case Stage::Draft: return Tr("Draft");
+    case Stage::Frozen: return Tr("Frozen");
+    case Stage::Signing: return Tr("Collecting signatures");
+    case Stage::Combined: return Tr("Signatures combined");
+    case Stage::FundingSigned: return Tr("Funding signed");
+    case Stage::Broadcast: return Tr("Broadcast");
+    }
+    return {};
+}
+
+UniValue MnShareSession::toJson() const
+{
+    UniValue ret(UniValue::VOBJ);
+    ret.pushKV("type", ENVELOPE_TYPE);
+    ret.pushKV("version", ENVELOPE_VERSION);
+    ret.pushKV("network", m_network.toStdString());
+    ret.pushKV("sessionId", m_session_id.toStdString());
+    ret.pushKV("revision", m_revision);
+    ret.pushKV("stage", StageKey(m_stage));
+    ret.pushKV("fundingTx", m_funding_tx.toStdString());
+
+    UniValue shares(UniValue::VARR);
+    for (const auto& share : m_shares) {
+        UniValue entry(UniValue::VOBJ);
+        entry.pushKV("label", share.label.toStdString());
+        entry.pushKV("amount", share.amount);
+        entry.pushKV("ownerAddress", share.ownerAddress.toStdString());
+        entry.pushKV("refundAddress", share.refundAddress.toStdString());
+        entry.pushKV("rewardAddress", share.rewardAddress.toStdString());
+        shares.push_back(entry);
+    }
+    ret.pushKV("shares", shares);
+
+    UniValue terms(UniValue::VOBJ);
+    terms.pushKV("coreP2PAddrs", m_terms.coreP2PAddrs.toStdString());
+    terms.pushKV("operatorPubKey", m_terms.operatorPubKey.toStdString());
+    terms.pushKV("votingAddress", m_terms.votingAddress.toStdString());
+    terms.pushKV("operatorReward", m_terms.operatorReward);
+    terms.pushKV("earlyPeriodBlocks", static_cast<int64_t>(m_terms.earlyPeriodBlocks));
+    terms.pushKV("earlyPenalty", m_terms.earlyPenalty);
+    ret.pushKV("terms", terms);
+
+    UniValue contributions(UniValue::VARR);
+    for (const auto& contribution : m_contributions) {
+        UniValue entry(UniValue::VOBJ);
+        entry.pushKV("label", contribution.label.toStdString());
+        UniValue inputs(UniValue::VARR);
+        for (const auto& input : contribution.inputs) {
+            UniValue in(UniValue::VOBJ);
+            in.pushKV("txid", input.txid.toStdString());
+            in.pushKV("vout", static_cast<int64_t>(input.vout));
+            in.pushKV("sequence", static_cast<int64_t>(input.sequence));
+            inputs.push_back(in);
+        }
+        entry.pushKV("inputs", inputs);
+        if (contribution.hasChange) {
+            UniValue change(UniValue::VOBJ);
+            change.pushKV("address", contribution.changeAddress.toStdString());
+            change.pushKV("amount", contribution.changeAmount);
+            entry.pushKV("change", change);
+        }
+        entry.pushKV("changeIndex", contribution.changeIndex);
+        contributions.push_back(entry);
+    }
+    ret.pushKV("contributions", contributions);
+
+    ret.pushKV("protx", m_protx.toStdString());
+    ret.pushKV("consentHash", m_consent_hash.toStdString());
+    ret.pushKV("collateralIndex", m_collateral_index);
+
+    UniValue sigs(UniValue::VARR);
+    for (const auto& sig : m_sigs) {
+        UniValue entry(UniValue::VOBJ);
+        entry.pushKV("shareIndex", sig.shareIndex);
+        entry.pushKV("signature", sig.signatureB64.toStdString());
+        sigs.push_back(entry);
+    }
+    ret.pushKV("sigs", sigs);
+
+    ret.pushKV("prepareWallet", m_prepare_wallet.toStdString());
+    ret.pushKV("operatorSecretHolder", m_operator_secret_holder.toStdString());
+    return ret;
+}
+
+QString MnShareSession::toJsonString() const
+{
+    return QString::fromStdString(toJson().write(/*prettyIndent=*/2));
+}
+
+bool MnShareSession::fromJson(const std::string& text, QString& error)
+{
+    UniValue json;
+    if (!json.read(text)) {
+        error = Tr("The file is not valid JSON.");
+        return false;
+    }
+    return fromJson(json, error);
+}
+
+bool MnShareSession::fromJson(const UniValue& json, QString& error)
+{
+    try {
+        if (!json.isObject()) {
+            error = Tr("The file is not a shared masternode session file.");
+            return false;
+        }
+        const UniValue& type{json.find_value("type")};
+        if (!type.isStr() || type.get_str() != ENVELOPE_TYPE) {
+            error = Tr("The file is not a shared masternode session file.");
+            return false;
+        }
+        const UniValue& version{json.find_value("version")};
+        if (!version.isNum() || version.getInt<int>() != ENVELOPE_VERSION) {
+            error = Tr("The session file uses an unsupported format version. Update Dash Core to open it.");
+            return false;
+        }
+        const UniValue& network{json.find_value("network")};
+        const std::string our_network{Params().NetworkIDString()};
+        if (!network.isStr() || network.get_str() != our_network) {
+            error = Tr("The session file is for the \"%1\" network but this node runs \"%2\". It cannot be used here.")
+                        .arg(network.isStr() ? QString::fromStdString(network.get_str()) : Tr("unknown"),
+                             QString::fromStdString(our_network));
+            return false;
+        }
+        const UniValue& session_id{json.find_value("sessionId")};
+        if (!session_id.isStr() || session_id.get_str().empty()) {
+            error = Tr("The session file has no session id.");
+            return false;
+        }
+        const UniValue& revision{json.find_value("revision")};
+        if (!revision.isNum() || revision.getInt<int>() < 1) {
+            error = Tr("The session file has an invalid revision.");
+            return false;
+        }
+        const UniValue& stage_value{json.find_value("stage")};
+        if (!stage_value.isStr()) {
+            error = Tr("The session file has no stage.");
+            return false;
+        }
+        const auto stage{StageFromKey(stage_value.get_str())};
+        if (!stage) {
+            error = Tr("The session file is at the unknown stage \"%1\". It was probably created by a newer Dash Core.")
+                        .arg(QString::fromStdString(stage_value.get_str()));
+            return false;
+        }
+
+        MnShareSession parsed;
+        parsed.m_network = QString::fromStdString(network.get_str());
+        parsed.m_session_id = QString::fromStdString(session_id.get_str());
+        parsed.m_revision = revision.getInt<int>();
+        parsed.m_stage = *stage;
+
+        if (const UniValue& v{json.find_value("fundingTx")}; v.isStr()) {
+            parsed.m_funding_tx = QString::fromStdString(v.get_str());
+        }
+
+        if (const UniValue& shares{json.find_value("shares")}; shares.isArray()) {
+            for (size_t i = 0; i < shares.size(); ++i) {
+                const UniValue& entry{shares[i]};
+                const bool well_formed{entry.isObject() && entry.find_value("amount").isNum() &&
+                                       entry.find_value("ownerAddress").isStr() &&
+                                       entry.find_value("refundAddress").isStr()};
+                if (!well_formed) {
+                    error = Tr("Share entry %1 in the session file is malformed.").arg(i + 1);
+                    return false;
+                }
+                Share share;
+                if (const UniValue& v{entry.find_value("label")}; v.isStr()) share.label = QString::fromStdString(v.get_str());
+                share.amount = entry.find_value("amount").getInt<int64_t>();
+                share.ownerAddress = QString::fromStdString(entry.find_value("ownerAddress").get_str());
+                share.refundAddress = QString::fromStdString(entry.find_value("refundAddress").get_str());
+                if (const UniValue& v{entry.find_value("rewardAddress")}; v.isStr()) {
+                    share.rewardAddress = QString::fromStdString(v.get_str());
+                }
+                parsed.m_shares.push_back(share);
+            }
+        }
+
+        if (const UniValue& terms{json.find_value("terms")}; terms.isObject()) {
+            if (const UniValue& v{terms.find_value("coreP2PAddrs")}; v.isStr()) parsed.m_terms.coreP2PAddrs = QString::fromStdString(v.get_str());
+            if (const UniValue& v{terms.find_value("operatorPubKey")}; v.isStr()) parsed.m_terms.operatorPubKey = QString::fromStdString(v.get_str());
+            if (const UniValue& v{terms.find_value("votingAddress")}; v.isStr()) parsed.m_terms.votingAddress = QString::fromStdString(v.get_str());
+            if (const UniValue& v{terms.find_value("operatorReward")}; v.isNum()) parsed.m_terms.operatorReward = v.getInt<int>();
+            if (const UniValue& v{terms.find_value("earlyPeriodBlocks")}; v.isNum()) {
+                const int64_t blocks{v.getInt<int64_t>()};
+                if (blocks < 0 || blocks > std::numeric_limits<uint32_t>::max()) {
+                    error = Tr("The session file has an invalid early period.");
+                    return false;
+                }
+                parsed.m_terms.earlyPeriodBlocks = static_cast<uint32_t>(blocks);
+            }
+            if (const UniValue& v{terms.find_value("earlyPenalty")}; v.isNum()) parsed.m_terms.earlyPenalty = v.getInt<int64_t>();
+        }
+
+        if (const UniValue& contributions{json.find_value("contributions")}; contributions.isArray()) {
+            for (size_t i = 0; i < contributions.size(); ++i) {
+                const UniValue& entry{contributions[i]};
+                if (!entry.isObject() || !entry.find_value("label").isStr() || !entry.find_value("inputs").isArray()) {
+                    error = Tr("Contribution entry %1 in the session file is malformed.").arg(i + 1);
+                    return false;
+                }
+                Contribution contribution;
+                contribution.label = QString::fromStdString(entry.find_value("label").get_str());
+                const UniValue& inputs{entry.find_value("inputs")};
+                for (size_t j = 0; j < inputs.size(); ++j) {
+                    const UniValue& in{inputs[j]};
+                    const bool well_formed{in.isObject() && in.find_value("txid").isStr() &&
+                                           in.find_value("vout").isNum() && in.find_value("sequence").isNum()};
+                    if (!well_formed) {
+                        error = Tr("Contribution entry %1 in the session file is malformed.").arg(i + 1);
+                        return false;
+                    }
+                    Input input;
+                    input.txid = QString::fromStdString(in.find_value("txid").get_str());
+                    input.vout = static_cast<uint32_t>(in.find_value("vout").getInt<int64_t>());
+                    input.sequence = static_cast<uint32_t>(in.find_value("sequence").getInt<int64_t>());
+                    if (!IsTxidHex(input.txid)) {
+                        error = Tr("Contribution entry %1 in the session file is malformed.").arg(i + 1);
+                        return false;
+                    }
+                    contribution.inputs.push_back(input);
+                }
+                if (const UniValue& change{entry.find_value("change")}; change.isObject()) {
+                    if (!change.find_value("address").isStr() || !change.find_value("amount").isNum()) {
+                        error = Tr("Contribution entry %1 in the session file is malformed.").arg(i + 1);
+                        return false;
+                    }
+                    contribution.hasChange = true;
+                    contribution.changeAddress = QString::fromStdString(change.find_value("address").get_str());
+                    contribution.changeAmount = change.find_value("amount").getInt<int64_t>();
+                }
+                if (const UniValue& v{entry.find_value("changeIndex")}; v.isNum()) contribution.changeIndex = v.getInt<int>();
+                parsed.m_contributions.push_back(contribution);
+            }
+        }
+
+        if (const UniValue& v{json.find_value("protx")}; v.isStr()) parsed.m_protx = QString::fromStdString(v.get_str());
+        if (const UniValue& v{json.find_value("consentHash")}; v.isStr()) {
+            const std::string& hash{v.get_str()};
+            if (!hash.empty() && !(hash.size() == 64 && IsHex(hash))) {
+                error = Tr("The session file has a malformed consent hash.");
+                return false;
+            }
+            parsed.m_consent_hash = QString::fromStdString(hash).toLower();
+        }
+        if (const UniValue& v{json.find_value("collateralIndex")}; v.isNum()) parsed.m_collateral_index = v.getInt<int>();
+
+        if (const UniValue& sigs{json.find_value("sigs")}; sigs.isArray()) {
+            for (size_t i = 0; i < sigs.size(); ++i) {
+                const UniValue& entry{sigs[i]};
+                if (!entry.isObject() || !entry.find_value("shareIndex").isNum() || !entry.find_value("signature").isStr()) {
+                    error = Tr("Signature entry %1 in the session file is malformed.").arg(i + 1);
+                    return false;
+                }
+                Signature sig;
+                sig.shareIndex = entry.find_value("shareIndex").getInt<int>();
+                sig.signatureB64 = QString::fromStdString(entry.find_value("signature").get_str());
+                parsed.m_sigs.push_back(sig);
+            }
+        }
+
+        if (const UniValue& v{json.find_value("prepareWallet")}; v.isStr()) parsed.m_prepare_wallet = QString::fromStdString(v.get_str());
+        if (const UniValue& v{json.find_value("operatorSecretHolder")}; v.isStr()) parsed.m_operator_secret_holder = QString::fromStdString(v.get_str());
+
+        if (parsed.m_stage != Stage::Draft && (parsed.m_protx.isEmpty() || parsed.m_consent_hash.isEmpty())) {
+            error = Tr("The session file is marked \"%1\" but is missing its frozen transaction or consent hash.")
+                        .arg(StageName(parsed.m_stage));
+            return false;
+        }
+
+        *this = std::move(parsed);
+        return true;
+    } catch (const std::exception& e) {
+        error = Tr("The session file could not be parsed: %1").arg(QString::fromUtf8(e.what()));
+        return false;
+    }
+}
+
+QStringList MnShareSession::validateShares() const
+{
+    QStringList errors;
+    const CAmount required_collateral{GetMnType(MnType::Regular).collat_amount};
+
+    if (m_shares.size() < CProRegTx::MIN_SHARES || m_shares.size() > CProRegTx::MAX_SHARES) {
+        errors << Tr("A shared masternode needs between %1 and %2 shares (currently %3).")
+                      .arg(CProRegTx::MIN_SHARES)
+                      .arg(CProRegTx::MAX_SHARES)
+                      .arg(m_shares.size());
+    }
+
+    std::optional<CKeyID> voting_key_id;
+    if (CTxDestination dest{DecodeDestination(m_terms.votingAddress.toStdString())}; const auto* pkhash = std::get_if<PKHash>(&dest)) {
+        voting_key_id = ToKeyID(*pkhash);
+    } else {
+        errors << Tr("The voting address must be a valid P2PKH address.");
+    }
+
+    // Resolve owner keys first: refund/reward scripts must not pay to any of them
+    std::vector<std::optional<CKeyID>> owner_key_ids;
+    std::map<CKeyID, size_t> seen_owner_keys;
+    for (size_t i = 0; i < m_shares.size(); ++i) {
+        const QString row{Tr("Share %1:").arg(i + 1)};
+        std::optional<CKeyID> key_id;
+        if (CTxDestination dest{DecodeDestination(m_shares[i].ownerAddress.toStdString())}; const auto* pkhash = std::get_if<PKHash>(&dest)) {
+            key_id = ToKeyID(*pkhash);
+        } else {
+            errors << row + QLatin1Char(' ') + Tr("the owner address must be a valid P2PKH address.");
+        }
+        if (key_id) {
+            if (const auto [it, inserted] = seen_owner_keys.emplace(*key_id, i); !inserted) {
+                errors << row + QLatin1Char(' ') +
+                              Tr("the owner address is already used by share %1. Every owner key must be unique.")
+                                  .arg(it->second + 1);
+            }
+        }
+        owner_key_ids.push_back(key_id);
+    }
+
+    CAmount total_amount{0};
+    CAmount min_amount{std::numeric_limits<CAmount>::max()};
+    std::map<CScript, size_t> seen_refund_scripts;
+    for (size_t i = 0; i < m_shares.size(); ++i) {
+        const Share& share{m_shares[i]};
+        const QString row{Tr("Share %1:").arg(i + 1)};
+
+        if (share.amount < CCollateralShare::MIN_AMOUNT || share.amount > required_collateral) {
+            errors << row + QLatin1Char(' ') +
+                          Tr("the amount must be between %1 and %2 DASH.")
+                              .arg(FormatDash(CCollateralShare::MIN_AMOUNT), FormatDash(required_collateral));
+        } else {
+            total_amount += share.amount;
+            min_amount = std::min(min_amount, share.amount);
+        }
+
+        const bool has_reward{!share.rewardAddress.isEmpty()};
+        const std::pair<const QString*, QString> payout_addrs[]{
+            {&share.refundAddress, Tr("refund")},
+            {&share.rewardAddress, Tr("reward")},
+        };
+        for (const auto& [addr, kind] : payout_addrs) {
+            if (addr == &share.rewardAddress && !has_reward) continue; // empty reward = fall back to refund
+            const CTxDestination dest{DecodeDestination(addr->toStdString())};
+            if (!std::holds_alternative<PKHash>(dest) && !std::holds_alternative<ScriptHash>(dest)) {
+                errors << row + QLatin1Char(' ') + Tr("the %1 address must be a valid P2PKH or P2SH address.").arg(kind);
+                continue;
+            }
+            if (addr == &share.refundAddress) {
+                const CScript script{GetScriptForDestination(dest)};
+                if (const auto [it, inserted] = seen_refund_scripts.emplace(script, i); !inserted) {
+                    errors << row + QLatin1Char(' ') +
+                                  Tr("the refund address is already used by share %1. Every refund address must be unique.")
+                                      .arg(it->second + 1);
+                }
+            }
+            if (voting_key_id && dest == CTxDestination(PKHash(*voting_key_id))) {
+                errors << row + QLatin1Char(' ') + Tr("the %1 address must not be the voting address.").arg(kind);
+            }
+            for (size_t j = 0; j < owner_key_ids.size(); ++j) {
+                if (owner_key_ids[j] && dest == CTxDestination(PKHash(*owner_key_ids[j]))) {
+                    errors << row + QLatin1Char(' ') +
+                                  Tr("the %1 address must not be share %2's owner address.").arg(kind).arg(j + 1);
+                }
+            }
+        }
+    }
+
+    if (!m_shares.empty() && total_amount != required_collateral) {
+        errors << Tr("The share amounts must sum to exactly %1 DASH (currently %2 DASH).")
+                      .arg(FormatDash(required_collateral), FormatDash(total_amount));
+    }
+    if (m_terms.earlyPeriodBlocks > CProRegTx::MAX_EARLY_PERIOD_BLOCKS) {
+        errors << Tr("The early period must be at most %1 blocks (about two years).").arg(CProRegTx::MAX_EARLY_PERIOD_BLOCKS);
+    }
+    if (m_terms.earlyPenalty < 0) {
+        errors << Tr("The early penalty cannot be negative.");
+    } else if (min_amount != std::numeric_limits<CAmount>::max() && m_terms.earlyPenalty >= min_amount) {
+        errors << Tr("The early penalty must be below the smallest share amount (%1 DASH).").arg(FormatDash(min_amount));
+    }
+    return errors;
+}
+
+bool MnShareSession::rebuildFundingTx(QString& error)
+{
+    CMutableTransaction tx;
+    tx.nVersion = 2;
+    for (const auto& contribution : m_contributions) {
+        for (const auto& input : contribution.inputs) {
+            if (!IsTxidHex(input.txid)) {
+                error = Tr("Contribution \"%1\" has a malformed input transaction id.").arg(contribution.label);
+                return false;
+            }
+            tx.vin.emplace_back(COutPoint(uint256S(input.txid.toStdString()), input.vout), CScript(), input.sequence);
+        }
+    }
+    for (auto& contribution : m_contributions) {
+        if (!contribution.hasChange) {
+            contribution.changeIndex = -1;
+            continue;
+        }
+        const CTxDestination dest{DecodeDestination(contribution.changeAddress.toStdString())};
+        if (!IsValidDestination(dest)) {
+            error = Tr("Contribution \"%1\" has an invalid change address.").arg(contribution.label);
+            return false;
+        }
+        contribution.changeIndex = static_cast<int>(tx.vout.size());
+        tx.vout.emplace_back(contribution.changeAmount, GetScriptForDestination(dest));
+    }
+    m_funding_tx = QString::fromStdString(EncodeHexTx(CTransaction(tx)));
+    return true;
+}
+
+bool MnShareSession::addContribution(const Contribution& contribution, QString& error)
+{
+    if (m_stage != Stage::Draft) {
+        error = Tr("Funding can only be changed while the session is a draft. Unfreeze it first (this discards all collected signatures).");
+        return false;
+    }
+    if (contribution.label.isEmpty()) {
+        error = Tr("The contribution needs a participant label.");
+        return false;
+    }
+    if (contribution.inputs.empty()) {
+        error = Tr("The contribution has no funding inputs.");
+        return false;
+    }
+    for (const auto& existing : m_contributions) {
+        if (existing.label == contribution.label) {
+            error = Tr("\"%1\" has already contributed. Remove the existing contribution first.").arg(contribution.label);
+            return false;
+        }
+        for (const auto& in : existing.inputs) {
+            for (const auto& new_in : contribution.inputs) {
+                if (in.txid.compare(new_in.txid, Qt::CaseInsensitive) == 0 && in.vout == new_in.vout) {
+                    error = Tr("Input %1:%2 is already contributed by \"%3\".")
+                                .arg(new_in.txid)
+                                .arg(new_in.vout)
+                                .arg(existing.label);
+                    return false;
+                }
+            }
+        }
+    }
+    if (contribution.hasChange && contribution.changeAmount <= 0) {
+        error = Tr("The change amount must be positive.");
+        return false;
+    }
+
+    m_contributions.push_back(contribution);
+    if (!rebuildFundingTx(error)) {
+        m_contributions.pop_back();
+        return false;
+    }
+    ++m_revision;
+    return true;
+}
+
+bool MnShareSession::removeContribution(const QString& label, QString& error)
+{
+    if (m_stage != Stage::Draft) {
+        error = Tr("Funding can only be changed while the session is a draft. Unfreeze it first (this discards all collected signatures).");
+        return false;
+    }
+    for (auto it = m_contributions.begin(); it != m_contributions.end(); ++it) {
+        if (it->label == label) {
+            m_contributions.erase(it);
+            if (!rebuildFundingTx(error)) return false;
+            ++m_revision;
+            return true;
+        }
+    }
+    error = Tr("No contribution from \"%1\" was found.").arg(label);
+    return false;
+}
+
+bool MnShareSession::freeze(const QString& protx_hex, const QString& consent_hash_hex, int collateral_index, QString& error)
+{
+    if (m_stage != Stage::Draft) {
+        error = Tr("Only a draft session can be frozen.");
+        return false;
+    }
+    CMutableTransaction tx;
+    CProRegTx payload;
+    if (!DecodeSharedProTx(protx_hex, tx, payload, error)) return false;
+    if (!(consent_hash_hex.size() == 64 && IsHex(consent_hash_hex.toStdString()))) {
+        error = Tr("The consent hash is malformed.");
+        return false;
+    }
+    const uint256 recomputed{payload.MakeSharedRegConsentHash(CTransaction(tx))};
+    if (recomputed != uint256S(consent_hash_hex.toStdString())) {
+        error = Tr("The consent hash does not match the prepared transaction. Do not sign; restart the preparation step.");
+        return false;
+    }
+    if (collateral_index < 0 || payload.collateralOutpoint.n != static_cast<uint32_t>(collateral_index)) {
+        error = Tr("The collateral output index does not match the prepared transaction.");
+        return false;
+    }
+    m_protx = protx_hex;
+    m_consent_hash = consent_hash_hex.toLower();
+    m_collateral_index = collateral_index;
+    m_sigs.clear();
+    m_stage = Stage::Frozen;
+    return true;
+}
+
+void MnShareSession::unfreeze()
+{
+    m_protx.clear();
+    m_consent_hash.clear();
+    m_collateral_index = -1;
+    m_sigs.clear();
+    m_stage = Stage::Draft;
+    // Signatures collected for the old consent hash can never apply to the
+    // reworked session; a new revision makes every circulating copy stale
+    ++m_revision;
+}
+
+bool MnShareSession::verifySignature(int share_index, const QString& sig_b64, QString& error) const
+{
+    if (m_protx.isEmpty() || m_consent_hash.isEmpty()) {
+        error = Tr("The session is not frozen yet; there is nothing to sign.");
+        return false;
+    }
+    CMutableTransaction tx;
+    CProRegTx payload;
+    if (!DecodeSharedProTx(m_protx, tx, payload, error)) return false;
+    if (share_index < 0 || static_cast<size_t>(share_index) >= payload.shares.size()) {
+        error = Tr("Share index %1 is out of range.").arg(share_index);
+        return false;
+    }
+    const uint256 consent_hash{payload.MakeSharedRegConsentHash(CTransaction(tx))};
+    if (consent_hash != uint256S(m_consent_hash.toStdString())) {
+        error = Tr("The session file is internally inconsistent: its prepared transaction no longer matches its consent hash. Do not sign; request a fresh copy.");
+        return false;
+    }
+    const auto sig{DecodeBase64(sig_b64.toStdString())};
+    if (!sig) {
+        error = Tr("The signature is not valid base64.");
+        return false;
+    }
+    const QString label{static_cast<size_t>(share_index) < m_shares.size() && !m_shares[share_index].label.isEmpty()
+                            ? m_shares[share_index].label
+                            : Tr("share %1").arg(share_index + 1)};
+    if (std::string str_error; !CHashSigner::VerifyHashCanonical(consent_hash, payload.shares[share_index].keyIDOwner, *sig, str_error)) {
+        error = Tr("The signature from %1 does not verify against the current terms. It was most likely made for an older version of this session — ask %1 to re-sign the current version.")
+                    .arg(label);
+        return false;
+    }
+    return true;
+}
+
+std::vector<MnShareSession::SignatureCheck> MnShareSession::verifyAllSignatures() const
+{
+    std::vector<SignatureCheck> ret;
+    ret.reserve(m_sigs.size());
+    for (const auto& sig : m_sigs) {
+        SignatureCheck check;
+        check.shareIndex = sig.shareIndex;
+        check.valid = verifySignature(sig.shareIndex, sig.signatureB64, check.error);
+        ret.push_back(check);
+    }
+    return ret;
+}
+
+const MnShareSession::Signature* MnShareSession::findSignature(int share_index) const
+{
+    for (const auto& sig : m_sigs) {
+        if (sig.shareIndex == share_index) return &sig;
+    }
+    return nullptr;
+}
+
+bool MnShareSession::addSignature(int share_index, const QString& sig_b64, QString& error)
+{
+    if (!verifySignature(share_index, sig_b64, error)) return false;
+    if (const Signature* existing = findSignature(share_index)) {
+        // RFC6979 signatures are deterministic: the same key signing the same
+        // digest always yields the same bytes, so a byte-identical duplicate
+        // is a harmless re-import and anything else signed a stale version
+        if (DecodeBase64(existing->signatureB64.toStdString()) == DecodeBase64(sig_b64.toStdString())) {
+            return true;
+        }
+        error = Tr("A different signature for this share is already recorded. One of the copies signed a stale version of the session — agree on the latest revision and have it re-signed.");
+        return false;
+    }
+    Signature sig;
+    sig.shareIndex = share_index;
+    sig.signatureB64 = sig_b64;
+    const auto pos = std::find_if(m_sigs.begin(), m_sigs.end(),
+                                  [share_index](const Signature& s) { return s.shareIndex > share_index; });
+    m_sigs.insert(pos, sig);
+    if (m_stage == Stage::Frozen) m_stage = Stage::Signing;
+    return true;
+}
+
+int MnShareSession::signedCount() const
+{
+    int count{0};
+    for (const auto& sig : m_sigs) {
+        if (sig.shareIndex >= 0 && static_cast<size_t>(sig.shareIndex) < m_shares.size()) ++count;
+    }
+    return count;
+}
+
+std::vector<int> MnShareSession::missingIndexes() const
+{
+    std::vector<int> ret;
+    for (size_t i = 0; i < m_shares.size(); ++i) {
+        if (!findSignature(static_cast<int>(i))) ret.push_back(static_cast<int>(i));
+    }
+    return ret;
+}
+
+QString MnShareSession::signatureFor(int share_index) const
+{
+    const Signature* sig{findSignature(share_index)};
+    return sig ? sig->signatureB64 : QString();
+}
+
+MnShareSession::MergeResult MnShareSession::mergeEnvelope(const MnShareSession& other, QString& error)
+{
+    if (other.m_session_id != m_session_id) {
+        error = Tr("The imported file belongs to a different session (id %1, this session is %2).")
+                    .arg(other.m_session_id.left(8), m_session_id.left(8));
+        return MergeResult::Conflict;
+    }
+    if (other.m_revision > m_revision) {
+        error = Tr("The imported copy is revision %1 of this session; this copy is revision %2 and is superseded by it.")
+                    .arg(other.m_revision)
+                    .arg(m_revision);
+        return MergeResult::OtherNewer;
+    }
+    if (other.m_revision < m_revision) {
+        error = Tr("The imported copy is revision %1 of this session; this copy is already at revision %2. Send the sender the newer file.")
+                    .arg(other.m_revision)
+                    .arg(m_revision);
+        return MergeResult::OtherOlder;
+    }
+
+    const bool frozen{!m_consent_hash.isEmpty()};
+    const bool other_frozen{!other.m_consent_hash.isEmpty()};
+    if (frozen != other_frozen) {
+        // Freezing does not bump the revision, so a frozen copy supersedes a
+        // draft copy of the same revision
+        error = other_frozen ? Tr("The imported copy of this session has already been frozen and supersedes this draft.")
+                             : Tr("This session has already been frozen; the imported copy is still a draft. Send the sender the newer file.");
+        return other_frozen ? MergeResult::OtherNewer : MergeResult::OtherOlder;
+    }
+    if (frozen && m_consent_hash.compare(other.m_consent_hash, Qt::CaseInsensitive) != 0) {
+        error = Tr("Both copies claim revision %1 but were frozen with different terms (check phrase %2 vs %3). They cannot be merged — agree on one authoritative copy, bump its revision and re-circulate it.")
+                    .arg(m_revision)
+                    .arg(consentCheckPhrase(), other.consentCheckPhrase());
+        return MergeResult::Conflict;
+    }
+    if (!frozen) {
+        if (m_funding_tx != other.m_funding_tx) {
+            error = Tr("Both copies claim revision %1 but contain different funding contributions. They cannot be merged — the participant who changed funding must bump the revision and re-circulate the file.")
+                        .arg(m_revision);
+            return MergeResult::Conflict;
+        }
+        return MergeResult::Merged;
+    }
+
+    // Same frozen terms: absorb the union of the other copy's verified signatures
+    QStringList warnings;
+    for (const auto& sig : other.m_sigs) {
+        if (QString sig_error; !addSignature(sig.shareIndex, sig.signatureB64, sig_error)) {
+            warnings << sig_error;
+        }
+    }
+    // Adopt a further-advanced stage together with its transaction (the protx
+    // field evolves along the stages: combined join sigs, then funding
+    // signatures live in the same transaction hex)
+    if (other.m_stage > m_stage) {
+        m_stage = other.m_stage;
+        m_protx = other.m_protx;
+    }
+    error = warnings.join(QLatin1Char('\n'));
+    return MergeResult::Merged;
+}
+
+bool MnShareSession::setCombinedTx(const QString& tx_hex, QString& error)
+{
+    if (m_stage != Stage::Frozen && m_stage != Stage::Signing) {
+        error = Tr("The session is not collecting signatures.");
+        return false;
+    }
+    if (signedCount() < static_cast<int>(m_shares.size())) {
+        error = Tr("Not every share has signed yet (%1 of %2). Combine only a fully signed session.")
+                    .arg(signedCount())
+                    .arg(m_shares.size());
+        return false;
+    }
+    CMutableTransaction tx;
+    CProRegTx payload;
+    if (!DecodeSharedProTx(tx_hex, tx, payload, error)) return false;
+    // Combining embeds the join signatures into the payload; everything the
+    // consent digest covers must be unchanged
+    if (payload.MakeSharedRegConsentHash(CTransaction(tx)) != uint256S(m_consent_hash.toStdString())) {
+        error = Tr("The combined transaction does not match the terms everyone signed. Do not broadcast it; restart from the prepared transaction.");
+        return false;
+    }
+    m_protx = tx_hex;
+    m_stage = Stage::Combined;
+    return true;
+}
+
+bool MnShareSession::setFundingSignedTx(const QString& tx_hex, QString& error)
+{
+    if (m_stage != Stage::Combined && m_stage != Stage::FundingSigned) {
+        error = Tr("The consent signatures have to be combined before the funding inputs are signed.");
+        return false;
+    }
+    CMutableTransaction tx;
+    CProRegTx payload;
+    if (!DecodeSharedProTx(tx_hex, tx, payload, error)) return false;
+    if (payload.MakeSharedRegConsentHash(CTransaction(tx)) != uint256S(m_consent_hash.toStdString())) {
+        error = Tr("The signed transaction does not match the terms everyone signed. Do not broadcast it.");
+        return false;
+    }
+    int unsigned_inputs{0};
+    for (const auto& in : tx.vin) {
+        if (in.scriptSig.empty()) ++unsigned_inputs;
+    }
+    if (unsigned_inputs > 0) {
+        error = Tr("%n funding input(s) are still unsigned.", nullptr, unsigned_inputs);
+        return false;
+    }
+    m_protx = tx_hex;
+    m_stage = Stage::FundingSigned;
+    return true;
+}
+
+bool MnShareSession::setBroadcast(QString& error)
+{
+    if (m_stage != Stage::FundingSigned) {
+        error = Tr("The session cannot be broadcast before every consent and funding signature is in place.");
+        return false;
+    }
+    m_stage = Stage::Broadcast;
+    return true;
+}
+
+QString MnShareSession::consentCheckPhrase() const
+{
+    return m_consent_hash.left(8).toUpper();
+}
+
+QString MnShareSession::HumanEarlyPeriod(uint32_t blocks)
+{
+    const qint64 minutes{static_cast<qint64>(blocks) * 5 / 2}; // 2.5-minute blocks
+    if (minutes < 120) {
+        return Tr("about %n minute(s)", nullptr, static_cast<int>(minutes));
+    }
+    if (minutes < 72 * 60) {
+        return Tr("about %n hour(s)", nullptr, static_cast<int>(minutes / 60));
+    }
+    return Tr("about %n day(s)", nullptr, static_cast<int>((minutes + 720) / 1440));
+}
+
+MnShareSession::PenaltyPreview MnShareSession::penaltyPreview(int actor_index, CAmount fee, int at_height,
+                                                              int registered_height) const
+{
+    std::vector<CAmount> amounts;
+    amounts.reserve(m_shares.size());
+    for (const auto& share : m_shares) {
+        amounts.push_back(share.amount);
+    }
+    return PenaltyPreviewFor(amounts, actor_index, m_terms.earlyPenalty, m_terms.earlyPeriodBlocks, fee, at_height,
+                             registered_height);
+}
+
+MnShareSession::PenaltyPreview MnShareSession::PenaltyPreviewFor(const std::vector<CAmount>& share_amounts,
+                                                                 int actor_index, CAmount early_penalty,
+                                                                 uint32_t early_period_blocks, CAmount fee,
+                                                                 int at_height, int registered_height)
+{
+    PenaltyPreview preview;
+    if (actor_index < 0 || static_cast<size_t>(actor_index) >= share_amounts.size()) {
+        preview.error = Tr("Share index %1 is out of range.").arg(actor_index);
+        return preview;
+    }
+    if (fee <= 0) {
+        preview.error = Tr("The fee must be positive.");
+        return preview;
+    }
+
+    // Mirrors the early-period decision in "protx dissolve": the transaction
+    // would confirm at at_height + 1
+    preview.penaltyFreeHeight = registered_height + static_cast<int>(early_period_blocks);
+    preview.early = static_cast<int64_t>(at_height) + 1 - registered_height < static_cast<int64_t>(early_period_blocks);
+    preview.penalty = preview.early ? early_penalty : 0;
+
+    const CAmount actor_output{share_amounts[actor_index] - preview.penalty - fee};
+    if (actor_output < 0) {
+        preview.error = Tr("The penalty and fee exceed the dissolving participant's share.");
+        return preview;
+    }
+
+    // Mirrors BuildProDisTx: pro-rata bonus with sequential floor, remainder
+    // to the last non-actor share, so the payouts always sum exactly
+    CAmount non_actor_total{0};
+    size_t last_non_actor{0};
+    for (size_t i = 0; i < share_amounts.size(); ++i) {
+        if (static_cast<int>(i) != actor_index) {
+            non_actor_total += share_amounts[i];
+            last_non_actor = i;
+        }
+    }
+    preview.payouts.assign(share_amounts.size(), 0);
+    CAmount distributed{0};
+    for (size_t i = 0; i < share_amounts.size(); ++i) {
+        if (static_cast<int>(i) == actor_index) {
+            preview.payouts[i] = actor_output;
+            continue;
+        }
+        CAmount bonus;
+        if (i == last_non_actor) {
+            bonus = preview.penalty - distributed;
+        } else {
+            arith_uint256 v{static_cast<uint64_t>(preview.penalty)};
+            v *= arith_uint256{static_cast<uint64_t>(share_amounts[i])};
+            v /= arith_uint256{static_cast<uint64_t>(non_actor_total)};
+            bonus = static_cast<CAmount>(v.GetLow64());
+        }
+        distributed += bonus;
+        preview.payouts[i] = share_amounts[i] + bonus;
+    }
+    preview.valid = true;
+    return preview;
+}

--- a/src/qt/mnsharesession.cpp
+++ b/src/qt/mnsharesession.cpp
@@ -328,10 +328,17 @@ bool MnShareSession::fromJson(const UniValue& json, QString& error)
                         error = Tr("Contribution entry %1 in the session file is malformed.").arg(i + 1);
                         return false;
                     }
+                    const int64_t vout{in.find_value("vout").getInt<int64_t>()};
+                    const int64_t sequence{in.find_value("sequence").getInt<int64_t>()};
+                    if (vout < 0 || vout > std::numeric_limits<uint32_t>::max() ||
+                        sequence < 0 || sequence > std::numeric_limits<uint32_t>::max()) {
+                        error = Tr("Contribution entry %1 in the session file is malformed.").arg(i + 1);
+                        return false;
+                    }
                     Input input;
                     input.txid = QString::fromStdString(in.find_value("txid").get_str());
-                    input.vout = static_cast<uint32_t>(in.find_value("vout").getInt<int64_t>());
-                    input.sequence = static_cast<uint32_t>(in.find_value("sequence").getInt<int64_t>());
+                    input.vout = static_cast<uint32_t>(vout);
+                    input.sequence = static_cast<uint32_t>(sequence);
                     if (!IsTxidHex(input.txid)) {
                         error = Tr("Contribution entry %1 in the session file is malformed.").arg(i + 1);
                         return false;
@@ -346,6 +353,10 @@ bool MnShareSession::fromJson(const UniValue& json, QString& error)
                     contribution.hasChange = true;
                     contribution.changeAddress = QString::fromStdString(change.find_value("address").get_str());
                     contribution.changeAmount = change.find_value("amount").getInt<int64_t>();
+                    if (contribution.changeAmount < 0) {
+                        error = Tr("Contribution entry %1 in the session file is malformed.").arg(i + 1);
+                        return false;
+                    }
                 }
                 if (const UniValue& v{entry.find_value("changeIndex")}; v.isNum()) contribution.changeIndex = v.getInt<int>();
                 parsed.m_contributions.push_back(contribution);
@@ -373,6 +384,11 @@ bool MnShareSession::fromJson(const UniValue& json, QString& error)
                 Signature sig;
                 sig.shareIndex = entry.find_value("shareIndex").getInt<int>();
                 sig.signatureB64 = QString::fromStdString(entry.find_value("signature").get_str());
+                if (std::any_of(parsed.m_sigs.begin(), parsed.m_sigs.end(),
+                                [&](const Signature& s) { return s.shareIndex == sig.shareIndex; })) {
+                    error = Tr("The session file lists more than one signature for share %1.").arg(sig.shareIndex + 1);
+                    return false;
+                }
                 parsed.m_sigs.push_back(sig);
             }
         }
@@ -380,10 +396,28 @@ bool MnShareSession::fromJson(const UniValue& json, QString& error)
         if (const UniValue& v{json.find_value("prepareWallet")}; v.isStr()) parsed.m_prepare_wallet = QString::fromStdString(v.get_str());
         if (const UniValue& v{json.find_value("operatorSecretHolder")}; v.isStr()) parsed.m_operator_secret_holder = QString::fromStdString(v.get_str());
 
-        if (parsed.m_stage != Stage::Draft && (parsed.m_protx.isEmpty() || parsed.m_consent_hash.isEmpty())) {
-            error = Tr("The session file is marked \"%1\" but is missing its frozen transaction or consent hash.")
-                        .arg(StageName(parsed.m_stage));
-            return false;
+        if (parsed.m_stage != Stage::Draft) {
+            if (parsed.m_protx.isEmpty() || parsed.m_consent_hash.isEmpty()) {
+                error = Tr("The session file is marked \"%1\" but is missing its frozen transaction or consent hash.")
+                            .arg(StageName(parsed.m_stage));
+                return false;
+            }
+            // A frozen file must register exactly the shares/terms it displays,
+            // and its prepared transaction must match its consent hash
+            CMutableTransaction frozen_tx;
+            CProRegTx frozen_payload;
+            if (!DecodeSharedProTx(parsed.m_protx, frozen_tx, frozen_payload, error)) return false;
+            if (frozen_payload.MakeSharedRegConsentHash(CTransaction(frozen_tx)) != uint256S(parsed.m_consent_hash.toStdString())) {
+                error = Tr("The session file's prepared transaction does not match its consent hash. Do not use it; request a fresh copy.");
+                return false;
+            }
+            if (!parsed.payloadMatchesEnvelope(error)) return false;
+            for (const auto& sig : parsed.m_sigs) {
+                if (sig.shareIndex < 0 || static_cast<size_t>(sig.shareIndex) >= parsed.m_shares.size()) {
+                    error = Tr("The session file has a signature for a share that does not exist.");
+                    return false;
+                }
+            }
         }
 
         *this = std::move(parsed);
@@ -420,7 +454,11 @@ QStringList MnShareSession::validateShares() const
         const QString row{Tr("Share %1:").arg(i + 1)};
         std::optional<CKeyID> key_id;
         if (CTxDestination dest{DecodeDestination(m_shares[i].ownerAddress.toStdString())}; const auto* pkhash = std::get_if<PKHash>(&dest)) {
-            key_id = ToKeyID(*pkhash);
+            if (const CKeyID id{ToKeyID(*pkhash)}; id.IsNull()) {
+                errors << row + QLatin1Char(' ') + Tr("the owner address must be a valid P2PKH address.");
+            } else {
+                key_id = id;
+            }
         } else {
             errors << row + QLatin1Char(' ') + Tr("the owner address must be a valid P2PKH address.");
         }
@@ -612,7 +650,13 @@ bool MnShareSession::freeze(const QString& protx_hex, const QString& consent_has
         error = Tr("The collateral output index does not match the prepared transaction.");
         return false;
     }
+    // The share table and terms the user reviewed must be exactly what the
+    // prepared transaction registers, otherwise the displayed session lies
     m_protx = protx_hex;
+    if (!payloadMatchesEnvelope(error)) {
+        m_protx.clear();
+        return false;
+    }
     m_consent_hash = consent_hash_hex.toLower();
     m_collateral_index = collateral_index;
     m_sigs.clear();
@@ -650,6 +694,9 @@ bool MnShareSession::verifySignature(int share_index, const QString& sig_b64, QS
         error = Tr("The session file is internally inconsistent: its prepared transaction no longer matches its consent hash. Do not sign; request a fresh copy.");
         return false;
     }
+    // A signature over the payload digest is meaningless if the payload is not
+    // the share table the participant reviewed
+    if (!payloadMatchesEnvelope(error)) return false;
     const auto sig{DecodeBase64(sig_b64.toStdString())};
     if (!sig) {
         error = Tr("The signature is not valid base64.");
@@ -685,6 +732,73 @@ const MnShareSession::Signature* MnShareSession::findSignature(int share_index) 
         if (sig.shareIndex == share_index) return &sig;
     }
     return nullptr;
+}
+
+bool MnShareSession::payloadMatchesEnvelope(QString& error) const
+{
+    CMutableTransaction tx;
+    CProRegTx payload;
+    if (!DecodeSharedProTx(m_protx, tx, payload, error)) return false;
+
+    if (payload.shares.size() != m_shares.size()) {
+        error = Tr("The session file's share table does not match its prepared transaction. Do not sign; request a fresh copy.");
+        return false;
+    }
+    for (size_t i = 0; i < m_shares.size(); ++i) {
+        const Share& share{m_shares[i]};
+        const CCollateralShare& signed_share{payload.shares[i]};
+
+        const CTxDestination owner{DecodeDestination(share.ownerAddress.toStdString())};
+        const auto* owner_pkhash{std::get_if<PKHash>(&owner)};
+        if (!owner_pkhash || ToKeyID(*owner_pkhash) != signed_share.keyIDOwner ||
+            share.amount != signed_share.amount ||
+            GetScriptForDestination(DecodeDestination(share.refundAddress.toStdString())) != signed_share.scriptRefund) {
+            error = Tr("Share %1 in the session file does not match its prepared transaction. Do not sign; request a fresh copy.").arg(i + 1);
+            return false;
+        }
+        const CScript expected_reward{share.rewardAddress.isEmpty()
+                                          ? CScript()
+                                          : GetScriptForDestination(DecodeDestination(share.rewardAddress.toStdString()))};
+        if (expected_reward != signed_share.scriptReward) {
+            error = Tr("Share %1's reward address in the session file does not match its prepared transaction. Do not sign; request a fresh copy.").arg(i + 1);
+            return false;
+        }
+    }
+
+    const CTxDestination voting{DecodeDestination(m_terms.votingAddress.toStdString())};
+    const auto* voting_pkhash{std::get_if<PKHash>(&voting)};
+    const bool operator_matches{QString::fromStdString(payload.pubKeyOperator.Get().ToString(/*specificLegacyScheme=*/false))
+                                    .compare(m_terms.operatorPubKey, Qt::CaseInsensitive) == 0};
+    if (!voting_pkhash || ToKeyID(*voting_pkhash) != payload.keyIDVoting ||
+        !operator_matches ||
+        m_terms.operatorReward != payload.nOperatorReward ||
+        m_terms.earlyPeriodBlocks != payload.nEarlyPeriodBlocks ||
+        m_terms.earlyPenalty != payload.nEarlyPenalty) {
+        error = Tr("The terms shown in the session file do not match its prepared transaction. Do not sign; request a fresh copy.");
+        return false;
+    }
+    return true;
+}
+
+bool MnShareSession::sameDraftState(const MnShareSession& other) const
+{
+    if (m_funding_tx != other.m_funding_tx) return false;
+    if (m_shares.size() != other.m_shares.size()) return false;
+    for (size_t i = 0; i < m_shares.size(); ++i) {
+        const Share& a{m_shares[i]};
+        const Share& b{other.m_shares[i]};
+        // Labels are local annotations, not consensus terms; ignore them
+        if (a.amount != b.amount || a.ownerAddress != b.ownerAddress ||
+            a.refundAddress != b.refundAddress || a.rewardAddress != b.rewardAddress) {
+            return false;
+        }
+    }
+    return m_terms.coreP2PAddrs == other.m_terms.coreP2PAddrs &&
+           m_terms.operatorPubKey == other.m_terms.operatorPubKey &&
+           m_terms.votingAddress == other.m_terms.votingAddress &&
+           m_terms.operatorReward == other.m_terms.operatorReward &&
+           m_terms.earlyPeriodBlocks == other.m_terms.earlyPeriodBlocks &&
+           m_terms.earlyPenalty == other.m_terms.earlyPenalty;
 }
 
 bool MnShareSession::addSignature(int share_index, const QString& sig_b64, QString& error)
@@ -770,8 +884,8 @@ MnShareSession::MergeResult MnShareSession::mergeEnvelope(const MnShareSession& 
         return MergeResult::Conflict;
     }
     if (!frozen) {
-        if (m_funding_tx != other.m_funding_tx) {
-            error = Tr("Both copies claim revision %1 but contain different funding contributions. They cannot be merged — the participant who changed funding must bump the revision and re-circulate the file.")
+        if (!sameDraftState(other)) {
+            error = Tr("Both copies claim revision %1 but their share tables, terms or funding differ. They cannot be merged — whoever changed the draft must bump the revision and re-circulate the file.")
                         .arg(m_revision);
             return MergeResult::Conflict;
         }
@@ -787,8 +901,18 @@ MnShareSession::MergeResult MnShareSession::mergeEnvelope(const MnShareSession& 
     }
     // Adopt a further-advanced stage together with its transaction (the protx
     // field evolves along the stages: combined join sigs, then funding
-    // signatures live in the same transaction hex)
+    // signatures live in the same transaction hex). Validate the incoming
+    // transaction the same way the direct setters do so a tampered "advanced"
+    // copy can neither overwrite a good protx nor fake completion.
     if (other.m_stage > m_stage) {
+        CMutableTransaction tx;
+        CProRegTx payload;
+        QString decode_error;
+        if (!DecodeSharedProTx(other.m_protx, tx, payload, decode_error) ||
+            payload.MakeSharedRegConsentHash(CTransaction(tx)) != uint256S(m_consent_hash.toStdString())) {
+            error = Tr("The imported copy claims to be further along but its transaction does not match the terms everyone signed. It was not adopted.");
+            return MergeResult::Conflict;
+        }
         m_stage = other.m_stage;
         m_protx = other.m_protx;
     }
@@ -918,11 +1042,19 @@ MnShareSession::PenaltyPreview MnShareSession::PenaltyPreviewFor(const std::vect
     // to the last non-actor share, so the payouts always sum exactly
     CAmount non_actor_total{0};
     size_t last_non_actor{0};
+    bool have_non_actor{false};
     for (size_t i = 0; i < share_amounts.size(); ++i) {
         if (static_cast<int>(i) != actor_index) {
             non_actor_total += share_amounts[i];
             last_non_actor = i;
+            have_non_actor = true;
         }
+    }
+    // A valid shared masternode always has at least two shares, but guard the
+    // division anyway so a malformed table cannot divide by zero
+    if (!have_non_actor || non_actor_total <= 0) {
+        preview.error = Tr("A unilateral dissolution needs at least one other share to receive the penalty.");
+        return preview;
     }
     preview.payouts.assign(share_amounts.size(), 0);
     CAmount distributed{0};

--- a/src/qt/mnsharesession.h
+++ b/src/qt/mnsharesession.h
@@ -1,0 +1,244 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_MNSHARESESSION_H
+#define BITCOIN_QT_MNSHARESESSION_H
+
+#include <consensus/amount.h>
+
+#include <univalue.h>
+
+#include <QString>
+#include <QStringList>
+
+#include <string>
+#include <vector>
+
+//! Pure-logic engine (no widgets, no QObject) for a shared-masternode
+//! multi-party session. It owns the session envelope: a JSON file passed
+//! between participants that fully describes the session, so any participant
+//! holding the latest copy can continue it.
+//!
+//! Envelope shape (UniValue JSON, version 1):
+//! {type, version, network, sessionId, revision, stage, fundingTx, shares[],
+//!  terms{}, contributions[], protx, consentHash, collateralIndex, sigs[],
+//!  prepareWallet, operatorSecretHolder}
+//!
+//! All amounts are duffs (CAmount). All user-displayable errors come back as
+//! translated QStrings. Signatures are verified natively at import time
+//! (recompute the consent digest from the envelope's protx hex and check each
+//! compact signature against the share owner key); an unverifiable signature
+//! is never counted.
+class MnShareSession
+{
+public:
+    enum class Stage {
+        Draft,         //!< terms and contributions still editable
+        Frozen,        //!< register_shared_prepare done; consent hash fixed
+        Signing,       //!< collecting share owner consent signatures
+        Combined,      //!< shared_combine done; join sigs embedded
+        FundingSigned, //!< every funding input carries its signature
+        Broadcast,     //!< sent to the network
+    };
+
+    enum class MergeResult {
+        Merged,     //!< envelopes were compatible; new data was absorbed
+        OtherNewer, //!< the imported envelope supersedes ours; caller decides
+        OtherOlder, //!< ours supersedes the imported one; nothing absorbed
+        Conflict,   //!< incompatible envelopes; see the error string
+    };
+
+    struct Share {
+        QString label;
+        CAmount amount{0};
+        QString ownerAddress;  //!< P2PKH only (immutable share owner key)
+        QString refundAddress; //!< P2PKH or P2SH, immutable
+        QString rewardAddress; //!< empty = fall back to the refund address
+    };
+
+    struct Input {
+        QString txid; //!< 64 hex chars
+        uint32_t vout{0};
+        //! Fixed at contribution time and never rewritten afterwards: the
+        //! consent digest covers every input's nSequence, so a rewrite after
+        //! freeze would invalidate all collected signatures.
+        uint32_t sequence{0xffffffff};
+    };
+
+    struct Contribution {
+        QString label;
+        std::vector<Input> inputs;
+        bool hasChange{false};
+        QString changeAddress;
+        CAmount changeAmount{0};
+        //! Output index of the change in the built funding transaction;
+        //! recomputed whenever the funding transaction is rebuilt
+        int changeIndex{-1};
+    };
+
+    struct Terms {
+        QString coreP2PAddrs;   //!< ADDR:PORT, or empty for a later ProUpServTx
+        QString operatorPubKey; //!< hex BLS public key (basic scheme)
+        QString votingAddress;  //!< P2PKH
+        int operatorReward{0};  //!< 0..10000, in 1/100 of a percent
+        uint32_t earlyPeriodBlocks{0};
+        CAmount earlyPenalty{0};
+    };
+
+    struct Signature {
+        int shareIndex{-1};
+        QString signatureB64; //!< base64 65-byte compact signature
+    };
+
+    struct SignatureCheck {
+        int shareIndex{-1};
+        bool valid{false};
+        QString error;
+    };
+
+    //! Mirror of the BuildProDisTx output math for previewing a unilateral
+    //! dissolution before it is built
+    struct PenaltyPreview {
+        bool valid{false};
+        QString error;
+        bool early{false};
+        CAmount penalty{0};
+        //! First block height at which a unilateral dissolution is penalty-free
+        int penaltyFreeHeight{0};
+        //! Refund per share index. The actor's entry is principal minus
+        //! penalty minus fee (a zero entry is omitted from the real
+        //! transaction); every other entry is principal plus its pro-rata
+        //! penalty bonus (sequential floor, remainder to the last non-actor).
+        std::vector<CAmount> payouts;
+    };
+
+    //! New Draft session: random sessionId, revision 1, current network
+    MnShareSession();
+
+    Stage stage() const { return m_stage; }
+    QString stageName() const { return StageName(m_stage); }
+    static QString StageName(Stage stage);
+
+    const QString& sessionId() const { return m_session_id; }
+    const QString& network() const { return m_network; }
+    int revision() const { return m_revision; }
+
+    std::vector<Share>& shares() { return m_shares; }
+    const std::vector<Share>& shares() const { return m_shares; }
+    Terms& terms() { return m_terms; }
+    const Terms& terms() const { return m_terms; }
+    const std::vector<Contribution>& contributions() const { return m_contributions; }
+    const std::vector<Signature>& signatures() const { return m_sigs; }
+
+    const QString& fundingTxHex() const { return m_funding_tx; }
+    const QString& protxHex() const { return m_protx; }
+    const QString& consentHash() const { return m_consent_hash; }
+    int collateralIndex() const { return m_collateral_index; }
+
+    const QString& prepareWallet() const { return m_prepare_wallet; }
+    void setPrepareWallet(const QString& name) { m_prepare_wallet = name; }
+    const QString& operatorSecretHolder() const { return m_operator_secret_holder; }
+    void setOperatorSecretHolder(const QString& label) { m_operator_secret_holder = label; }
+
+    //! Serialize the envelope
+    UniValue toJson() const;
+    QString toJsonString() const;
+
+    //! Strict parse of an envelope. The network must match the running node
+    //! (hard error naming both networks) and the stage must be known.
+    //! Signatures are stored as-is; callers must run verifyAllSignatures()
+    //! (or rely on addSignature/mergeEnvelope, which verify) before counting
+    //! them.
+    bool fromJson(const UniValue& json, QString& error);
+    bool fromJson(const std::string& text, QString& error);
+
+    //! All current draft-side share-table problems at once, mirroring the
+    //! consensus checks in IsShareListTriviallyValid (empty list = valid)
+    QStringList validateShares() const;
+
+    //! Draft only: record a participant's funding contribution and rebuild
+    //! the funding transaction deterministically (inputs, then change
+    //! outputs, both in contribution order). Bumps the revision.
+    bool addContribution(const Contribution& contribution, QString& error);
+    //! Draft only: remove a contribution by label and rebuild. Bumps the revision.
+    bool removeContribution(const QString& label, QString& error);
+
+    //! Record the register_shared_prepare result and advance Draft -> Frozen.
+    //! Cross-checks that the protx hex parses as a shared registration and
+    //! that its recomputed consent digest equals consent_hash_hex.
+    bool freeze(const QString& protx_hex, const QString& consent_hash_hex, int collateral_index, QString& error);
+    //! Discard the frozen transaction and all signatures, return to Draft and
+    //! bump the revision (previously collected signatures can never apply again)
+    void unfreeze();
+
+    //! Verify one base64 compact signature against the frozen transaction:
+    //! recompute the consent digest from the protx hex, hard-compare it to
+    //! the stored consentHash, then check the signature against the share
+    //! owner key (canonical encoding required)
+    bool verifySignature(int share_index, const QString& sig_b64, QString& error) const;
+    //! Re-verify every stored signature (import-time verification)
+    std::vector<SignatureCheck> verifyAllSignatures() const;
+
+    //! Store a signature after verifying it. A byte-identical duplicate is a
+    //! silent success; a different signature for an already-signed index is
+    //! rejected as a stale-version conflict.
+    bool addSignature(int share_index, const QString& sig_b64, QString& error);
+    int signedCount() const;
+    std::vector<int> missingIndexes() const;
+    //! Base64 signature for a share index, or empty if not signed yet
+    QString signatureFor(int share_index) const;
+
+    //! Absorb another copy of the same session. Never merges across
+    //! diverging terms: a higher/lower revision or a consent-hash mismatch is
+    //! reported to the caller (supersede dialog) instead. On Merged, the
+    //! union of the other envelope's *verified* signatures is absorbed and a
+    //! further-advanced stage (with its transaction hex) is adopted; error
+    //! carries any skipped-signature warnings even on success.
+    MergeResult mergeEnvelope(const MnShareSession& other, QString& error);
+
+    //! Record the shared_combine result and advance to Combined
+    bool setCombinedTx(const QString& tx_hex, QString& error);
+    //! Record the fully signed funding transaction and advance to FundingSigned
+    bool setFundingSignedTx(const QString& tx_hex, QString& error);
+    //! Mark the session broadcast
+    bool setBroadcast(QString& error);
+
+    //! First 8 hex characters of the consent hash, uppercased: the phrase
+    //! participants read aloud to each other before signing
+    QString consentCheckPhrase() const;
+    //! Approximate duration of a block count at 2.5 minutes per block
+    static QString HumanEarlyPeriod(uint32_t blocks);
+
+    //! Preview of a unilateral dissolution built at chain height at_height
+    //! (the transaction would confirm at at_height + 1), using this
+    //! session's share table and penalty terms
+    PenaltyPreview penaltyPreview(int actor_index, CAmount fee, int at_height, int registered_height) const;
+    //! Same math for an already-registered masternode's share amounts
+    static PenaltyPreview PenaltyPreviewFor(const std::vector<CAmount>& share_amounts, int actor_index,
+                                            CAmount early_penalty, uint32_t early_period_blocks, CAmount fee,
+                                            int at_height, int registered_height);
+
+private:
+    //! Rebuild m_funding_tx from m_contributions (deterministic order) and
+    //! refresh each contribution's changeIndex
+    bool rebuildFundingTx(QString& error);
+    const Signature* findSignature(int share_index) const;
+
+    QString m_network;
+    QString m_session_id;
+    int m_revision{1};
+    Stage m_stage{Stage::Draft};
+    QString m_funding_tx;
+    std::vector<Share> m_shares;
+    Terms m_terms;
+    std::vector<Contribution> m_contributions;
+    QString m_protx;
+    QString m_consent_hash;
+    int m_collateral_index{-1};
+    std::vector<Signature> m_sigs;
+    QString m_prepare_wallet;
+    QString m_operator_secret_holder;
+};
+
+#endif // BITCOIN_QT_MNSHARESESSION_H

--- a/src/qt/mnsharesession.h
+++ b/src/qt/mnsharesession.h
@@ -224,6 +224,15 @@ private:
     //! refresh each contribution's changeIndex
     bool rebuildFundingTx(QString& error);
     const Signature* findSignature(int share_index) const;
+    //! Decode m_protx and require its CProRegTx payload's share table and terms
+    //! to match the envelope's displayed m_shares/m_terms exactly. The displayed
+    //! terms are what a participant reviews before signing, but the wallet signs
+    //! the digest of the *payload*, so a mismatch means the file shows one set of
+    //! terms while a different set would be registered — it must never verify.
+    bool payloadMatchesEnvelope(QString& error) const;
+    //! True when the draft-editable state (shares, terms, contributions) of two
+    //! copies is identical; used to reject silent merges of diverging drafts
+    bool sameDraftState(const MnShareSession& other) const;
 
     QString m_network;
     QString m_session_id;

--- a/src/qt/protxsender.cpp
+++ b/src/qt/protxsender.cpp
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/protxsender.h>
+
+#include <interfaces/node.h>
+#include <qt/walletmodel.h>
+#include <rpc/protocol.h>
+#include <util/threadnames.h>
+
+#include <QTimer>
+#include <QUrl>
+
+namespace {
+//! Consensus/RPC reject substrings worth a friendlier explanation than the raw error
+struct KnownError {
+    const char* needle;
+    const char* explanation;
+};
+const KnownError KNOWN_ERRORS[]{
+    {"bad-protx-dup-key", QT_TRANSLATE_NOOP("ProTxSender", "One of the chosen keys is already in use by a registered masternode or share. Every owner and voting key may be used only once network-wide.")},
+    {"bad-protx-dup-addr", QT_TRANSLATE_NOOP("ProTxSender", "The chosen service address is already in use by a registered masternode.")},
+    {"bad-protx-shares-payee-reuse", QT_TRANSLATE_NOOP("ProTxSender", "A refund or reward address may not double as a share owner or voting address. Use distinct addresses for payouts and keys.")},
+    {"bad-protx-shares-sig", QT_TRANSLATE_NOOP("ProTxSender", "A participant's consent signature does not match the final transaction. This happens when the terms or the funding transaction changed after signing; collect fresh signatures.")},
+    {"bad-protx-version", QT_TRANSLATE_NOOP("ProTxSender", "The network does not accept this transaction version yet. Wait for the v24 hard fork to activate.")},
+    {"too-early", QT_TRANSLATE_NOOP("ProTxSender", "This feature is not active on the network yet. Wait for the v24 hard fork to activate.")},
+    {"bad-prodis-dup", QT_TRANSLATE_NOOP("ProTxSender", "A dissolution for this masternode is already pending.")},
+};
+} // anonymous namespace
+
+//! Runs on ProTxSender's worker thread; the only place executeRpc is called
+class ProTxWorker : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit ProTxWorker(interfaces::Node& node) : m_node{node} {}
+
+public Q_SLOTS:
+    void execute(const QString& method, const QString& params_json, const QString& uri)
+    {
+        ProTxResult ret;
+        try {
+            UniValue params(UniValue::VOBJ);
+            if (!params_json.isEmpty() && !params.read(params_json.toStdString())) {
+                throw std::runtime_error("internal error: invalid parameter encoding");
+            }
+            ret.value = m_node.executeRpc(method.toStdString(), params, uri.toStdString());
+            ret.ok = true;
+        } catch (UniValue& err) {
+            // JSONRPCError shape: {code, message}
+            if (const auto& code{err.find_value("code")}; code.isNum()) {
+                ret.code = code.getInt<int>();
+            }
+            QString message;
+            if (const auto& msg{err.find_value("message")}; msg.isStr()) {
+                message = QString::fromStdString(msg.get_str());
+            } else {
+                message = QString::fromStdString(err.write());
+            }
+            ret.message = ProTxSender::translateError(ret.code, message);
+        } catch (const std::exception& e) {
+            ret.code = RPC_MISC_ERROR;
+            ret.message = QString::fromStdString(e.what());
+        }
+        Q_EMIT result(ret);
+    }
+
+Q_SIGNALS:
+    void result(const ProTxResult& result);
+
+private:
+    interfaces::Node& m_node;
+};
+
+ProTxSender::ProTxSender(interfaces::Node& node, QObject* parent) :
+    QObject(parent)
+{
+    qRegisterMetaType<ProTxResult>("ProTxResult");
+
+    auto* worker = new ProTxWorker(node);
+    worker->moveToThread(&m_thread);
+    connect(&m_thread, &QThread::finished, worker, &QObject::deleteLater);
+    connect(this, &ProTxSender::executeRequested, worker, &ProTxWorker::execute);
+    connect(worker, &ProTxWorker::result, this, [this](const ProTxResult& result) {
+        m_busy = false;
+        Q_EMIT finished(result);
+    });
+
+    m_thread.start();
+    QTimer::singleShot(0, worker, [] { util::ThreadRename("qt-protxsender"); });
+}
+
+ProTxSender::~ProTxSender()
+{
+    m_thread.quit();
+    m_thread.wait();
+}
+
+bool ProTxSender::execute(const QString& method, const UniValue& params, const WalletModel* wallet_model)
+{
+    if (m_busy) return false;
+    m_busy = true;
+
+    QString uri;
+    if (wallet_model) {
+        const QByteArray encoded_name{QUrl::toPercentEncoding(wallet_model->getWalletName())};
+        uri = "/wallet/" + QString::fromUtf8(encoded_name);
+    }
+    Q_EMIT executeRequested(method, QString::fromStdString(params.write()), uri);
+    return true;
+}
+
+QString ProTxSender::translateError(int code, const QString& message)
+{
+    for (const auto& known : KNOWN_ERRORS) {
+        if (message.contains(QLatin1String(known.needle))) {
+            return tr(known.explanation) + "\n\n" + tr("Details: %1").arg(message);
+        }
+    }
+    switch (code) {
+    case RPC_IN_WARMUP:
+        return tr("The node is still starting up. Try again once it has finished.");
+    case RPC_METHOD_NOT_FOUND:
+        return tr("This command is not available. Wallet support may be disabled.");
+    case RPC_WALLET_UNLOCK_NEEDED:
+        return tr("The wallet needs to be unlocked for this action.");
+    default:
+        return message;
+    }
+}
+
+#include <qt/protxsender.moc>

--- a/src/qt/protxsender.h
+++ b/src/qt/protxsender.h
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_PROTXSENDER_H
+#define BITCOIN_QT_PROTXSENDER_H
+
+#include <univalue.h>
+
+#include <QMetaType>
+#include <QObject>
+#include <QString>
+#include <QThread>
+
+class WalletModel;
+
+namespace interfaces {
+class Node;
+} // namespace interfaces
+
+//! Outcome of a single RPC command executed by ProTxSender
+struct ProTxResult
+{
+    bool ok{false};
+    UniValue value;   //!< RPC result when ok
+    int code{0};      //!< RPC error code otherwise
+    QString message;  //!< user-displayable error otherwise
+};
+
+Q_DECLARE_METATYPE(ProTxResult)
+
+//! The GUI's write path for masternode management: runs protx (and related) RPC
+//! commands with named arguments on a dedicated worker thread against the wallet
+//! selected by a WalletModel, and translates RPC errors into user-displayable
+//! messages. Named-argument dispatch keeps the GUI independent of RPC parameter
+//! order. Commands are serialized; one instance is meant to be owned per dialog.
+class ProTxSender : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit ProTxSender(interfaces::Node& node, QObject* parent = nullptr);
+    ~ProTxSender() override;
+
+    //! True while a command is executing
+    bool isBusy() const { return m_busy; }
+
+    //! Execute `method` (the full command name, e.g. "protx register_fund") with
+    //! named `params` against `wallet_model`'s wallet (nullptr for node-level
+    //! commands). The outcome arrives via finished(). Returns false when a
+    //! command is already in flight.
+    bool execute(const QString& method, const UniValue& params, const WalletModel* wallet_model);
+
+    //! Map an RPC error to a message a user can act on
+    static QString translateError(int code, const QString& message);
+
+Q_SIGNALS:
+    void finished(const ProTxResult& result);
+    //! Internal handoff to the worker thread
+    void executeRequested(const QString& method, const QString& params_json, const QString& uri);
+
+private:
+    QThread m_thread;
+    bool m_busy{false};
+};
+
+#endif // BITCOIN_QT_PROTXSENDER_H

--- a/src/qt/sharedmncreatedialog.cpp
+++ b/src/qt/sharedmncreatedialog.cpp
@@ -1,0 +1,1764 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/sharedmncreatedialog.h>
+
+#include <coins.h>
+#include <core_io.h>
+#include <evo/dmn_types.h>
+#include <evo/providertx.h>
+#include <interfaces/node.h>
+#include <interfaces/wallet.h>
+#include <key_io.h>
+#include <primitives/transaction.h>
+#include <script/standard.h>
+#include <uint256.h>
+#include <univalue.h>
+#include <wallet/coincontrol.h>
+
+#include <qt/bitcoinamountfield.h>
+#include <qt/bitcoinunits.h>
+#include <qt/guiutil.h>
+#include <qt/masternodewidgets.h>
+#include <qt/optionsmodel.h>
+#include <qt/protxsender.h>
+#include <qt/sendcoinsrecipient.h>
+#include <qt/walletmodel.h>
+#include <qt/walletmodeltransaction.h>
+
+#include <QApplication>
+#include <QCheckBox>
+#include <QClipboard>
+#include <QComboBox>
+#include <QDoubleSpinBox>
+#include <QEventLoop>
+#include <QFile>
+#include <QFormLayout>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QLabel>
+#include <QLineEdit>
+#include <QListWidget>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QSpinBox>
+#include <QStackedWidget>
+#include <QTableWidget>
+#include <QTableWidgetItem>
+#include <QVBoxLayout>
+
+#include <algorithm>
+#include <map>
+#include <memory>
+#include <utility>
+
+namespace {
+
+constexpr int COL_LABEL{0};
+constexpr int COL_AMOUNT{1};
+constexpr int COL_OWNER{2};
+constexpr int COL_REFUND{3};
+constexpr int COL_REWARD{4};
+
+constexpr int FEE_UTXO_TXID_ROLE{Qt::UserRole};
+constexpr int FEE_UTXO_VOUT_ROLE{Qt::UserRole + 1};
+constexpr int FEE_UTXO_VALUE_ROLE{Qt::UserRole + 2};
+
+QLabel* MakeHint(const QString& text, QWidget* parent)
+{
+    auto* label{new QLabel(text, parent)};
+    label->setWordWrap(true);
+    return label;
+}
+
+QString FormatAmount(const WalletModel* wallet_model, CAmount amount)
+{
+    const auto unit{wallet_model && wallet_model->getOptionsModel() ?
+                        wallet_model->getOptionsModel()->getDisplayUnit() :
+                        BitcoinUnits::Unit::DASH};
+    return BitcoinUnits::formatWithUnit(unit, amount, /*plussign=*/false, BitcoinUnits::SeparatorStyle::ALWAYS);
+}
+
+//! Editable-cell representation of an amount: plain DASH decimal that
+//! BitcoinUnits::parse round-trips
+QString AmountCellText(CAmount amount)
+{
+    return BitcoinUnits::format(BitcoinUnits::Unit::DASH, amount, /*plussign=*/false,
+                                BitcoinUnits::SeparatorStyle::NEVER);
+}
+
+QString OutpointKey(const QString& txid, uint32_t vout)
+{
+    return txid.toLower() + QLatin1Char(':') + QString::number(vout);
+}
+
+//! scriptSig presence per input of a serialized transaction, keyed by
+//! lowercase "txid:vout"; empty map when the hex does not decode
+std::map<QString, bool> InputSignatureMap(const QString& tx_hex)
+{
+    std::map<QString, bool> ret;
+    CMutableTransaction tx;
+    if (!DecodeHexTx(tx, tx_hex.toStdString())) return ret;
+    for (const auto& in : tx.vin) {
+        ret[OutpointKey(QString::fromStdString(in.prevout.hash.ToString()), in.prevout.n)] = !in.scriptSig.empty();
+    }
+    return ret;
+}
+
+QString ShareDisplayLabel(const MnShareSession& session, int index)
+{
+    if (index >= 0 && static_cast<size_t>(index) < session.shares().size() &&
+        !session.shares()[index].label.isEmpty()) {
+        return session.shares()[index].label;
+    }
+    return QObject::tr("share %1").arg(index + 1);
+}
+
+} // anonymous namespace
+
+SharedMnCreateDialog::SharedMnCreateDialog(interfaces::Node& node, WalletModel* wallet_model, QWidget* parent) :
+    QDialog(parent),
+    m_node{node},
+    m_wallet_model{wallet_model},
+    m_v24_active{node.isV24Active()},
+    m_sender{new ProTxSender(node, this)}
+{
+    setMinimumSize(980, 720);
+
+    auto* layout = new QVBoxLayout(this);
+    layout->addWidget(buildHeader());
+
+    m_pages = new QStackedWidget(this);
+    m_pages->insertWidget(PageDraft, buildDraftPage());
+    m_pages->insertWidget(PageSigning, buildSigningPage());
+    m_pages->insertWidget(PageCombined, buildCombinedPage());
+    m_pages->insertWidget(PageBroadcast, buildBroadcastPage());
+    m_pages->insertWidget(PageDead, buildDeadPage());
+    layout->addWidget(m_pages, /*stretch=*/1);
+
+    GUIUtil::updateFonts();
+    refreshFundingCandidates();
+    refreshAll();
+}
+
+SharedMnCreateDialog::~SharedMnCreateDialog() = default;
+
+QWidget* SharedMnCreateDialog::buildHeader()
+{
+    auto* header = new QWidget(this);
+    auto* layout = new QVBoxLayout(header);
+    layout->setContentsMargins(0, 0, 0, 0);
+
+    auto* top_row = new QHBoxLayout();
+    m_breadcrumb = new QLabel(header);
+    m_breadcrumb->setTextFormat(Qt::RichText);
+    top_row->addWidget(m_breadcrumb, /*stretch=*/1);
+
+    m_import_button = new QPushButton(tr("Import"), header);
+    m_import_button->setToolTip(tr("Merge a session copy from the clipboard into this session."));
+    connect(m_import_button, &QPushButton::clicked, this, &SharedMnCreateDialog::importFromClipboard);
+    top_row->addWidget(m_import_button);
+
+    m_load_button = new QPushButton(tr("Load…"), header);
+    m_load_button->setToolTip(tr("Merge a session file into this session."));
+    connect(m_load_button, &QPushButton::clicked, this, &SharedMnCreateDialog::loadFromFile);
+    top_row->addWidget(m_load_button);
+
+    m_export_button = new QPushButton(tr("Export"), header);
+    m_export_button->setToolTip(tr("Copy this session to the clipboard to pass to another participant."));
+    connect(m_export_button, &QPushButton::clicked, this, &SharedMnCreateDialog::exportToClipboard);
+    top_row->addWidget(m_export_button);
+
+    m_save_button = new QPushButton(tr("Save…"), header);
+    m_save_button->setToolTip(tr("Save this session to a file to pass to another participant."));
+    connect(m_save_button, &QPushButton::clicked, this, &SharedMnCreateDialog::saveToFile);
+    top_row->addWidget(m_save_button);
+    layout->addLayout(top_row);
+
+    layout->addWidget(MakeHint(tr("This file is the session — any participant with the latest copy can continue it."),
+                               header));
+
+    m_phrase_label = new QLabel(header);
+    m_phrase_label->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    m_phrase_label->setAlignment(Qt::AlignCenter);
+    GUIUtil::setFont({m_phrase_label}, GUIUtil::FontWeight::Bold, 22);
+    layout->addWidget(m_phrase_label);
+
+    m_phrase_hint = MakeHint(tr("Check phrase — read this aloud to the other participants before signing. Everyone "
+                                "must see the same phrase; a different phrase means different terms."),
+                             header);
+    m_phrase_hint->setAlignment(Qt::AlignCenter);
+    layout->addWidget(m_phrase_hint);
+
+    return header;
+}
+
+QWidget* SharedMnCreateDialog::buildDraftPage()
+{
+    auto* page = new QWidget(this);
+    auto* layout = new QVBoxLayout(page);
+
+    auto* shares_box = new QGroupBox(tr("Shares (2–8 participants, amounts must sum to the collateral)"), page);
+    auto* shares_layout = new QVBoxLayout(shares_box);
+    m_share_table = new QTableWidget(0, 5, shares_box);
+    m_share_table->setHorizontalHeaderLabels(
+        {tr("Label"), tr("Amount (DASH)"), tr("Owner address"), tr("Refund address"), tr("Reward address (optional)")});
+    m_share_table->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
+    m_share_table->horizontalHeader()->setSectionResizeMode(COL_LABEL, QHeaderView::ResizeToContents);
+    m_share_table->horizontalHeader()->setSectionResizeMode(COL_AMOUNT, QHeaderView::ResizeToContents);
+    m_share_table->verticalHeader()->setVisible(false);
+    connect(m_share_table, &QTableWidget::cellChanged, this, &SharedMnCreateDialog::onShareCellChanged);
+    shares_layout->addWidget(m_share_table);
+
+    auto* share_buttons = new QHBoxLayout();
+    m_add_share_button = new QPushButton(tr("Add Share"), shares_box);
+    connect(m_add_share_button, &QPushButton::clicked, this, &SharedMnCreateDialog::addShareRow);
+    share_buttons->addWidget(m_add_share_button);
+    m_remove_share_button = new QPushButton(tr("Remove Share"), shares_box);
+    connect(m_remove_share_button, &QPushButton::clicked, this, &SharedMnCreateDialog::removeShareRow);
+    share_buttons->addWidget(m_remove_share_button);
+    m_my_address_button = new QPushButton(tr("Use My Wallet Address"), shares_box);
+    m_my_address_button->setToolTip(tr("Fill the selected owner, refund or reward cell with a fresh address from "
+                                       "this wallet."));
+    connect(m_my_address_button, &QPushButton::clicked, this, &SharedMnCreateDialog::useMyWalletAddress);
+    share_buttons->addWidget(m_my_address_button);
+    share_buttons->addStretch();
+    m_sum_label = new QLabel(shares_box);
+    share_buttons->addWidget(m_sum_label);
+    shares_layout->addLayout(share_buttons);
+    layout->addWidget(shares_box);
+
+    auto* middle = new QHBoxLayout();
+
+    auto* terms_box = new QGroupBox(tr("Terms"), page);
+    auto* terms_form = new QFormLayout(terms_box);
+
+    m_service_edit = new QLineEdit(terms_box);
+    m_service_edit->setPlaceholderText(tr("IP:PORT — leave empty to set later with a service update"));
+    connect(m_service_edit, &QLineEdit::textChanged, this, &SharedMnCreateDialog::onTermsChanged);
+    terms_form->addRow(tr("Service address:"), m_service_edit);
+
+    m_operator_widget = new OperatorKeyWidget(terms_box);
+    connect(m_operator_widget, &OperatorKeyWidget::changed, this, &SharedMnCreateDialog::onTermsChanged);
+    terms_form->addRow(tr("Operator key:"), m_operator_widget);
+
+    m_operator_secret_label = new QLabel(terms_box);
+    m_operator_secret_label->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    m_operator_secret_label->setWordWrap(true);
+    m_operator_secret_label->setVisible(false);
+    terms_form->addRow(QString(), m_operator_secret_label);
+
+    m_secret_holder_edit = new QLineEdit(terms_box);
+    m_secret_holder_edit->setPlaceholderText(tr("Participant label, e.g. Alice"));
+    m_secret_holder_edit->setToolTip(tr("Recorded in the session so everyone knows who can start and revive the "
+                                        "masternode."));
+    connect(m_secret_holder_edit, &QLineEdit::textChanged, this, &SharedMnCreateDialog::onTermsChanged);
+    terms_form->addRow(tr("Operator secret held by:"), m_secret_holder_edit);
+
+    m_voting_edit = new QLineEdit(terms_box);
+    m_voting_edit->setPlaceholderText(tr("P2PKH address of the voting key"));
+    connect(m_voting_edit, &QLineEdit::textChanged, this, &SharedMnCreateDialog::onTermsChanged);
+    terms_form->addRow(tr("Voting address:"), m_voting_edit);
+
+    m_operator_reward_spin = new QDoubleSpinBox(terms_box);
+    m_operator_reward_spin->setRange(0.0, 100.0);
+    m_operator_reward_spin->setDecimals(2);
+    m_operator_reward_spin->setSuffix(QStringLiteral(" %"));
+    connect(m_operator_reward_spin, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this,
+            &SharedMnCreateDialog::onTermsChanged);
+    terms_form->addRow(tr("Operator reward:"), m_operator_reward_spin);
+
+    m_early_period_spin = new QSpinBox(terms_box);
+    m_early_period_spin->setRange(0, static_cast<int>(CProRegTx::MAX_EARLY_PERIOD_BLOCKS));
+    connect(m_early_period_spin, QOverload<int>::of(&QSpinBox::valueChanged), this,
+            &SharedMnCreateDialog::onTermsChanged);
+    m_early_period_hint = new QLabel(terms_box);
+    auto* early_period_box = new QVBoxLayout();
+    early_period_box->addWidget(m_early_period_spin);
+    early_period_box->addWidget(m_early_period_hint);
+    terms_form->addRow(tr("Early period (blocks):"), early_period_box);
+
+    m_early_penalty_field = new BitcoinAmountField(terms_box);
+    connect(m_early_penalty_field, &BitcoinAmountField::valueChanged, this, &SharedMnCreateDialog::onTermsChanged);
+    m_early_penalty_hint = new QLabel(terms_box);
+    m_early_penalty_hint->setWordWrap(true);
+    auto* early_penalty_box = new QVBoxLayout();
+    early_penalty_box->addWidget(m_early_penalty_field);
+    early_penalty_box->addWidget(m_early_penalty_hint);
+    terms_form->addRow(tr("Early penalty:"), early_penalty_box);
+
+    middle->addWidget(terms_box, /*stretch=*/1);
+
+    auto* right_column = new QVBoxLayout();
+
+    auto* validation_box = new QGroupBox(tr("Validation"), page);
+    auto* validation_layout = new QVBoxLayout(validation_box);
+    m_validation_list = new QListWidget(validation_box);
+    m_validation_list->setSelectionMode(QAbstractItemView::NoSelection);
+    m_validation_list->setFocusPolicy(Qt::NoFocus);
+    validation_layout->addWidget(m_validation_list);
+    right_column->addWidget(validation_box, /*stretch=*/1);
+
+    auto* funding_box = new QGroupBox(tr("Funding"), page);
+    auto* funding_layout = new QVBoxLayout(funding_box);
+    funding_layout->addWidget(
+        MakeHint(tr("Each participant contributes a single output of exactly their total share amount. The "
+                    "coordinator additionally contributes one small input to pay the transaction fee and takes "
+                    "the only change output."),
+                 funding_box));
+
+    auto* funding_form = new QFormLayout();
+    m_my_label_edit = new QLineEdit(funding_box);
+    m_my_label_edit->setPlaceholderText(tr("How the other participants know you, e.g. Alice"));
+    funding_form->addRow(tr("My participant label:"), m_my_label_edit);
+
+    m_coordinator_check = new QCheckBox(tr("I am the coordinator (add the fee input and take the change)"), funding_box);
+    funding_form->addRow(QString(), m_coordinator_check);
+
+    m_fee_amount_field = new BitcoinAmountField(funding_box);
+    m_fee_amount_field->setValue(100000); // 0.001 DASH covers even a maximal 8-share registration
+    funding_form->addRow(tr("Transaction fee:"), m_fee_amount_field);
+
+    m_fee_utxo_combo = new QComboBox(funding_box);
+    m_fee_utxo_combo->setToolTip(tr("A small wallet output the coordinator adds to pay the fee from."));
+    funding_form->addRow(tr("Fee input:"), m_fee_utxo_combo);
+    funding_layout->addLayout(funding_form);
+
+    auto* funding_buttons = new QHBoxLayout();
+    m_add_funding_button = new QPushButton(tr("Add My Funding"), funding_box);
+    connect(m_add_funding_button, &QPushButton::clicked, this, &SharedMnCreateDialog::addMyFunding);
+    funding_buttons->addWidget(m_add_funding_button);
+    m_remove_funding_button = new QPushButton(tr("Remove Selected"), funding_box);
+    connect(m_remove_funding_button, &QPushButton::clicked, this, &SharedMnCreateDialog::removeSelectedContribution);
+    funding_buttons->addWidget(m_remove_funding_button);
+    m_refresh_funding_button = new QPushButton(tr("Refresh"), funding_box);
+    connect(m_refresh_funding_button, &QPushButton::clicked, this, &SharedMnCreateDialog::refreshFundingCandidates);
+    funding_buttons->addWidget(m_refresh_funding_button);
+    funding_buttons->addStretch();
+    funding_layout->addLayout(funding_buttons);
+
+    m_contrib_list = new QListWidget(funding_box);
+    m_contrib_list->setToolTip(tr("Funding contributions recorded in the session."));
+    funding_layout->addWidget(m_contrib_list);
+    m_funding_status_label = new QLabel(funding_box);
+    m_funding_status_label->setWordWrap(true);
+    funding_layout->addWidget(m_funding_status_label);
+    right_column->addWidget(funding_box, /*stretch=*/2);
+
+    middle->addLayout(right_column, /*stretch=*/1);
+    layout->addLayout(middle, /*stretch=*/1);
+
+    auto* freeze_row = new QHBoxLayout();
+    freeze_row->addStretch();
+    m_freeze_button = new QPushButton(tr("Freeze Terms…"), page);
+    connect(m_freeze_button, &QPushButton::clicked, this, &SharedMnCreateDialog::freezeSession);
+    freeze_row->addWidget(m_freeze_button);
+    layout->addLayout(freeze_row);
+
+    if (m_wallet_model == nullptr) {
+        for (QPushButton* button : {m_my_address_button, m_add_funding_button, m_remove_funding_button}) {
+            button->setEnabled(false);
+            button->setToolTip(tr("No wallet is available."));
+        }
+    }
+    return page;
+}
+
+QWidget* SharedMnCreateDialog::buildSigningPage()
+{
+    auto* page = new QWidget(this);
+    auto* layout = new QVBoxLayout(page);
+
+    auto* sheet_box = new QGroupBox(tr("Frozen terms"), page);
+    auto* sheet_layout = new QVBoxLayout(sheet_box);
+    m_term_sheet = new QLabel(sheet_box);
+    m_term_sheet->setTextFormat(Qt::RichText);
+    m_term_sheet->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    m_term_sheet->setWordWrap(true);
+    sheet_layout->addWidget(m_term_sheet);
+    layout->addWidget(sheet_box, /*stretch=*/1);
+
+    auto* sigs_box = new QGroupBox(tr("Consent signatures"), page);
+    auto* sigs_layout = new QVBoxLayout(sigs_box);
+    m_sig_table = new QTableWidget(0, 3, sigs_box);
+    m_sig_table->setHorizontalHeaderLabels({tr("Share"), tr("Participant"), tr("Status")});
+    m_sig_table->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
+    m_sig_table->horizontalHeader()->setStretchLastSection(true);
+    m_sig_table->verticalHeader()->setVisible(false);
+    m_sig_table->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    m_sig_table->setSelectionMode(QAbstractItemView::NoSelection);
+    sigs_layout->addWidget(m_sig_table);
+
+    auto* sign_row = new QHBoxLayout();
+    m_sign_button = new QPushButton(tr("Sign With This Wallet"), sigs_box);
+    connect(m_sign_button, &QPushButton::clicked, this, &SharedMnCreateDialog::signConsent);
+    sign_row->addWidget(m_sign_button);
+    m_unfreeze_button = new QPushButton(tr("Unfreeze…"), sigs_box);
+    m_unfreeze_button->setToolTip(tr("Return the session to a draft. All collected signatures are discarded."));
+    connect(m_unfreeze_button, &QPushButton::clicked, this, &SharedMnCreateDialog::unfreezeSession);
+    sign_row->addWidget(m_unfreeze_button);
+    sign_row->addStretch();
+    sigs_layout->addLayout(sign_row);
+    layout->addWidget(sigs_box, /*stretch=*/1);
+
+    return page;
+}
+
+QWidget* SharedMnCreateDialog::buildCombinedPage()
+{
+    auto* page = new QWidget(this);
+    auto* layout = new QVBoxLayout(page);
+
+    m_combined_status = new QLabel(page);
+    m_combined_status->setWordWrap(true);
+    layout->addWidget(m_combined_status);
+
+    auto* combine_row = new QHBoxLayout();
+    m_combine_button = new QPushButton(tr("Combine Signatures"), page);
+    m_combine_button->setToolTip(tr("Embed every share owner's consent signature into the transaction."));
+    connect(m_combine_button, &QPushButton::clicked, this, &SharedMnCreateDialog::combineSignatures);
+    combine_row->addWidget(m_combine_button);
+    combine_row->addStretch();
+    layout->addLayout(combine_row);
+
+    auto* funding_box = new QGroupBox(tr("Funding signatures"), page);
+    auto* funding_layout = new QVBoxLayout(funding_box);
+    funding_layout->addWidget(
+        MakeHint(tr("After combining, every contributor signs their own funding inputs in turn. Pass the session "
+                    "to the next participant listed as pending."),
+                 funding_box));
+    m_funding_sig_list = new QListWidget(funding_box);
+    m_funding_sig_list->setSelectionMode(QAbstractItemView::NoSelection);
+    m_funding_sig_list->setFocusPolicy(Qt::NoFocus);
+    funding_layout->addWidget(m_funding_sig_list);
+
+    auto* sign_row = new QHBoxLayout();
+    m_sign_funding_button = new QPushButton(tr("Sign Funding Inputs With This Wallet"), funding_box);
+    connect(m_sign_funding_button, &QPushButton::clicked, this, &SharedMnCreateDialog::signFundingInputs);
+    sign_row->addWidget(m_sign_funding_button);
+    sign_row->addStretch();
+    funding_layout->addLayout(sign_row);
+    layout->addWidget(funding_box, /*stretch=*/1);
+
+    return page;
+}
+
+QWidget* SharedMnCreateDialog::buildBroadcastPage()
+{
+    auto* page = new QWidget(this);
+    auto* layout = new QVBoxLayout(page);
+
+    m_broadcast_summary = new QLabel(page);
+    m_broadcast_summary->setTextFormat(Qt::RichText);
+    m_broadcast_summary->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    m_broadcast_summary->setWordWrap(true);
+    layout->addWidget(m_broadcast_summary);
+
+    auto* broadcast_row = new QHBoxLayout();
+    m_broadcast_button = new QPushButton(tr("Broadcast"), page);
+    connect(m_broadcast_button, &QPushButton::clicked, this, &SharedMnCreateDialog::broadcastSession);
+    broadcast_row->addWidget(m_broadcast_button);
+    broadcast_row->addStretch();
+    layout->addLayout(broadcast_row);
+
+    m_success_label = new QLabel(page);
+    m_success_label->setTextFormat(Qt::RichText);
+    m_success_label->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    m_success_label->setWordWrap(true);
+    m_success_label->setVisible(false);
+    layout->addWidget(m_success_label);
+    layout->addStretch();
+
+    return page;
+}
+
+QWidget* SharedMnCreateDialog::buildDeadPage()
+{
+    auto* page = new QWidget(this);
+    auto* layout = new QVBoxLayout(page);
+    layout->addStretch();
+
+    auto* title = new QLabel(tr("This session is dead"), page);
+    title->setAlignment(Qt::AlignCenter);
+    GUIUtil::setFont({title}, GUIUtil::FontWeight::Bold, 18);
+    layout->addWidget(title);
+
+    m_dead_label = new QLabel(page);
+    m_dead_label->setWordWrap(true);
+    m_dead_label->setAlignment(Qt::AlignCenter);
+    layout->addWidget(m_dead_label);
+
+    auto* restart_row = new QHBoxLayout();
+    restart_row->addStretch();
+    auto* restart_button = new QPushButton(tr("Unlock My Coins and Restart From Draft"), page);
+    connect(restart_button, &QPushButton::clicked, this, &SharedMnCreateDialog::restartFromDraft);
+    restart_row->addWidget(restart_button);
+    restart_row->addStretch();
+    layout->addLayout(restart_row);
+    layout->addStretch();
+
+    return page;
+}
+
+bool SharedMnCreateDialog::canSign() const
+{
+    return m_wallet_model != nullptr && !m_wallet_model->wallet().privateKeysDisabled();
+}
+
+bool SharedMnCreateDialog::runRpc(const QString& method, const UniValue& params, bool needs_unlock, ProTxResult& result)
+{
+    if (m_busy) return false;
+
+    // UnlockContext is neither copyable nor movable: keep it on this stack
+    // frame and wait in a nested event loop until the worker thread reports back
+    struct UnlockHolder {
+        WalletModel::UnlockContext ctx;
+        explicit UnlockHolder(WalletModel& wallet_model) : ctx(wallet_model.requestUnlock()) {}
+    };
+    std::unique_ptr<UnlockHolder> unlock;
+    if (needs_unlock) {
+        if (!canSign()) return false;
+        unlock = std::make_unique<UnlockHolder>(*m_wallet_model);
+        if (!unlock->ctx.isValid()) return false;
+    }
+
+    setBusy(true);
+    QEventLoop loop;
+    connect(m_sender, &ProTxSender::finished, &loop, [&](const ProTxResult& r) {
+        result = r;
+        loop.quit();
+    });
+    if (!m_sender->execute(method, params, m_wallet_model)) {
+        setBusy(false);
+        return false;
+    }
+    loop.exec();
+    setBusy(false);
+    return true;
+}
+
+void SharedMnCreateDialog::setBusy(bool busy)
+{
+    m_busy = busy;
+    if (busy) {
+        QApplication::setOverrideCursor(Qt::WaitCursor);
+    } else {
+        QApplication::restoreOverrideCursor();
+    }
+    m_pages->setEnabled(!busy);
+    for (QPushButton* button : {m_import_button, m_load_button, m_export_button, m_save_button}) {
+        button->setEnabled(!busy);
+    }
+}
+
+void SharedMnCreateDialog::refreshAll()
+{
+    refreshHeader();
+    if (m_dead) {
+        m_dead_label->setText(m_dead_reason);
+        m_pages->setCurrentIndex(PageDead);
+        return;
+    }
+    const int total{static_cast<int>(m_session.shares().size())};
+    const bool all_signed{total > 0 && m_session.signedCount() == total};
+    switch (m_session.stage()) {
+    case MnShareSession::Stage::Draft:
+        refreshDraftPage();
+        m_pages->setCurrentIndex(PageDraft);
+        break;
+    case MnShareSession::Stage::Frozen:
+    case MnShareSession::Stage::Signing:
+        if (all_signed) {
+            refreshCombinedPage();
+            m_pages->setCurrentIndex(PageCombined);
+        } else {
+            refreshSigningPage();
+            m_pages->setCurrentIndex(PageSigning);
+        }
+        break;
+    case MnShareSession::Stage::Combined:
+        refreshCombinedPage();
+        m_pages->setCurrentIndex(PageCombined);
+        break;
+    case MnShareSession::Stage::FundingSigned:
+    case MnShareSession::Stage::Broadcast:
+        refreshBroadcastPage();
+        m_pages->setCurrentIndex(PageBroadcast);
+        break;
+    }
+}
+
+void SharedMnCreateDialog::refreshHeader()
+{
+    setWindowTitle(tr("Shared Masternode Session %1").arg(m_session.sessionId().left(8)));
+
+    QStringList crumbs;
+    for (const auto stage : {MnShareSession::Stage::Draft, MnShareSession::Stage::Frozen,
+                             MnShareSession::Stage::Signing, MnShareSession::Stage::Combined,
+                             MnShareSession::Stage::FundingSigned, MnShareSession::Stage::Broadcast}) {
+        const QString name{MnShareSession::StageName(stage).toHtmlEscaped()};
+        crumbs << (stage == m_session.stage() ? QStringLiteral("<b>%1</b>").arg(name) : name);
+    }
+    m_breadcrumb->setText(crumbs.join(QStringLiteral(" → ")) +
+                          QStringLiteral(" &nbsp;·&nbsp; ") + tr("revision %1").arg(m_session.revision()));
+
+    const bool show_phrase{!m_dead && m_session.stage() != MnShareSession::Stage::Draft &&
+                           !m_session.consentHash().isEmpty()};
+    m_phrase_label->setVisible(show_phrase);
+    m_phrase_hint->setVisible(show_phrase);
+    if (show_phrase) {
+        m_phrase_label->setText(m_session.consentCheckPhrase());
+    }
+}
+
+void SharedMnCreateDialog::refreshDraftPage()
+{
+    refreshSharesTable();
+    pushTermsToWidgets();
+    refreshContributions();
+    refreshValidation();
+}
+
+void SharedMnCreateDialog::refreshSharesTable()
+{
+    m_updating = true;
+    const auto& shares{m_session.shares()};
+    m_share_table->setRowCount(static_cast<int>(shares.size()));
+    for (int row = 0; row < static_cast<int>(shares.size()); ++row) {
+        const auto& share{shares[row]};
+        const auto set_cell = [this, row](int column, const QString& text) {
+            auto* item = m_share_table->item(row, column);
+            if (item == nullptr) {
+                item = new QTableWidgetItem();
+                m_share_table->setItem(row, column, item);
+            }
+            item->setText(text);
+        };
+        set_cell(COL_LABEL, share.label);
+        set_cell(COL_AMOUNT, share.amount > 0 ? AmountCellText(share.amount) : QString());
+        set_cell(COL_OWNER, share.ownerAddress);
+        set_cell(COL_REFUND, share.refundAddress);
+        set_cell(COL_REWARD, share.rewardAddress);
+    }
+    m_updating = false;
+    m_add_share_button->setEnabled(shares.size() < CProRegTx::MAX_SHARES);
+}
+
+void SharedMnCreateDialog::refreshValidation()
+{
+    const QStringList errors{m_session.validateShares()};
+    m_validation_list->clear();
+    if (errors.isEmpty()) {
+        auto* item = new QListWidgetItem(tr("The share table and terms are valid."), m_validation_list);
+        item->setForeground(Qt::darkGreen);
+    } else {
+        for (const QString& error : errors) {
+            new QListWidgetItem(error, m_validation_list);
+        }
+    }
+
+    const CAmount required{GetMnType(MnType::Regular).collat_amount};
+    CAmount total{0};
+    CAmount min_share{0};
+    for (const auto& share : m_session.shares()) {
+        total += share.amount;
+        if (share.amount > 0 && (min_share == 0 || share.amount < min_share)) min_share = share.amount;
+    }
+    m_sum_label->setText(tr("%1 of %2").arg(FormatAmount(m_wallet_model, total), FormatAmount(m_wallet_model, required)));
+
+    m_early_period_hint->setText(MnShareSession::HumanEarlyPeriod(static_cast<uint32_t>(m_early_period_spin->value())));
+    if (min_share > 0) {
+        m_early_penalty_field->SetMaxValue(min_share - 1);
+        m_early_penalty_hint->setText(tr("Paid by a participant who dissolves unilaterally during the early period; "
+                                         "must stay below the smallest share (%1).")
+                                          .arg(FormatAmount(m_wallet_model, min_share)));
+    } else {
+        m_early_penalty_hint->setText(tr("Paid by a participant who dissolves unilaterally during the early period; "
+                                         "must stay below the smallest share."));
+    }
+
+    const bool can_freeze{m_v24_active && errors.isEmpty() && !m_session.contributions().empty() && !m_busy};
+    m_freeze_button->setEnabled(can_freeze);
+    if (!m_v24_active) {
+        m_freeze_button->setToolTip(tr("Shared masternodes require the v24 hard fork to be active."));
+    } else if (errors.isEmpty() && m_session.contributions().empty()) {
+        m_freeze_button->setToolTip(tr("Add at least one funding contribution first."));
+    } else {
+        m_freeze_button->setToolTip(tr("Prepare the registration transaction and fix the terms. After freezing, "
+                                       "every share owner signs the consent check phrase."));
+    }
+}
+
+void SharedMnCreateDialog::refreshContributions()
+{
+    m_contrib_list->clear();
+    CAmount resolved_total{0};
+    int unknown_inputs{0};
+    for (const auto& contribution : m_session.contributions()) {
+        CAmount resolved{0};
+        int unknown{0};
+        for (const auto& input : contribution.inputs) {
+            Coin coin;
+            if (m_node.getUnspentOutput(COutPoint(uint256S(input.txid.toStdString()), input.vout), coin)) {
+                resolved += coin.out.nValue;
+            } else {
+                ++unknown;
+            }
+        }
+        resolved_total += resolved;
+        unknown_inputs += unknown;
+        QString text{tr("%1 — %n input(s)", nullptr, static_cast<int>(contribution.inputs.size()))
+                         .arg(contribution.label)};
+        if (resolved > 0) text += tr(", %1 resolved").arg(FormatAmount(m_wallet_model, resolved));
+        if (unknown > 0) text += tr(", %n unconfirmed or unknown input(s)", nullptr, unknown);
+        if (contribution.hasChange) {
+            text += tr(", change %1 to %2").arg(FormatAmount(m_wallet_model, contribution.changeAmount),
+                                                contribution.changeAddress);
+        }
+        new QListWidgetItem(text, m_contrib_list);
+    }
+
+    const CAmount required{GetMnType(MnType::Regular).collat_amount};
+    QString status{tr("Funding inputs resolve to %1 of the %2 collateral plus fee.")
+                       .arg(FormatAmount(m_wallet_model, resolved_total), FormatAmount(m_wallet_model, required))};
+    if (unknown_inputs > 0) {
+        status += QLatin1Char(' ') +
+                  tr("%n input(s) could not be resolved yet (unconfirmed outputs resolve after their transaction "
+                     "confirms).",
+                     nullptr, unknown_inputs);
+    }
+    m_funding_status_label->setText(status);
+}
+
+void SharedMnCreateDialog::refreshSigningPage()
+{
+    // Term sheet
+    QStringList rows;
+    rows << QStringLiteral("<b>%1</b>").arg(tr("Shares"));
+    const auto& shares{m_session.shares()};
+    for (size_t i = 0; i < shares.size(); ++i) {
+        const auto& share{shares[i]};
+        QString line{tr("%1. %2 — %3, owner %4, refund %5")
+                         .arg(i + 1)
+                         .arg(ShareDisplayLabel(m_session, static_cast<int>(i)).toHtmlEscaped(),
+                              FormatAmount(m_wallet_model, share.amount), share.ownerAddress.toHtmlEscaped(),
+                              share.refundAddress.toHtmlEscaped())};
+        line += share.rewardAddress.isEmpty() ? QLatin1Char(' ') + tr("(rewards to the refund address)") :
+                                                QLatin1Char(' ') + tr("(rewards to %1)").arg(share.rewardAddress.toHtmlEscaped());
+        rows << line;
+    }
+    const auto& terms{m_session.terms()};
+    rows << QStringLiteral("<br><b>%1</b>").arg(tr("Terms"));
+    rows << tr("Service: %1").arg(terms.coreP2PAddrs.isEmpty() ?
+                                      tr("(none — set later with a service update)") :
+                                      terms.coreP2PAddrs.toHtmlEscaped());
+    rows << tr("Operator key: %1").arg(terms.operatorPubKey.toHtmlEscaped());
+    rows << tr("Operator secret held by: %1")
+                .arg(m_session.operatorSecretHolder().isEmpty() ? tr("(not recorded)") :
+                                                                  m_session.operatorSecretHolder().toHtmlEscaped());
+    rows << tr("Voting: %1").arg(terms.votingAddress.toHtmlEscaped());
+    rows << tr("Operator reward: %1%").arg(QString::number(terms.operatorReward / 100.0, 'f', 2));
+    rows << tr("Early period: %1 blocks (%2)")
+                .arg(terms.earlyPeriodBlocks)
+                .arg(MnShareSession::HumanEarlyPeriod(terms.earlyPeriodBlocks));
+    rows << tr("Early penalty: %1").arg(FormatAmount(m_wallet_model, terms.earlyPenalty));
+    if (!m_session.prepareWallet().isEmpty()) {
+        rows << tr("Prepared by wallet: %1").arg(m_session.prepareWallet().toHtmlEscaped());
+    }
+    m_term_sheet->setText(rows.join(QStringLiteral("<br>")));
+
+    // Signature checklist. Stored signatures were verified when added, but an
+    // envelope loaded from disk is re-verified here so a stale or tampered
+    // signature is surfaced instead of counted (A7).
+    const auto my_indexes{myShareIndexes()};
+    m_sig_table->setRowCount(static_cast<int>(shares.size()));
+    for (int i = 0; i < static_cast<int>(shares.size()); ++i) {
+        const QString label{ShareDisplayLabel(m_session, i)};
+        QString status;
+        const QString sig{m_session.signatureFor(i)};
+        if (sig.isEmpty()) {
+            status = tr("Pending — ask %1 to sign").arg(label);
+        } else if (QString sig_error; m_session.verifySignature(i, sig, sig_error)) {
+            status = tr("Signed");
+        } else {
+            status = sig_error;
+        }
+        const auto set_cell = [this, i](int column, const QString& text) {
+            auto* item = new QTableWidgetItem(text);
+            item->setFlags(item->flags() & ~Qt::ItemIsEditable);
+            m_sig_table->setItem(i, column, item);
+        };
+        set_cell(0, QString::number(i + 1));
+        set_cell(1, label + (std::count(my_indexes.begin(), my_indexes.end(), i) > 0 ?
+                                 QLatin1Char(' ') + tr("(you)") :
+                                 QString()));
+        set_cell(2, status);
+    }
+
+    const bool signing_stage{m_session.stage() == MnShareSession::Stage::Frozen ||
+                             m_session.stage() == MnShareSession::Stage::Signing};
+    m_sign_button->setEnabled(signing_stage && canSign() && !my_indexes.empty() && !m_busy);
+    if (!canSign()) {
+        m_sign_button->setToolTip(m_wallet_model == nullptr ? tr("No wallet is available.") :
+                                                              tr("This wallet is watch-only and cannot sign."));
+    } else if (my_indexes.empty()) {
+        m_sign_button->setToolTip(tr("This wallet holds none of the share owner keys."));
+    } else {
+        m_sign_button->setToolTip(tr("Sign the consent check phrase with every share owner key in this wallet."));
+    }
+    m_unfreeze_button->setEnabled(signing_stage && !m_busy);
+}
+
+void SharedMnCreateDialog::refreshCombinedPage()
+{
+    const int total{static_cast<int>(m_session.shares().size())};
+    const bool combined{m_session.stage() == MnShareSession::Stage::Combined};
+    const bool ready_to_combine{!combined && total > 0 && m_session.signedCount() == total};
+
+    m_combine_button->setVisible(!combined);
+    m_combine_button->setEnabled(ready_to_combine && m_v24_active && !m_busy);
+    if (!m_v24_active) m_combine_button->setToolTip(tr("Shared masternodes require the v24 hard fork to be active."));
+    m_combined_status->setText(combined ?
+                                   tr("All %n consent signature(s) are embedded in the transaction. The funding "
+                                      "inputs now have to be signed by their contributors.",
+                                      nullptr, total) :
+                                   tr("Every share owner has signed. Combine the signatures into the transaction to "
+                                      "continue."));
+
+    m_funding_sig_list->clear();
+    const auto signed_map{InputSignatureMap(m_session.protxHex())};
+    int outstanding{0};
+    for (const auto& contribution : m_session.contributions()) {
+        int done{0};
+        for (const auto& input : contribution.inputs) {
+            const auto it{signed_map.find(OutpointKey(input.txid, input.vout))};
+            if (it != signed_map.end() && it->second) ++done;
+        }
+        const int inputs{static_cast<int>(contribution.inputs.size())};
+        if (done < inputs) ++outstanding;
+        new QListWidgetItem(done == inputs ?
+                                tr("%1 — signed").arg(contribution.label) :
+                                tr("%1 — pending (%2 of %3 inputs signed)").arg(contribution.label).arg(done).arg(inputs),
+                            m_funding_sig_list);
+    }
+    if (outstanding == 0 && combined && !m_session.contributions().empty()) {
+        new QListWidgetItem(tr("All funding inputs are signed."), m_funding_sig_list);
+    }
+
+    m_sign_funding_button->setEnabled(combined && canSign() && !m_busy);
+    m_sign_funding_button->setToolTip(!combined ? tr("Combine the consent signatures first.") :
+                                      canSign()  ? tr("Sign every funding input this wallet holds the keys for.") :
+                                                   tr("No wallet able to sign is available."));
+}
+
+void SharedMnCreateDialog::refreshBroadcastPage()
+{
+    const bool broadcast{m_session.stage() == MnShareSession::Stage::Broadcast};
+
+    CMutableTransaction tx;
+    QString txid;
+    if (DecodeHexTx(tx, m_session.protxHex().toStdString())) {
+        txid = QString::fromStdString(tx.GetHash().ToString());
+    }
+
+    QStringList rows;
+    rows << tr("The shared masternode registration is fully signed.");
+    rows << tr("Check phrase: <b>%1</b>").arg(m_session.consentCheckPhrase());
+    rows << tr("Transaction id: %1").arg(txid.toHtmlEscaped());
+    rows << tr("Size: %n byte(s), collateral output index %1", nullptr,
+               static_cast<int>(m_session.protxHex().size() / 2))
+                .arg(m_session.collateralIndex());
+    m_broadcast_summary->setText(rows.join(QStringLiteral("<br>")));
+
+    m_broadcast_button->setVisible(!broadcast);
+    m_broadcast_button->setEnabled(!broadcast && m_v24_active && !m_busy);
+    if (!m_v24_active) m_broadcast_button->setToolTip(tr("Shared masternodes require the v24 hard fork to be active."));
+
+    m_success_label->setVisible(broadcast);
+    if (broadcast) {
+        m_success_label->setText(
+            QStringLiteral("<b>%1</b><br><br>%2<br><b>%3</b><br><br>%4")
+                .arg(tr("The registration was sent to the network."), tr("Provider transaction hash (proTxHash):"),
+                     txid.toHtmlEscaped(),
+                     tr("IMPORTANT: once the registration has one confirmation, every participant should generate "
+                        "standby dissolutions from the Masternodes list (select the new masternode, then Dissolve → "
+                        "Standby) and store both variants together with their refund-key backup, separately from the "
+                        "share owner key. A standby dissolution never expires and recovers your principal even if "
+                        "your owner key is lost.")));
+    }
+}
+
+void SharedMnCreateDialog::syncShareFromTable(int row)
+{
+    auto& shares{m_session.shares()};
+    if (row < 0 || row >= static_cast<int>(shares.size())) return;
+    const auto cell = [this, row](int column) {
+        const auto* item = m_share_table->item(row, column);
+        return item != nullptr ? item->text().trimmed() : QString();
+    };
+    shares[row].label = cell(COL_LABEL);
+    CAmount amount{0};
+    if (!BitcoinUnits::parse(BitcoinUnits::Unit::DASH, cell(COL_AMOUNT), &amount)) amount = 0;
+    shares[row].amount = amount;
+    shares[row].ownerAddress = cell(COL_OWNER);
+    shares[row].refundAddress = cell(COL_REFUND);
+    shares[row].rewardAddress = cell(COL_REWARD);
+}
+
+void SharedMnCreateDialog::syncTermsToSession()
+{
+    auto& terms{m_session.terms()};
+    terms.coreP2PAddrs = m_service_edit->text().trimmed();
+    // Keep an imported operator key unless this dialog's widget holds a valid
+    // replacement (the widget cannot be pre-filled from a session file)
+    if (m_operator_widget->isValid()) {
+        terms.operatorPubKey = m_operator_widget->publicKeyHex();
+    }
+    terms.votingAddress = m_voting_edit->text().trimmed();
+    terms.operatorReward = qRound(m_operator_reward_spin->value() * 100.0);
+    terms.earlyPeriodBlocks = static_cast<uint32_t>(m_early_period_spin->value());
+    terms.earlyPenalty = m_early_penalty_field->value();
+    m_session.setOperatorSecretHolder(m_secret_holder_edit->text().trimmed());
+
+    if (m_operator_widget->hasGeneratedSecret()) {
+        m_operator_secret_label->setVisible(true);
+        m_operator_secret_label->setText(
+            tr("Operator secret key (write it down now, it is not stored anywhere): %1")
+                .arg(m_operator_widget->secretHex()));
+    } else {
+        m_operator_secret_label->setVisible(false);
+    }
+}
+
+void SharedMnCreateDialog::pushTermsToWidgets()
+{
+    m_updating = true;
+    const auto& terms{m_session.terms()};
+    m_service_edit->setText(terms.coreP2PAddrs);
+    m_voting_edit->setText(terms.votingAddress);
+    m_operator_reward_spin->setValue(terms.operatorReward / 100.0);
+    m_early_period_spin->setValue(static_cast<int>(terms.earlyPeriodBlocks));
+    m_early_penalty_field->setValue(terms.earlyPenalty);
+    m_secret_holder_edit->setText(m_session.operatorSecretHolder());
+    m_updating = false;
+}
+
+void SharedMnCreateDialog::importFromClipboard()
+{
+    adoptImportedText(QApplication::clipboard()->text(), tr("clipboard"));
+}
+
+void SharedMnCreateDialog::loadFromFile()
+{
+    const QString filename{GUIUtil::getOpenFileName(this, tr("Load Shared Masternode Session"), QString(),
+                                                    tr("Session files (*.json)"), nullptr)};
+    if (filename.isEmpty()) return;
+    QFile file(filename);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        QMessageBox::critical(this, windowTitle(), tr("Could not open %1 for reading.").arg(filename));
+        return;
+    }
+    adoptImportedText(QString::fromUtf8(file.readAll()), filename);
+}
+
+void SharedMnCreateDialog::exportToClipboard()
+{
+    GUIUtil::setClipboard(m_session.toJsonString());
+    QMessageBox::information(this, windowTitle(),
+                             tr("The session was copied to the clipboard. Also save it to a file so it cannot be "
+                                "lost to a clipboard overwrite."));
+}
+
+void SharedMnCreateDialog::saveToFile()
+{
+    writeSessionToFile();
+}
+
+bool SharedMnCreateDialog::writeSessionToFile()
+{
+    const QString suggested{QStringLiteral("shared-mn-session-%1-r%2.json")
+                                .arg(m_session.sessionId().left(8))
+                                .arg(m_session.revision())};
+    const QString filename{GUIUtil::getSaveFileName(this, tr("Save Shared Masternode Session"), suggested,
+                                                    tr("Session files (*.json)"), nullptr)};
+    if (filename.isEmpty()) return false;
+    QFile file(filename);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
+        QMessageBox::critical(this, windowTitle(), tr("Could not open %1 for writing.").arg(filename));
+        return false;
+    }
+    file.write(m_session.toJsonString().toUtf8());
+    file.close();
+    m_dirty = false;
+    return true;
+}
+
+void SharedMnCreateDialog::adoptImportedText(const QString& text, const QString& source)
+{
+    if (text.trimmed().isEmpty()) {
+        QMessageBox::warning(this, windowTitle(), tr("%1 does not contain a session file.").arg(source));
+        return;
+    }
+    MnShareSession imported;
+    QString error;
+    if (!imported.fromJson(text.toStdString(), error)) {
+        QMessageBox::critical(this, windowTitle(), error);
+        return;
+    }
+
+    // A pristine dialog adopts the imported session outright
+    const bool pristine{m_session.stage() == MnShareSession::Stage::Draft && m_session.shares().empty() &&
+                        m_session.contributions().empty() && !m_dirty};
+    if (pristine) {
+        m_session = imported;
+        afterImport();
+        return;
+    }
+
+    QString merge_error;
+    switch (m_session.mergeEnvelope(imported, merge_error)) {
+    case MnShareSession::MergeResult::Merged:
+        if (!merge_error.isEmpty()) {
+            QMessageBox::warning(this, tr("Merged with warnings"), merge_error);
+        }
+        markDirty();
+        afterImport();
+        break;
+    case MnShareSession::MergeResult::OtherOlder:
+        QMessageBox::information(this, tr("Imported copy is older"), merge_error);
+        break;
+    case MnShareSession::MergeResult::OtherNewer: {
+        const auto choice{QMessageBox::question(
+            this, tr("Imported copy is newer"),
+            merge_error + QStringLiteral("\n\n") + tr("Adopt the newer copy? Your local copy is discarded."),
+            QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes)};
+        if (choice == QMessageBox::Yes) {
+            m_session = imported;
+            markDirty();
+            afterImport();
+        }
+        break;
+    }
+    case MnShareSession::MergeResult::Conflict: {
+        QMessageBox box(this);
+        box.setIcon(QMessageBox::Warning);
+        box.setWindowTitle(tr("Session conflict"));
+        box.setText(merge_error);
+        box.setInformativeText(tr("Replace this session with the imported copy, or keep working on this one?"));
+        auto* replace{box.addButton(tr("Replace With Imported"), QMessageBox::DestructiveRole)};
+        box.addButton(tr("Keep Mine"), QMessageBox::RejectRole);
+        box.exec();
+        if (box.clickedButton() == replace) {
+            m_session = imported;
+            markDirty();
+            afterImport();
+        }
+        break;
+    }
+    }
+}
+
+void SharedMnCreateDialog::afterImport()
+{
+    // A7: an adopted envelope's signatures were stored as-is by fromJson;
+    // re-verify them all and drop any that do not verify against the frozen
+    // terms so they are flagged instead of counted (mergeEnvelope verifies on
+    // its own, so this is a no-op for merges)
+    QStringList bad;
+    for (const auto& check : m_session.verifyAllSignatures()) {
+        if (!check.valid) bad << check.error;
+    }
+    if (!bad.isEmpty()) {
+        UniValue json{m_session.toJson()};
+        UniValue sigs(UniValue::VARR);
+        for (const auto& sig : m_session.signatures()) {
+            QString sig_error;
+            if (!m_session.verifySignature(sig.shareIndex, sig.signatureB64, sig_error)) continue;
+            UniValue entry(UniValue::VOBJ);
+            entry.pushKV("shareIndex", sig.shareIndex);
+            entry.pushKV("signature", sig.signatureB64.toStdString());
+            sigs.push_back(entry);
+        }
+        json.pushKV("sigs", sigs);
+        QString error;
+        m_session.fromJson(json, error); // leaves the session untouched on failure
+        QMessageBox::warning(this, tr("Signatures not counted"), bad.join(QLatin1Char('\n')));
+    }
+
+    // A replacement session gets a fresh liveness verdict
+    m_dead = false;
+    m_dead_reason.clear();
+    checkSessionLiveness();
+    refreshAll();
+}
+
+void SharedMnCreateDialog::checkSessionLiveness()
+{
+    QStringList spent;
+    for (const auto& contribution : m_session.contributions()) {
+        for (const auto& input : contribution.inputs) {
+            const COutPoint outpoint{uint256S(input.txid.toStdString()), input.vout};
+            Coin coin;
+            if (m_node.getUnspentOutput(outpoint, coin)) continue;
+            // Not in the confirmed UTXO set. A wallet-known unconfirmed output
+            // is merely pending; anything else is spent (or never existed)
+            if (m_wallet_model != nullptr) {
+                const auto known{m_wallet_model->wallet().getCoins({outpoint})};
+                if (!known.empty() && known.front().depth_in_main_chain >= 0 && !known.front().is_spent) continue;
+            }
+            spent << tr("%1:%2 (contributed by %3)").arg(input.txid).arg(input.vout).arg(contribution.label);
+        }
+    }
+    if (!spent.isEmpty()) {
+        markDead(tr("A funding input of this session was spent (or does not exist), so the recorded funding "
+                    "transaction can never confirm. The session cannot be continued — restart from a new draft.") +
+                 QStringLiteral("\n\n") + spent.join(QLatin1Char('\n')));
+    }
+}
+
+void SharedMnCreateDialog::markDead(const QString& reason)
+{
+    m_dead = true;
+    m_dead_reason = reason;
+    refreshAll();
+}
+
+void SharedMnCreateDialog::markDirty()
+{
+    m_dirty = true;
+}
+
+void SharedMnCreateDialog::offerExport(const QString& why)
+{
+    if (m_dead) return;
+    const auto choice{QMessageBox::question(
+        this, windowTitle(),
+        why + QStringLiteral("\n\n") +
+            tr("Copy the updated session to the clipboard and save it to a file now? The other participants need "
+               "the latest copy to continue."),
+        QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes)};
+    if (choice != QMessageBox::Yes) return;
+    GUIUtil::setClipboard(m_session.toJsonString());
+    writeSessionToFile();
+}
+
+void SharedMnCreateDialog::addShareRow()
+{
+    if (m_session.stage() != MnShareSession::Stage::Draft) return;
+    auto& shares{m_session.shares()};
+    if (shares.size() >= CProRegTx::MAX_SHARES) return;
+    MnShareSession::Share share;
+    share.label = tr("Participant %1").arg(shares.size() + 1);
+    shares.push_back(share);
+    markDirty();
+    refreshSharesTable();
+    refreshValidation();
+}
+
+void SharedMnCreateDialog::removeShareRow()
+{
+    if (m_session.stage() != MnShareSession::Stage::Draft) return;
+    const int row{m_share_table->currentRow()};
+    auto& shares{m_session.shares()};
+    if (row < 0 || row >= static_cast<int>(shares.size())) return;
+    shares.erase(shares.begin() + row);
+    markDirty();
+    refreshSharesTable();
+    refreshValidation();
+}
+
+void SharedMnCreateDialog::useMyWalletAddress()
+{
+    if (m_wallet_model == nullptr) return;
+    const int row{m_share_table->currentRow()};
+    if (row < 0 || row >= m_share_table->rowCount()) {
+        QMessageBox::information(this, windowTitle(), tr("Select a share row first."));
+        return;
+    }
+    int column{m_share_table->currentColumn()};
+    if (column != COL_OWNER && column != COL_REFUND && column != COL_REWARD) column = COL_OWNER;
+
+    QString error;
+    const QString address{freshAddress(error)};
+    if (address.isEmpty()) {
+        QMessageBox::critical(this, windowTitle(), error);
+        return;
+    }
+    auto* item = m_share_table->item(row, column);
+    if (item == nullptr) {
+        item = new QTableWidgetItem();
+        m_share_table->setItem(row, column, item);
+    }
+    item->setText(address); // triggers onShareCellChanged -> session sync
+}
+
+void SharedMnCreateDialog::onShareCellChanged(int row, int column)
+{
+    Q_UNUSED(column);
+    if (m_updating) return;
+    syncShareFromTable(row);
+    markDirty();
+    refreshValidation();
+}
+
+void SharedMnCreateDialog::onTermsChanged()
+{
+    if (m_updating) return;
+    syncTermsToSession();
+    markDirty();
+    refreshValidation();
+}
+
+std::vector<int> SharedMnCreateDialog::myShareIndexes() const
+{
+    std::vector<int> ret;
+    if (m_wallet_model == nullptr) return ret;
+    const auto& shares{m_session.shares()};
+    for (size_t i = 0; i < shares.size(); ++i) {
+        const CTxDestination dest{DecodeDestination(shares[i].ownerAddress.toStdString())};
+        if (IsValidDestination(dest) && m_wallet_model->wallet().isSpendable(dest)) {
+            ret.push_back(static_cast<int>(i));
+        }
+    }
+    return ret;
+}
+
+CAmount SharedMnCreateDialog::myShareTotal() const
+{
+    CAmount total{0};
+    for (const int index : myShareIndexes()) {
+        total += m_session.shares()[index].amount;
+    }
+    return total;
+}
+
+QString SharedMnCreateDialog::freshAddress(QString& error) const
+{
+    error.clear();
+    if (m_wallet_model == nullptr) {
+        error = tr("No wallet is available.");
+        return {};
+    }
+    auto dest{m_wallet_model->wallet().getNewDestination(/*label=*/"")};
+    if (!dest) {
+        error = tr("Could not generate a new address: %1")
+                    .arg(QString::fromStdString(util::ErrorString(dest).translated));
+        return {};
+    }
+    return QString::fromStdString(EncodeDestination(*dest));
+}
+
+std::optional<MnShareSession::Input> SharedMnCreateDialog::findFundingChip(CAmount amount) const
+{
+    if (m_wallet_model == nullptr || amount <= 0) return std::nullopt;
+    for (const auto& [dest, coins] : m_wallet_model->wallet().listCoins()) {
+        for (const auto& [outpoint, txout] : coins) {
+            if (txout.txout.nValue != amount || txout.is_spent || txout.depth_in_main_chain < 0) continue;
+            if (m_wallet_model->wallet().isLockedCoin(outpoint)) continue;
+            MnShareSession::Input input;
+            input.txid = QString::fromStdString(outpoint.hash.ToString());
+            input.vout = outpoint.n;
+            return input;
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<MnShareSession::Input> SharedMnCreateDialog::prepareFundingChip(CAmount amount, QString& error)
+{
+    QString address{freshAddress(error)};
+    if (address.isEmpty()) return std::nullopt;
+
+    WalletModel::UnlockContext ctx(m_wallet_model->requestUnlock());
+    if (!ctx.isValid()) {
+        error = tr("Wallet unlock was cancelled.");
+        return std::nullopt;
+    }
+
+    SendCoinsRecipient recipient(address, tr("Shared masternode funding"), amount, /*_message=*/QString());
+    WalletModelTransaction transaction({recipient});
+    wallet::CCoinControl coin_control;
+    const auto prepared{m_wallet_model->prepareTransaction(transaction, coin_control)};
+    if (prepared.status != WalletModel::OK) {
+        error = tr("Could not prepare the funding output (is the balance sufficient to cover %1 plus fee?)")
+                    .arg(FormatAmount(m_wallet_model, amount));
+        return std::nullopt;
+    }
+    m_wallet_model->sendCoins(transaction, /*fIsCoinJoin=*/false);
+
+    const CTransactionRef& wtx{transaction.getWtx()};
+    const CScript script{GetScriptForDestination(DecodeDestination(address.toStdString()))};
+    for (size_t n = 0; n < wtx->vout.size(); ++n) {
+        if (wtx->vout[n].scriptPubKey == script && wtx->vout[n].nValue == amount) {
+            MnShareSession::Input input;
+            input.txid = QString::fromStdString(wtx->GetHash().ToString());
+            input.vout = static_cast<uint32_t>(n);
+            return input;
+        }
+    }
+    error = tr("The funding transaction was sent but its output could not be located.");
+    return std::nullopt;
+}
+
+void SharedMnCreateDialog::refreshFundingCandidates()
+{
+    m_fee_utxo_combo->clear();
+    if (m_wallet_model == nullptr) return;
+
+    std::vector<std::tuple<CAmount, QString, uint32_t>> candidates;
+    for (const auto& [dest, coins] : m_wallet_model->wallet().listCoins()) {
+        for (const auto& [outpoint, txout] : coins) {
+            if (txout.is_spent || txout.depth_in_main_chain < 1) continue;
+            if (m_wallet_model->wallet().isLockedCoin(outpoint)) continue;
+            candidates.emplace_back(txout.txout.nValue, QString::fromStdString(outpoint.hash.ToString()), outpoint.n);
+        }
+    }
+    std::sort(candidates.begin(), candidates.end());
+    for (const auto& [value, txid, vout] : candidates) {
+        m_fee_utxo_combo->addItem(QStringLiteral("%1 — %2:%3").arg(FormatAmount(m_wallet_model, value),
+                                                                   txid.left(16) + QStringLiteral("…"),
+                                                                   QString::number(vout)));
+        const int index{m_fee_utxo_combo->count() - 1};
+        m_fee_utxo_combo->setItemData(index, txid, FEE_UTXO_TXID_ROLE);
+        m_fee_utxo_combo->setItemData(index, vout, FEE_UTXO_VOUT_ROLE);
+        m_fee_utxo_combo->setItemData(index, static_cast<qlonglong>(value), FEE_UTXO_VALUE_ROLE);
+    }
+    refreshContributions();
+}
+
+void SharedMnCreateDialog::addMyFunding()
+{
+    if (m_wallet_model == nullptr || m_session.stage() != MnShareSession::Stage::Draft || m_busy) return;
+
+    const QString label{m_my_label_edit->text().trimmed()};
+    if (label.isEmpty()) {
+        QMessageBox::information(this, windowTitle(), tr("Enter your participant label first."));
+        return;
+    }
+    const CAmount amount{myShareTotal()};
+    if (amount <= 0) {
+        QMessageBox::information(this, windowTitle(),
+                                 tr("This wallet owns none of the shares. Set the owner address of your share(s) "
+                                    "to an address of this wallet first — your contribution must equal your total "
+                                    "share amount."));
+        return;
+    }
+
+    MnShareSession::Contribution contribution;
+    contribution.label = label;
+
+    auto chip{findFundingChip(amount)};
+    if (!chip) {
+        const auto choice{QMessageBox::question(
+            this, windowTitle(),
+            tr("No single unlocked output of exactly %1 exists in this wallet. Prepare one now with an ordinary "
+               "send to a fresh address of your own? (This pays one extra transaction fee.)")
+                .arg(FormatAmount(m_wallet_model, amount)),
+            QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes)};
+        if (choice != QMessageBox::Yes) return;
+        QString error;
+        chip = prepareFundingChip(amount, error);
+        if (!chip) {
+            QMessageBox::critical(this, windowTitle(), error);
+            return;
+        }
+    }
+    contribution.inputs.push_back(*chip);
+
+    if (m_coordinator_check->isChecked()) {
+        const int fee_index{m_fee_utxo_combo->currentIndex()};
+        const CAmount fee{m_fee_amount_field->value()};
+        if (fee_index < 0 || fee <= 0) {
+            QMessageBox::information(this, windowTitle(), tr("Select a fee input and a positive fee amount."));
+            return;
+        }
+        MnShareSession::Input fee_input;
+        fee_input.txid = m_fee_utxo_combo->itemData(fee_index, FEE_UTXO_TXID_ROLE).toString();
+        fee_input.vout = m_fee_utxo_combo->itemData(fee_index, FEE_UTXO_VOUT_ROLE).toUInt();
+        const CAmount fee_value{m_fee_utxo_combo->itemData(fee_index, FEE_UTXO_VALUE_ROLE).toLongLong()};
+        if (fee_input.txid == chip->txid && fee_input.vout == chip->vout) {
+            QMessageBox::information(this, windowTitle(),
+                                     tr("The fee input is the funding output itself. Pick a different, smaller "
+                                        "output."));
+            return;
+        }
+        if (fee_value < fee) {
+            QMessageBox::information(this, windowTitle(), tr("The selected fee input is smaller than the fee."));
+            return;
+        }
+        contribution.inputs.push_back(fee_input);
+        if (fee_value > fee) {
+            QString error;
+            const QString change_address{freshAddress(error)};
+            if (change_address.isEmpty()) {
+                QMessageBox::critical(this, windowTitle(), error);
+                return;
+            }
+            contribution.hasChange = true;
+            contribution.changeAddress = change_address;
+            contribution.changeAmount = fee_value - fee;
+        }
+    }
+
+    QString error;
+    if (!m_session.addContribution(contribution, error)) {
+        QMessageBox::critical(this, windowTitle(), error);
+        return;
+    }
+    setContributionLocked(contribution, /*lock=*/true); // A8: contributed coins stay locked
+    markDirty();
+    refreshContributions();
+    refreshValidation();
+}
+
+void SharedMnCreateDialog::removeSelectedContribution()
+{
+    if (m_session.stage() != MnShareSession::Stage::Draft) return;
+    const int row{m_contrib_list->currentRow()};
+    const auto& contributions{m_session.contributions()};
+    if (row < 0 || row >= static_cast<int>(contributions.size())) {
+        QMessageBox::information(this, windowTitle(), tr("Select a contribution first."));
+        return;
+    }
+    const MnShareSession::Contribution removed{contributions[row]};
+    QString error;
+    if (!m_session.removeContribution(removed.label, error)) {
+        QMessageBox::critical(this, windowTitle(), error);
+        return;
+    }
+    setContributionLocked(removed, /*lock=*/false);
+    markDirty();
+    refreshContributions();
+    refreshValidation();
+}
+
+void SharedMnCreateDialog::setContributionLocked(const MnShareSession::Contribution& contribution, bool lock)
+{
+    if (m_wallet_model == nullptr) return;
+    for (const auto& input : contribution.inputs) {
+        const COutPoint outpoint{uint256S(input.txid.toStdString()), input.vout};
+        if (lock) {
+            m_wallet_model->wallet().lockCoin(outpoint, /*write_to_db=*/true);
+        } else {
+            m_wallet_model->wallet().unlockCoin(outpoint);
+        }
+    }
+}
+
+void SharedMnCreateDialog::unlockAllContributedCoins()
+{
+    for (const auto& contribution : m_session.contributions()) {
+        setContributionLocked(contribution, /*lock=*/false);
+    }
+}
+
+void SharedMnCreateDialog::freezeSession()
+{
+    if (m_session.stage() != MnShareSession::Stage::Draft || m_busy) return;
+    syncTermsToSession();
+    if (!m_session.validateShares().isEmpty() || m_session.fundingTxHex().isEmpty()) {
+        refreshValidation();
+        return;
+    }
+
+    const auto& terms{m_session.terms()};
+    QString parse_error;
+    const QStringList services{MasternodeWidgetUtil::parseServiceList(terms.coreP2PAddrs, parse_error)};
+    if (!parse_error.isEmpty()) {
+        QMessageBox::critical(this, windowTitle(), parse_error);
+        return;
+    }
+
+    const auto choice{QMessageBox::question(
+        this, tr("Freeze the session terms?"),
+        tr("Freezing prepares the registration transaction and fixes the share table, the terms and every funding "
+           "input. Afterwards every share owner must sign the consent check phrase; any further change discards all "
+           "collected signatures.") +
+            QStringLiteral("\n\n") +
+            tr("Make sure every participant has contributed funding — the funding inputs cannot be changed without "
+               "unfreezing."),
+        QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Yes)};
+    if (choice != QMessageBox::Yes) return;
+
+    UniValue params(UniValue::VOBJ);
+    params.pushKV("fundingTx", m_session.fundingTxHex().toStdString());
+    UniValue shares(UniValue::VARR);
+    for (const auto& share : m_session.shares()) {
+        UniValue entry(UniValue::VOBJ);
+        entry.pushKV("amount", share.amount);
+        entry.pushKV("refundAddress", share.refundAddress.toStdString());
+        if (!share.rewardAddress.isEmpty()) {
+            entry.pushKV("rewardAddress", share.rewardAddress.toStdString());
+        }
+        entry.pushKV("ownerAddress", share.ownerAddress.toStdString());
+        shares.push_back(entry);
+    }
+    params.pushKV("shares", shares);
+    UniValue service_arr(UniValue::VARR);
+    for (const QString& service : services) {
+        service_arr.push_back(service.toStdString());
+    }
+    params.pushKV("coreP2PAddrs", service_arr);
+    params.pushKV("operatorPubKey", terms.operatorPubKey.toStdString());
+    params.pushKV("votingAddress", terms.votingAddress.toStdString());
+    params.pushKV("operatorReward",
+                  QStringLiteral("%1.%2").arg(terms.operatorReward / 100).arg(terms.operatorReward % 100, 2, 10, QLatin1Char('0')).toStdString());
+    params.pushKV("earlyPeriodBlocks", static_cast<int64_t>(terms.earlyPeriodBlocks));
+    params.pushKV("earlyPenalty", terms.earlyPenalty);
+
+    // register_shared_prepare only assembles the transaction; no keys are involved
+    ProTxResult result;
+    if (!runRpc("protx register_shared_prepare", params, /*needs_unlock=*/false, result)) return;
+    if (!result.ok) {
+        QMessageBox::critical(this, tr("Prepare failed"), result.message);
+        return;
+    }
+    const UniValue& tx{result.value.find_value("tx")};
+    const UniValue& collateral_index{result.value.find_value("collateralIndex")};
+    const UniValue& consent_hash{result.value.find_value("consentHash")};
+    if (!result.value.isObject() || !tx.isStr() || !collateral_index.isNum() || !consent_hash.isStr()) {
+        QMessageBox::critical(this, tr("Prepare failed"), tr("Unexpected reply to the prepare request."));
+        return;
+    }
+    QString error;
+    if (!m_session.freeze(QString::fromStdString(tx.get_str()), QString::fromStdString(consent_hash.get_str()),
+                          collateral_index.getInt<int>(), error)) {
+        QMessageBox::critical(this, tr("Prepare failed"), error);
+        return;
+    }
+    if (m_wallet_model != nullptr) {
+        m_session.setPrepareWallet(m_wallet_model->getWalletName());
+    }
+    markDirty();
+    refreshAll();
+    offerExport(tr("The terms are frozen. Every participant must now verify the check phrase and sign."));
+}
+
+void SharedMnCreateDialog::signConsent()
+{
+    if (m_busy || !canSign()) return;
+    if (m_session.stage() != MnShareSession::Stage::Frozen && m_session.stage() != MnShareSession::Stage::Signing) {
+        return;
+    }
+
+    UniValue params(UniValue::VOBJ);
+    params.pushKV("tx", m_session.protxHex().toStdString());
+    ProTxResult result;
+    if (!runRpc("protx shared_sign", params, /*needs_unlock=*/true, result)) return;
+    if (!result.ok) {
+        QMessageBox::critical(this, tr("Signing failed"), result.message);
+        return;
+    }
+    if (!result.value.isArray()) {
+        QMessageBox::critical(this, tr("Signing failed"), tr("Unexpected reply to the signing request."));
+        return;
+    }
+
+    int added{0};
+    QStringList errors;
+    for (const auto& entry : result.value.getValues()) {
+        try {
+            const int share_index{entry.find_value("shareIndex").getInt<int>()};
+            const QString signature{QString::fromStdString(entry.find_value("signature").get_str())};
+            if (QString error; m_session.addSignature(share_index, signature, error)) {
+                ++added;
+            } else {
+                errors << error;
+            }
+        } catch (const std::exception& e) {
+            errors << QString::fromUtf8(e.what());
+        }
+    }
+    if (!errors.isEmpty()) {
+        QMessageBox::warning(this, tr("Signing finished with warnings"), errors.join(QLatin1Char('\n')));
+    }
+    markDirty();
+    refreshAll();
+    if (added > 0) {
+        offerExport(tr("%n signature(s) were recorded (%1 of %2 shares signed).", nullptr, added)
+                        .arg(m_session.signedCount())
+                        .arg(m_session.shares().size()));
+    }
+}
+
+void SharedMnCreateDialog::unfreezeSession()
+{
+    if (m_session.stage() != MnShareSession::Stage::Frozen && m_session.stage() != MnShareSession::Stage::Signing) {
+        return;
+    }
+    const int sigs{m_session.signedCount()};
+    const auto choice{QMessageBox::question(
+        this, tr("Unfreeze the session?"),
+        tr("Unfreezing returns the session to a draft and discards %n collected signature(s). Everyone will have to "
+           "sign again after the terms are re-frozen.",
+           nullptr, sigs),
+        QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel)};
+    if (choice != QMessageBox::Yes) return;
+    m_session.unfreeze();
+    markDirty();
+    refreshAll();
+}
+
+void SharedMnCreateDialog::combineSignatures()
+{
+    if (m_busy) return;
+    const int total{static_cast<int>(m_session.shares().size())};
+    if (m_session.signedCount() != total || total == 0) return;
+
+    UniValue params(UniValue::VOBJ);
+    params.pushKV("tx", m_session.protxHex().toStdString());
+    UniValue signatures(UniValue::VARR);
+    for (const auto& sig : m_session.signatures()) {
+        UniValue entry(UniValue::VOBJ);
+        entry.pushKV("shareIndex", sig.shareIndex);
+        entry.pushKV("signature", sig.signatureB64.toStdString());
+        signatures.push_back(entry);
+    }
+    params.pushKV("signatures", signatures);
+    params.pushKV("submit", false);
+
+    ProTxResult result;
+    if (!runRpc("protx shared_combine", params, /*needs_unlock=*/false, result)) return;
+    if (!result.ok) {
+        QMessageBox::critical(this, tr("Combine failed"), result.message);
+        return;
+    }
+    if (!result.value.isStr()) {
+        QMessageBox::critical(this, tr("Combine failed"), tr("Unexpected reply to the combine request."));
+        return;
+    }
+    QString error;
+    if (!m_session.setCombinedTx(QString::fromStdString(result.value.get_str()), error)) {
+        QMessageBox::critical(this, tr("Combine failed"), error);
+        return;
+    }
+    markDirty();
+    refreshAll();
+    offerExport(tr("The consent signatures are combined. Every contributor must now sign their funding inputs."));
+}
+
+void SharedMnCreateDialog::signFundingInputs()
+{
+    if (m_busy || !canSign() || m_session.stage() != MnShareSession::Stage::Combined) return;
+
+    const QString before{m_session.protxHex()};
+    UniValue params(UniValue::VOBJ);
+    params.pushKV("hexstring", before.toStdString());
+    ProTxResult result;
+    if (!runRpc("signrawtransactionwithwallet", params, /*needs_unlock=*/true, result)) return;
+    if (!result.ok) {
+        QMessageBox::critical(this, tr("Signing failed"), result.message);
+        return;
+    }
+    const UniValue& hex{result.value.find_value("hex")};
+    const UniValue& complete{result.value.find_value("complete")};
+    if (!result.value.isObject() || !hex.isStr() || !complete.isBool()) {
+        QMessageBox::critical(this, tr("Signing failed"), tr("Unexpected reply to the signing request."));
+        return;
+    }
+    const QString signed_hex{QString::fromStdString(hex.get_str())};
+
+    QString error;
+    if (complete.get_bool()) {
+        if (!m_session.setFundingSignedTx(signed_hex, error)) {
+            QMessageBox::critical(this, tr("Signing failed"), error);
+            return;
+        }
+        markDirty();
+        refreshAll();
+        offerExport(tr("All funding inputs are signed. The registration is ready to broadcast."));
+        return;
+    }
+
+    if (signed_hex == before) {
+        QMessageBox::information(this, windowTitle(),
+                                 tr("This wallet could not add any funding signatures. Pass the session to a "
+                                    "participant whose inputs are still pending."));
+        return;
+    }
+    if (!replaceSessionProTx(signed_hex, error)) {
+        QMessageBox::critical(this, tr("Signing failed"), error);
+        return;
+    }
+    markDirty();
+    refreshAll();
+    offerExport(tr("This wallet's funding inputs are signed; other contributors still have to sign theirs. Pass "
+                   "the session to the next participant."));
+}
+
+bool SharedMnCreateDialog::replaceSessionProTx(const QString& tx_hex, QString& error)
+{
+    // The session API only accepts a *complete* funding-signed transaction; a
+    // partially signed one is stored by rewriting the envelope's protx field
+    // and re-parsing (fromJson leaves the session untouched on failure)
+    UniValue json{m_session.toJson()};
+    json.pushKV("protx", tx_hex.toStdString());
+    return m_session.fromJson(json, error);
+}
+
+void SharedMnCreateDialog::broadcastSession()
+{
+    if (m_busy || m_session.stage() != MnShareSession::Stage::FundingSigned) return;
+
+    const auto choice{QMessageBox::question(
+        this, tr("Broadcast the registration?"),
+        tr("This sends the shared masternode registration to the network. It cannot be undone; the collateral can "
+           "only be recovered through a dissolution afterwards."),
+        QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Yes)};
+    if (choice != QMessageBox::Yes) return;
+
+    UniValue params(UniValue::VOBJ);
+    params.pushKV("hexstring", m_session.protxHex().toStdString());
+    ProTxResult result;
+    if (!runRpc("sendrawtransaction", params, /*needs_unlock=*/false, result)) return;
+    if (!result.ok) {
+        QMessageBox::critical(this, tr("Broadcast failed"), result.message);
+        return;
+    }
+    QString error;
+    if (!m_session.setBroadcast(error)) {
+        QMessageBox::critical(this, tr("Broadcast failed"), error);
+        return;
+    }
+    markDirty();
+    refreshAll();
+    offerExport(tr("The registration was broadcast. Share the final session copy with every participant for their "
+                   "records."));
+}
+
+void SharedMnCreateDialog::restartFromDraft()
+{
+    unlockAllContributedCoins();
+    m_session = MnShareSession();
+    m_dead = false;
+    m_dead_reason.clear();
+    m_dirty = false;
+    refreshFundingCandidates();
+    refreshAll();
+}
+
+void SharedMnCreateDialog::reject()
+{
+    if (m_busy) return;
+    if (m_dirty && !m_dead) {
+        QMessageBox box(this);
+        box.setIcon(QMessageBox::Question);
+        box.setWindowTitle(windowTitle());
+        box.setText(tr("The session has unsaved changes. A participant without the latest copy cannot continue the "
+                       "session."));
+        box.setStandardButtons(QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel);
+        box.setDefaultButton(QMessageBox::Save);
+        switch (box.exec()) {
+        case QMessageBox::Save:
+            if (!writeSessionToFile()) return;
+            break;
+        case QMessageBox::Discard:
+            break;
+        default:
+            return;
+        }
+    }
+    QDialog::reject();
+}

--- a/src/qt/sharedmncreatedialog.cpp
+++ b/src/qt/sharedmncreatedialog.cpp
@@ -66,11 +66,32 @@ constexpr int FEE_UTXO_TXID_ROLE{Qt::UserRole};
 constexpr int FEE_UTXO_VOUT_ROLE{Qt::UserRole + 1};
 constexpr int FEE_UTXO_VALUE_ROLE{Qt::UserRole + 2};
 
+//! Largest funding-input excess over collateral plus change accepted at
+//! freeze time without a strong warning (the excess is paid to miners as fee)
+constexpr CAmount MAX_EXPECTED_FUNDING_FEE{COIN / 100};
+
 QLabel* MakeHint(const QString& text, QWidget* parent)
 {
     auto* label{new QLabel(text, parent)};
     label->setWordWrap(true);
     return label;
+}
+
+//! Message box for text carrying untrusted content (participant labels from
+//! an imported session file): rendered as plain text so a crafted label
+//! cannot inject rich-text markup into the warning that talks about it
+int ShowPlainMessage(QWidget* parent, QMessageBox::Icon icon, const QString& title, const QString& text,
+                     QMessageBox::StandardButtons buttons = QMessageBox::Ok,
+                     QMessageBox::StandardButton default_button = QMessageBox::NoButton)
+{
+    QMessageBox box(parent);
+    box.setIcon(icon);
+    box.setWindowTitle(title);
+    box.setTextFormat(Qt::PlainText);
+    box.setText(text);
+    box.setStandardButtons(buttons);
+    if (default_button != QMessageBox::NoButton) box.setDefaultButton(default_button);
+    return box.exec();
 }
 
 QString FormatAmount(const WalletModel* wallet_model, CAmount amount)
@@ -243,6 +264,13 @@ QWidget* SharedMnCreateDialog::buildDraftPage()
     m_operator_widget = new OperatorKeyWidget(terms_box);
     connect(m_operator_widget, &OperatorKeyWidget::changed, this, &SharedMnCreateDialog::onTermsChanged);
     terms_form->addRow(tr("Operator key:"), m_operator_widget);
+
+    m_operator_session_key_label = new QLabel(terms_box);
+    m_operator_session_key_label->setTextFormat(Qt::PlainText);
+    m_operator_session_key_label->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    m_operator_session_key_label->setWordWrap(true);
+    m_operator_session_key_label->setVisible(false);
+    terms_form->addRow(QString(), m_operator_session_key_label);
 
     m_operator_secret_label = new QLabel(terms_box);
     m_operator_secret_label->setTextInteractionFlags(Qt::TextSelectableByMouse);
@@ -486,6 +514,7 @@ QWidget* SharedMnCreateDialog::buildDeadPage()
     layout->addWidget(title);
 
     m_dead_label = new QLabel(page);
+    m_dead_label->setTextFormat(Qt::PlainText); // shows imported participant labels
     m_dead_label->setWordWrap(true);
     m_dead_label->setAlignment(Qt::AlignCenter);
     layout->addWidget(m_dead_label);
@@ -700,9 +729,8 @@ void SharedMnCreateDialog::refreshContributions()
         CAmount resolved{0};
         int unknown{0};
         for (const auto& input : contribution.inputs) {
-            Coin coin;
-            if (m_node.getUnspentOutput(COutPoint(uint256S(input.txid.toStdString()), input.vout), coin)) {
-                resolved += coin.out.nValue;
+            if (const auto value{resolveInputValue(input)}) {
+                resolved += *value;
             } else {
                 ++unknown;
             }
@@ -911,9 +939,10 @@ void SharedMnCreateDialog::syncTermsToSession()
 {
     auto& terms{m_session.terms()};
     terms.coreP2PAddrs = m_service_edit->text().trimmed();
-    // Keep an imported operator key unless this dialog's widget holds a valid
-    // replacement (the widget cannot be pre-filled from a session file)
-    if (m_operator_widget->isValid()) {
+    // An imported session's operator key is the group's agreed key: never
+    // replace it with this dialog's widget (the widget cannot be pre-filled
+    // from a session file, so its "generated" key is always a local one)
+    if (!m_operator_key_from_import && m_operator_widget->isValid()) {
         terms.operatorPubKey = m_operator_widget->publicKeyHex();
     }
     terms.votingAddress = m_voting_edit->text().trimmed();
@@ -922,7 +951,9 @@ void SharedMnCreateDialog::syncTermsToSession()
     terms.earlyPenalty = m_early_penalty_field->value();
     m_session.setOperatorSecretHolder(m_secret_holder_edit->text().trimmed());
 
-    if (m_operator_widget->hasGeneratedSecret()) {
+    const bool widget_key_in_use{!m_operator_key_from_import ||
+                                 m_operator_widget->publicKeyHex() == terms.operatorPubKey};
+    if (widget_key_in_use && m_operator_widget->hasGeneratedSecret()) {
         m_operator_secret_label->setVisible(true);
         m_operator_secret_label->setText(
             tr("Operator secret key (write it down now, it is not stored anywhere): %1")
@@ -942,6 +973,21 @@ void SharedMnCreateDialog::pushTermsToWidgets()
     m_early_period_spin->setValue(static_cast<int>(terms.earlyPeriodBlocks));
     m_early_penalty_field->setValue(terms.earlyPenalty);
     m_secret_holder_edit->setText(m_session.operatorSecretHolder());
+
+    const bool imported_key{m_operator_key_from_import && !terms.operatorPubKey.isEmpty()};
+    m_operator_widget->setEnabled(!imported_key);
+    m_operator_session_key_label->setVisible(imported_key);
+    if (imported_key) {
+        m_operator_widget->setToolTip(tr("The imported session already carries the group's agreed operator key; "
+                                         "it is kept as-is."));
+        m_operator_session_key_label->setText(tr("Operator key from the imported session (used as-is): %1")
+                                                  .arg(terms.operatorPubKey));
+        if (m_operator_widget->publicKeyHex() != terms.operatorPubKey) {
+            m_operator_secret_label->setVisible(false); // the widget's local secret is not the session key
+        }
+    } else {
+        m_operator_widget->setToolTip(QString());
+    }
     m_updating = false;
 }
 
@@ -1004,7 +1050,7 @@ void SharedMnCreateDialog::adoptImportedText(const QString& text, const QString&
     MnShareSession imported;
     QString error;
     if (!imported.fromJson(text.toStdString(), error)) {
-        QMessageBox::critical(this, windowTitle(), error);
+        ShowPlainMessage(this, QMessageBox::Critical, windowTitle(), error);
         return;
     }
 
@@ -1021,20 +1067,21 @@ void SharedMnCreateDialog::adoptImportedText(const QString& text, const QString&
     switch (m_session.mergeEnvelope(imported, merge_error)) {
     case MnShareSession::MergeResult::Merged:
         if (!merge_error.isEmpty()) {
-            QMessageBox::warning(this, tr("Merged with warnings"), merge_error);
+            ShowPlainMessage(this, QMessageBox::Warning, tr("Merged with warnings"), merge_error);
         }
         markDirty();
         afterImport();
         break;
     case MnShareSession::MergeResult::OtherOlder:
-        QMessageBox::information(this, tr("Imported copy is older"), merge_error);
+        ShowPlainMessage(this, QMessageBox::Information, tr("Imported copy is older"), merge_error);
         break;
     case MnShareSession::MergeResult::OtherNewer: {
-        const auto choice{QMessageBox::question(
-            this, tr("Imported copy is newer"),
+        const int choice{ShowPlainMessage(
+            this, QMessageBox::Question, tr("Imported copy is newer"),
             merge_error + QStringLiteral("\n\n") + tr("Adopt the newer copy? Your local copy is discarded."),
             QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes)};
         if (choice == QMessageBox::Yes) {
+            unlockAllContributedCoins(); // the replaced session's coin locks would otherwise leak
             m_session = imported;
             markDirty();
             afterImport();
@@ -1045,12 +1092,14 @@ void SharedMnCreateDialog::adoptImportedText(const QString& text, const QString&
         QMessageBox box(this);
         box.setIcon(QMessageBox::Warning);
         box.setWindowTitle(tr("Session conflict"));
+        box.setTextFormat(Qt::PlainText);
         box.setText(merge_error);
         box.setInformativeText(tr("Replace this session with the imported copy, or keep working on this one?"));
         auto* replace{box.addButton(tr("Replace With Imported"), QMessageBox::DestructiveRole)};
         box.addButton(tr("Keep Mine"), QMessageBox::RejectRole);
         box.exec();
         if (box.clickedButton() == replace) {
+            unlockAllContributedCoins(); // the replaced session's coin locks would otherwise leak
             m_session = imported;
             markDirty();
             afterImport();
@@ -1084,13 +1133,20 @@ void SharedMnCreateDialog::afterImport()
         json.pushKV("sigs", sigs);
         QString error;
         m_session.fromJson(json, error); // leaves the session untouched on failure
-        QMessageBox::warning(this, tr("Signatures not counted"), bad.join(QLatin1Char('\n')));
+        ShowPlainMessage(this, QMessageBox::Warning, tr("Signatures not counted"), bad.join(QLatin1Char('\n')));
     }
+
+    // An imported envelope's operator key is the group's agreed key; from now
+    // on this dialog displays it read-only instead of the generate widget
+    m_operator_key_from_import = !m_session.terms().operatorPubKey.isEmpty();
 
     // A replacement session gets a fresh liveness verdict
     m_dead = false;
     m_dead_reason.clear();
     checkSessionLiveness();
+    // Keep the A8 invariant on this machine too: any of this wallet's coins
+    // the adopted session uses as funding inputs must be locked
+    if (!m_dead) lockKnownContributedCoins();
     refreshAll();
 }
 
@@ -1102,17 +1158,20 @@ void SharedMnCreateDialog::checkSessionLiveness()
             const COutPoint outpoint{uint256S(input.txid.toStdString()), input.vout};
             Coin coin;
             if (m_node.getUnspentOutput(outpoint, coin)) continue;
-            // Not in the confirmed UTXO set. A wallet-known unconfirmed output
-            // is merely pending; anything else is spent (or never existed)
-            if (m_wallet_model != nullptr) {
-                const auto known{m_wallet_model->wallet().getCoins({outpoint})};
-                if (!known.empty() && known.front().depth_in_main_chain >= 0 && !known.front().is_spent) continue;
-            }
+            // Not in the confirmed UTXO set — which alone proves nothing:
+            // getUnspentOutput consults neither the mempool nor other wallets,
+            // so another participant's unconfirmed chip looks exactly the
+            // same. Only an input this wallet tracks and reports spent is
+            // proof the funding transaction can never confirm.
+            if (m_wallet_model == nullptr) continue;
+            const auto known{m_wallet_model->wallet().getCoins({outpoint})};
+            if (known.empty() || known.front().depth_in_main_chain < 0) continue; // unknown here: pending
+            if (!known.front().is_spent) continue; // own unconfirmed output: pending
             spent << tr("%1:%2 (contributed by %3)").arg(input.txid).arg(input.vout).arg(contribution.label);
         }
     }
     if (!spent.isEmpty()) {
-        markDead(tr("A funding input of this session was spent (or does not exist), so the recorded funding "
+        markDead(tr("A funding input contributed from this wallet was spent, so the recorded funding "
                     "transaction can never confirm. The session cannot be continued — restart from a new draft.") +
                  QStringLiteral("\n\n") + spent.join(QLatin1Char('\n')));
     }
@@ -1454,6 +1513,34 @@ void SharedMnCreateDialog::unlockAllContributedCoins()
     }
 }
 
+std::optional<CAmount> SharedMnCreateDialog::resolveInputValue(const MnShareSession::Input& input) const
+{
+    const COutPoint outpoint{uint256S(input.txid.toStdString()), input.vout};
+    Coin coin;
+    if (m_node.getUnspentOutput(outpoint, coin)) return coin.out.nValue;
+    // Not confirmed: this wallet can still value its own pending outputs
+    if (m_wallet_model != nullptr) {
+        const auto known{m_wallet_model->wallet().getCoins({outpoint})};
+        if (!known.empty() && known.front().depth_in_main_chain >= 0 && !known.front().is_spent) {
+            return known.front().txout.nValue;
+        }
+    }
+    return std::nullopt;
+}
+
+void SharedMnCreateDialog::lockKnownContributedCoins()
+{
+    if (m_wallet_model == nullptr) return;
+    for (const auto& contribution : m_session.contributions()) {
+        for (const auto& input : contribution.inputs) {
+            const COutPoint outpoint{uint256S(input.txid.toStdString()), input.vout};
+            const auto known{m_wallet_model->wallet().getCoins({outpoint})};
+            if (known.empty() || known.front().depth_in_main_chain < 0 || known.front().is_spent) continue;
+            m_wallet_model->wallet().lockCoin(outpoint, /*write_to_db=*/true);
+        }
+    }
+}
+
 void SharedMnCreateDialog::freezeSession()
 {
     if (m_session.stage() != MnShareSession::Stage::Draft || m_busy) return;
@@ -1471,12 +1558,61 @@ void SharedMnCreateDialog::freezeSession()
         return;
     }
 
+    // Funding sufficiency gate. register_shared_prepare cannot value-check the
+    // inputs (they may be unconfirmed), so a mismatch would otherwise surface
+    // only at the final broadcast — or silently overpay the excess to miners.
+    // Inputs this node cannot resolve (other participants' unconfirmed chips)
+    // are surfaced honestly instead of blocking the flow.
+    const CAmount collateral{GetMnType(MnType::Regular).collat_amount};
+    CAmount change_total{0};
+    CAmount resolved_total{0};
+    int unresolved{0};
+    for (const auto& contribution : m_session.contributions()) {
+        if (contribution.hasChange) change_total += contribution.changeAmount;
+        for (const auto& input : contribution.inputs) {
+            if (const auto value{resolveInputValue(input)}) {
+                resolved_total += *value;
+            } else {
+                ++unresolved;
+            }
+        }
+    }
+    QString funding_note;
+    if (unresolved == 0) {
+        const CAmount implied_fee{resolved_total - collateral - change_total};
+        if (implied_fee <= 0) {
+            QMessageBox::critical(
+                this, tr("Funding is insufficient"),
+                tr("The recorded funding inputs total %1, but the collateral (%2) plus change (%3) plus a positive "
+                   "transaction fee requires more. The funding transaction could never be broadcast — adjust the "
+                   "contributions before freezing.")
+                    .arg(FormatAmount(m_wallet_model, resolved_total), FormatAmount(m_wallet_model, collateral),
+                         FormatAmount(m_wallet_model, change_total)));
+            return;
+        }
+        if (implied_fee > MAX_EXPECTED_FUNDING_FEE) {
+            funding_note = tr("WARNING: the funding inputs exceed the collateral plus change by %1 — that entire "
+                              "excess would be paid to miners as the transaction fee. Continue only if this is "
+                              "intended.")
+                               .arg(FormatAmount(m_wallet_model, implied_fee));
+        } else {
+            funding_note = tr("The funding inputs cover the collateral; %1 pays the transaction fee.")
+                               .arg(FormatAmount(m_wallet_model, implied_fee));
+        }
+    } else {
+        funding_note = tr("%n funding input(s) cannot be value-checked on this node yet (other participants' "
+                          "unconfirmed contributions). Resolved inputs total %1 of the %2 collateral — make sure "
+                          "every contribution is exactly its share total before freezing.",
+                          nullptr, unresolved)
+                           .arg(FormatAmount(m_wallet_model, resolved_total), FormatAmount(m_wallet_model, collateral));
+    }
+
     const auto choice{QMessageBox::question(
         this, tr("Freeze the session terms?"),
         tr("Freezing prepares the registration transaction and fixes the share table, the terms and every funding "
            "input. Afterwards every share owner must sign the consent check phrase; any further change discards all "
            "collected signatures.") +
-            QStringLiteral("\n\n") +
+            QStringLiteral("\n\n") + funding_note + QStringLiteral("\n\n") +
             tr("Make sure every participant has contributed funding — the funding inputs cannot be changed without "
                "unfreezing."),
         QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Yes)};
@@ -1572,7 +1708,7 @@ void SharedMnCreateDialog::signConsent()
         }
     }
     if (!errors.isEmpty()) {
-        QMessageBox::warning(this, tr("Signing finished with warnings"), errors.join(QLatin1Char('\n')));
+        ShowPlainMessage(this, QMessageBox::Warning, tr("Signing finished with warnings"), errors.join(QLatin1Char('\n')));
     }
     markDirty();
     refreshAll();
@@ -1735,6 +1871,7 @@ void SharedMnCreateDialog::restartFromDraft()
     m_dead = false;
     m_dead_reason.clear();
     m_dirty = false;
+    m_operator_key_from_import = false;
     refreshFundingCandidates();
     refreshAll();
 }
@@ -1742,19 +1879,31 @@ void SharedMnCreateDialog::restartFromDraft()
 void SharedMnCreateDialog::reject()
 {
     if (m_busy) return;
-    if (m_dirty && !m_dead) {
+    if (m_dead) {
+        // A dead session can never continue; closing must not strand the
+        // funding coin locks (the restart button unlocks them the same way)
+        unlockAllContributedCoins();
+        QDialog::reject();
+        return;
+    }
+    if (m_dirty) {
         QMessageBox box(this);
         box.setIcon(QMessageBox::Question);
         box.setWindowTitle(windowTitle());
         box.setText(tr("The session has unsaved changes. A participant without the latest copy cannot continue the "
                        "session."));
+        if (!m_session.contributions().empty() && m_session.stage() != MnShareSession::Stage::Broadcast) {
+            box.setInformativeText(tr("Discarding also unlocks the coins this session reserved for funding; save "
+                                      "instead to keep them reserved and continue later."));
+        }
         box.setStandardButtons(QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel);
         box.setDefaultButton(QMessageBox::Save);
         switch (box.exec()) {
         case QMessageBox::Save:
             if (!writeSessionToFile()) return;
-            break;
+            break; // saved to continue later: the funding coins stay locked
         case QMessageBox::Discard:
+            if (m_session.stage() != MnShareSession::Stage::Broadcast) unlockAllContributedCoins();
             break;
         default:
             return;

--- a/src/qt/sharedmncreatedialog.h
+++ b/src/qt/sharedmncreatedialog.h
@@ -158,6 +158,13 @@ private:
     //! Lock or unlock a contribution's inputs in this wallet
     void setContributionLocked(const MnShareSession::Contribution& contribution, bool lock);
     void unlockAllContributedCoins();
+    //! Lock every contribution input this wallet knows (after adopting an
+    //! imported session, so its funding coins cannot be spent by accident)
+    void lockKnownContributedCoins();
+    //! Value of a recorded funding input: from the confirmed UTXO set, or
+    //! from this wallet for its own (possibly unconfirmed) outputs; nullopt
+    //! for other participants' unconfirmed inputs
+    std::optional<CAmount> resolveInputValue(const MnShareSession::Input& input) const;
 
     interfaces::Node& m_node;
     WalletModel* const m_wallet_model;
@@ -170,6 +177,9 @@ private:
     bool m_dead{false};
     QString m_dead_reason;
     bool m_updating{false}; //!< guards table/widget refresh against change signals
+    //! The session was imported with an agreed operator key: display it
+    //! read-only and never overwrite it from this dialog's key widget
+    bool m_operator_key_from_import{false};
 
     // Header
     QLabel* m_breadcrumb{nullptr};
@@ -190,6 +200,7 @@ private:
     QLineEdit* m_service_edit{nullptr};
     OperatorKeyWidget* m_operator_widget{nullptr};
     QLabel* m_operator_secret_label{nullptr};
+    QLabel* m_operator_session_key_label{nullptr};
     QLineEdit* m_secret_holder_edit{nullptr};
     QLineEdit* m_voting_edit{nullptr};
     QDoubleSpinBox* m_operator_reward_spin{nullptr};

--- a/src/qt/sharedmncreatedialog.h
+++ b/src/qt/sharedmncreatedialog.h
@@ -1,0 +1,234 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_SHAREDMNCREATEDIALOG_H
+#define BITCOIN_QT_SHAREDMNCREATEDIALOG_H
+
+#include <consensus/amount.h>
+
+#include <qt/mnsharesession.h>
+
+#include <QDialog>
+#include <QString>
+
+#include <optional>
+#include <vector>
+
+class BitcoinAmountField;
+class OperatorKeyWidget;
+class ProTxSender;
+struct ProTxResult;
+class UniValue;
+class WalletModel;
+
+namespace interfaces {
+class Node;
+} // namespace interfaces
+
+QT_BEGIN_NAMESPACE
+class QCheckBox;
+class QComboBox;
+class QDoubleSpinBox;
+class QLabel;
+class QLineEdit;
+class QListWidget;
+class QPushButton;
+class QSpinBox;
+class QStackedWidget;
+class QTableWidget;
+QT_END_NAMESPACE
+
+//! Resumable multi-party session dialog creating a shared masternode: a group
+//! drafts a share table and terms, pools funding inputs, freezes the terms via
+//! "protx register_shared_prepare", collects every share owner's consent
+//! signature, combines them, has each contributor sign their funding inputs
+//! and finally broadcasts the registration. The session state lives in one
+//! MnShareSession envelope that participants pass around as JSON (clipboard or
+//! file); any participant holding the latest copy can continue the session in
+//! this dialog.
+class SharedMnCreateDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit SharedMnCreateDialog(interfaces::Node& node, WalletModel* wallet_model, QWidget* parent = nullptr);
+    ~SharedMnCreateDialog() override;
+
+    //! Close protection: prompts to save an unsaved session first
+    void reject() override;
+
+private Q_SLOTS:
+    // Session envelope plumbing (always available)
+    void importFromClipboard();
+    void exportToClipboard();
+    void loadFromFile();
+    void saveToFile();
+
+    // Draft page
+    void addShareRow();
+    void removeShareRow();
+    void useMyWalletAddress();
+    void onShareCellChanged(int row, int column);
+    void onTermsChanged();
+    void addMyFunding();
+    void removeSelectedContribution();
+    void refreshFundingCandidates();
+    void freezeSession();
+
+    // Frozen/Signing page
+    void signConsent();
+    void unfreezeSession();
+
+    // Combined page
+    void combineSignatures();
+    void signFundingInputs();
+
+    // Broadcast page
+    void broadcastSession();
+
+    // Dead-session page
+    void restartFromDraft();
+
+private:
+    enum Page : int {
+        PageDraft = 0,
+        PageSigning,
+        PageCombined,
+        PageBroadcast,
+        PageDead,
+    };
+
+    QWidget* buildHeader();
+    QWidget* buildDraftPage();
+    QWidget* buildSigningPage();
+    QWidget* buildCombinedPage();
+    QWidget* buildBroadcastPage();
+    QWidget* buildDeadPage();
+
+    //! True when a wallet able to sign is selected
+    bool canSign() const;
+    //! Execute one RPC command on the bridge, waiting in a nested event loop on
+    //! the GUI thread (keeps the non-movable unlock context alive when
+    //! needs_unlock). Returns false when the call could not be started.
+    bool runRpc(const QString& method, const UniValue& params, bool needs_unlock, ProTxResult& result);
+    void setBusy(bool busy);
+
+    // Session -> UI
+    void refreshAll();
+    void refreshHeader();
+    void refreshDraftPage();
+    void refreshSharesTable();
+    void refreshValidation();
+    void refreshContributions();
+    void refreshSigningPage();
+    void refreshCombinedPage();
+    void refreshBroadcastPage();
+
+    // UI -> session
+    void syncShareFromTable(int row);
+    void syncTermsToSession();
+    void pushTermsToWidgets();
+
+    //! Parse an imported envelope and adopt or merge it into the current session
+    void adoptImportedText(const QString& text, const QString& source);
+    void afterImport();
+    //! A8: re-check that every recorded funding input is still unspent
+    void checkSessionLiveness();
+    void markDead(const QString& reason);
+    void markDirty();
+    //! Prompt to circulate the updated envelope (clipboard + file, per A3)
+    void offerExport(const QString& why);
+    bool writeSessionToFile();
+
+    //! Share indexes whose owner key this wallet can sign with
+    std::vector<int> myShareIndexes() const;
+    //! Sum of this wallet's share amounts (what "my funding" must contribute)
+    CAmount myShareTotal() const;
+    //! Fresh receive address from the wallet, or empty with an error set
+    QString freshAddress(QString& error) const;
+    //! Send exactly `amount` to a fresh own address and return the created
+    //! outpoint (the "chip" that becomes this participant's funding input)
+    std::optional<MnShareSession::Input> prepareFundingChip(CAmount amount, QString& error);
+    //! Find a single unlocked wallet UTXO of exactly `amount`
+    std::optional<MnShareSession::Input> findFundingChip(CAmount amount) const;
+    //! Replace the session's transaction hex in place (partially signed funding
+    //! inputs) without changing the stage, via an envelope round-trip
+    bool replaceSessionProTx(const QString& tx_hex, QString& error);
+    //! Lock or unlock a contribution's inputs in this wallet
+    void setContributionLocked(const MnShareSession::Contribution& contribution, bool lock);
+    void unlockAllContributedCoins();
+
+    interfaces::Node& m_node;
+    WalletModel* const m_wallet_model;
+    const bool m_v24_active;
+    MnShareSession m_session;
+    ProTxSender* const m_sender;
+
+    bool m_busy{false};
+    bool m_dirty{false};
+    bool m_dead{false};
+    QString m_dead_reason;
+    bool m_updating{false}; //!< guards table/widget refresh against change signals
+
+    // Header
+    QLabel* m_breadcrumb{nullptr};
+    QLabel* m_phrase_label{nullptr};
+    QLabel* m_phrase_hint{nullptr};
+    QPushButton* m_import_button{nullptr};
+    QPushButton* m_export_button{nullptr};
+    QPushButton* m_load_button{nullptr};
+    QPushButton* m_save_button{nullptr};
+
+    QStackedWidget* m_pages{nullptr};
+
+    // Draft page
+    QTableWidget* m_share_table{nullptr};
+    QPushButton* m_add_share_button{nullptr};
+    QPushButton* m_remove_share_button{nullptr};
+    QPushButton* m_my_address_button{nullptr};
+    QLineEdit* m_service_edit{nullptr};
+    OperatorKeyWidget* m_operator_widget{nullptr};
+    QLabel* m_operator_secret_label{nullptr};
+    QLineEdit* m_secret_holder_edit{nullptr};
+    QLineEdit* m_voting_edit{nullptr};
+    QDoubleSpinBox* m_operator_reward_spin{nullptr};
+    QSpinBox* m_early_period_spin{nullptr};
+    QLabel* m_early_period_hint{nullptr};
+    BitcoinAmountField* m_early_penalty_field{nullptr};
+    QLabel* m_early_penalty_hint{nullptr};
+    QListWidget* m_validation_list{nullptr};
+    QLabel* m_sum_label{nullptr};
+    QLineEdit* m_my_label_edit{nullptr};
+    QCheckBox* m_coordinator_check{nullptr};
+    BitcoinAmountField* m_fee_amount_field{nullptr};
+    QComboBox* m_fee_utxo_combo{nullptr};
+    QPushButton* m_add_funding_button{nullptr};
+    QPushButton* m_remove_funding_button{nullptr};
+    QPushButton* m_refresh_funding_button{nullptr};
+    QListWidget* m_contrib_list{nullptr};
+    QLabel* m_funding_status_label{nullptr};
+    QPushButton* m_freeze_button{nullptr};
+
+    // Frozen/Signing page
+    QLabel* m_term_sheet{nullptr};
+    QTableWidget* m_sig_table{nullptr};
+    QPushButton* m_sign_button{nullptr};
+    QPushButton* m_unfreeze_button{nullptr};
+
+    // Combined page
+    QLabel* m_combined_status{nullptr};
+    QPushButton* m_combine_button{nullptr};
+    QListWidget* m_funding_sig_list{nullptr};
+    QPushButton* m_sign_funding_button{nullptr};
+
+    // Broadcast page
+    QLabel* m_broadcast_summary{nullptr};
+    QPushButton* m_broadcast_button{nullptr};
+    QLabel* m_success_label{nullptr};
+
+    // Dead page
+    QLabel* m_dead_label{nullptr};
+};
+
+#endif // BITCOIN_QT_SHAREDMNCREATEDIALOG_H

--- a/src/qt/sharedmndialogs.cpp
+++ b/src/qt/sharedmndialogs.cpp
@@ -1,0 +1,1495 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/sharedmndialogs.h>
+
+#include <chainparams.h>
+#include <coins.h>
+#include <core_io.h>
+#include <evo/providertx.h>
+#include <evo/specialtx.h>
+#include <hash.h>
+#include <interfaces/node.h>
+#include <interfaces/wallet.h>
+#include <key_io.h>
+#include <messagesigner.h>
+#include <primitives/transaction.h>
+#include <script/standard.h>
+#include <uint256.h>
+#include <univalue.h>
+#include <util/strencodings.h>
+
+#include <qt/bitcoinunits.h>
+#include <qt/guiutil.h>
+#include <qt/masternodemodel.h>
+#include <qt/masternodewidgets.h>
+#include <qt/mnsharesession.h>
+#include <qt/protxsender.h>
+#include <qt/qvalidatedlineedit.h>
+#include <qt/walletmodel.h>
+
+#include <QApplication>
+#include <QCheckBox>
+#include <QClipboard>
+#include <QComboBox>
+#include <QCoreApplication>
+#include <QDateTime>
+#include <QDialogButtonBox>
+#include <QEventLoop>
+#include <QFile>
+#include <QFormLayout>
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QLabel>
+#include <QLineEdit>
+#include <QLocale>
+#include <QMessageBox>
+#include <QPlainTextEdit>
+#include <QPushButton>
+#include <QRegularExpression>
+#include <QSettings>
+#include <QSpinBox>
+#include <QStringList>
+#include <QTabWidget>
+#include <QTableWidget>
+#include <QTextStream>
+#include <QVBoxLayout>
+
+#include <algorithm>
+#include <optional>
+
+namespace {
+
+constexpr const char* SIG_ENVELOPE_TYPE{"dash-shared-mn-sigs"};
+constexpr int SIG_ENVELOPE_VERSION{1};
+//! Duffs; mirrors the RPC-side default of "protx dissolve" / "protx dissolve_prepare"
+constexpr int DEFAULT_DISSOLVE_FEE{100000};
+//! ~14 days of 2.5-minute blocks: below this distance to the penalty-free
+//! boundary the unilateral tab suggests waiting instead
+constexpr int NUDGE_BOUNDARY_BLOCKS{14 * 24 * 24};
+constexpr qint64 SECONDS_PER_BLOCK{150};
+constexpr qint64 MAX_ENVELOPE_FILE_BYTES{2 * 1024 * 1024};
+
+QString OwnerAddress(const interfaces::MnShare& share)
+{
+    return QString::fromStdString(EncodeDestination(PKHash(share.keyIDOwner)));
+}
+
+QString ScriptAddress(const CScript& script)
+{
+    CTxDestination dest;
+    if (!ExtractDestination(script, dest)) return {};
+    return QString::fromStdString(EncodeDestination(dest));
+}
+
+QString FormatDash(CAmount amount)
+{
+    return BitcoinUnits::formatWithUnit(BitcoinUnits::Unit::DASH, amount);
+}
+
+//! "block N (~date)" for a block `blocks_ahead` past the current tip
+QString ApproxBlockDate(int blocks_ahead)
+{
+    const QDateTime when{QDateTime::currentDateTime().addSecs(static_cast<qint64>(blocks_ahead) * SECONDS_PER_BLOCK)};
+    return QLocale().toString(when, QLocale::ShortFormat);
+}
+
+//! Recompute the digest the share owners of `pro_tx_hash` must sign for
+//! `tx_hex`, mirroring the resolution in "protx shared_sign"
+bool ComputeSharedSignHash(SharedSigCollector::Kind kind, const QString& pro_tx_hash, size_t share_count,
+                           const QString& tx_hex, uint256& hash, QString& error)
+{
+    const auto Tr = [](const char* text) { return QCoreApplication::translate("SharedSigCollector", text); };
+
+    CMutableTransaction tx;
+    if (!DecodeHexTx(tx, tx_hex.toStdString())) {
+        error = Tr("The transaction is not valid transaction hex.");
+        return false;
+    }
+    if (kind == SharedSigCollector::Kind::Dissolve) {
+        if (tx.nType != TRANSACTION_PROVIDER_DISSOLVE) {
+            error = Tr("The transaction is not a dissolution transaction.");
+            return false;
+        }
+        const auto opt_ptx = GetTxPayload<CProDisTx>(tx);
+        if (!opt_ptx) {
+            error = Tr("The transaction payload is not deserializable.");
+            return false;
+        }
+        if (QString::fromStdString(opt_ptx->proTxHash.ToString()).compare(pro_tx_hash, Qt::CaseInsensitive) != 0) {
+            error = Tr("The transaction dissolves a different masternode.");
+            return false;
+        }
+        if (!opt_ptx->vchSigs.empty()) {
+            error = Tr("The transaction already carries signatures; expected the unsigned prepared transaction.");
+            return false;
+        }
+        // Unanimous mode: the digest commits to one signature per share
+        hash = opt_ptx->MakeSignHash(CTransaction(tx), static_cast<uint8_t>(share_count));
+        return true;
+    }
+    if (tx.nType != TRANSACTION_PROVIDER_UPDATE_SHARED_REGISTRAR) {
+        error = Tr("The transaction is not a shared registrar update.");
+        return false;
+    }
+    const auto opt_ptx = GetTxPayload<CProUpSharedRegTx>(tx);
+    if (!opt_ptx) {
+        error = Tr("The transaction payload is not deserializable.");
+        return false;
+    }
+    if (QString::fromStdString(opt_ptx->proTxHash.ToString()).compare(pro_tx_hash, Qt::CaseInsensitive) != 0) {
+        error = Tr("The transaction updates a different masternode.");
+        return false;
+    }
+    // SER_GETHASH serialization excludes the signature vector
+    hash = ::SerializeHash(*opt_ptx);
+    return true;
+}
+
+} // anonymous namespace
+
+// ----------------------------------------------------------------------------
+// UpdateShareDialog
+// ----------------------------------------------------------------------------
+
+UpdateShareDialog::UpdateShareDialog(interfaces::Node& node, WalletModel* wallet_model, const MasternodeEntry& entry, QWidget* parent) :
+    MasternodeActionDialog(node, wallet_model, entry, parent),
+    m_v24_active{node.isV24Active()}
+{
+    auto* form = new QFormLayout();
+
+    m_share_combo = new QComboBox(this);
+    const auto& shares = entry.shares();
+    for (size_t i = 0; i < shares.size(); ++i) {
+        if (!wallet_model || wallet_model->wallet().privateKeysDisabled()) break;
+        if (!wallet_model->wallet().isSpendable(PKHash(shares[i].keyIDOwner))) continue;
+        m_share_combo->addItem(tr("Share #%1 — %2 — %3").arg(i).arg(FormatDash(shares[i].amount), OwnerAddress(shares[i])),
+                               static_cast<int>(i));
+    }
+    connect(m_share_combo, qOverload<int>(&QComboBox::currentIndexChanged), this, &UpdateShareDialog::validate);
+    form->addRow(tr("My share:"), m_share_combo);
+
+    m_reward_edit = new QValidatedLineEdit(this);
+    GUIUtil::setupAddressWidget(m_reward_edit, this);
+    m_reward_edit->setPlaceholderText(tr("Leave blank to pay rewards to the immutable refund address again"));
+    connect(m_reward_edit, &QLineEdit::textChanged, this, &UpdateShareDialog::validate);
+    form->addRow(tr("New reward address:"), m_reward_edit);
+
+    m_fee_source = new FeeSourcePicker(this);
+    m_fee_source->setWalletModel(wallet_model);
+    m_fee_source->refresh();
+    connect(m_fee_source, qOverload<int>(&QComboBox::currentIndexChanged), this, &UpdateShareDialog::validate);
+    form->addRow(tr("Fee source:"), m_fee_source);
+
+    setupUi(tr("Update Share Reward Address"),
+            tr("Change where one collateral share of this shared masternode receives its owner rewards. Only the share's owner key (held by this wallet) can change it; the share amount and refund address are immutable."),
+            form, tr("Send Update"));
+
+    if (!m_is_shared) {
+        showError(tr("This masternode is not shared and has no share table."));
+    } else if (!m_v24_active) {
+        showError(tr("Shared masternode maintenance requires the v24 hard fork to be active."));
+    } else if (m_share_combo->count() == 0) {
+        showError(tr("This wallet does not hold any of this masternode's share owner keys."));
+    }
+    validate();
+}
+
+void UpdateShareDialog::validate()
+{
+    bool ok{m_is_shared && m_v24_active};
+    ok &= m_share_combo->currentIndex() >= 0;
+    ok &= m_reward_edit->text().isEmpty() || m_reward_edit->isValid();
+    ok &= !m_fee_source->selectedAddress().isEmpty();
+    setOkValid(ok);
+}
+
+void UpdateShareDialog::submit()
+{
+    if (m_share_combo->currentIndex() < 0) return;
+
+    UniValue params(UniValue::VOBJ);
+    params.pushKV("proTxHash", m_protx_hash.toStdString());
+    params.pushKV("shareIndex", m_share_combo->currentData().toInt());
+    // An empty string reverts rewards to the refund script
+    params.pushKV("rewardAddress", m_reward_edit->text().trimmed().toStdString());
+    params.pushKV("feeSourceAddress", m_fee_source->selectedAddress().toStdString());
+
+    runProTx("protx update_share", params);
+}
+
+// ----------------------------------------------------------------------------
+// SharedSigCollector
+// ----------------------------------------------------------------------------
+
+SharedSigCollector::SharedSigCollector(Kind kind, const QString& pro_tx_hash,
+                                       const std::vector<interfaces::MnShare>& shares, QWidget* parent) :
+    QWidget(parent),
+    m_kind{kind},
+    m_protx_hash{pro_tx_hash},
+    m_shares{shares}
+{
+    auto* layout = new QVBoxLayout(this);
+    layout->setContentsMargins(0, 0, 0, 0);
+
+    m_phrase_label = new QLabel(this);
+    QFont phrase_font{m_phrase_label->font()};
+    phrase_font.setPointSize(phrase_font.pointSize() + 8);
+    phrase_font.setBold(true);
+    phrase_font.setLetterSpacing(QFont::AbsoluteSpacing, 2);
+    m_phrase_label->setFont(phrase_font);
+    m_phrase_label->setAlignment(Qt::AlignCenter);
+    m_phrase_label->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    layout->addWidget(m_phrase_label);
+
+    auto* phrase_caption = new QLabel(tr("Check phrase — every participant must see the same phrase; read it aloud to each other before anyone signs."), this);
+    phrase_caption->setWordWrap(true);
+    phrase_caption->setAlignment(Qt::AlignCenter);
+    layout->addWidget(phrase_caption);
+
+    m_tx_view = new QPlainTextEdit(this);
+    m_tx_view->setReadOnly(true);
+    m_tx_view->setFont(GUIUtil::fixedPitchFont());
+    m_tx_view->setMaximumHeight(90);
+    m_tx_view->setPlaceholderText(tr("No prepared transaction yet — start the flow on one wallet, or import its session here."));
+    layout->addWidget(m_tx_view);
+
+    auto* buttons = new QHBoxLayout();
+    m_copy_button = new QPushButton(tr("Copy session"), this);
+    connect(m_copy_button, &QPushButton::clicked, this, &SharedSigCollector::copyEnvelope);
+    buttons->addWidget(m_copy_button);
+    m_save_button = new QPushButton(tr("Save session…"), this);
+    connect(m_save_button, &QPushButton::clicked, this, &SharedSigCollector::saveEnvelope);
+    buttons->addWidget(m_save_button);
+    auto* paste_button = new QPushButton(tr("Import from clipboard"), this);
+    connect(paste_button, &QPushButton::clicked, this, &SharedSigCollector::pasteEnvelope);
+    buttons->addWidget(paste_button);
+    auto* load_button = new QPushButton(tr("Import from file…"), this);
+    connect(load_button, &QPushButton::clicked, this, &SharedSigCollector::loadEnvelope);
+    buttons->addWidget(load_button);
+    buttons->addStretch();
+    layout->addLayout(buttons);
+
+    m_checklist_label = new QLabel(this);
+    m_checklist_label->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    layout->addWidget(m_checklist_label);
+
+    m_status_label = new QLabel(this);
+    m_status_label->setWordWrap(true);
+    m_status_label->setVisible(false);
+    layout->addWidget(m_status_label);
+
+    refreshUi();
+}
+
+QString SharedSigCollector::signHashHex() const
+{
+    if (m_tx_hex.isEmpty()) return {};
+    uint256 hash;
+    QString error;
+    if (!ComputeSharedSignHash(m_kind, m_protx_hash, m_shares.size(), m_tx_hex, hash, error)) return {};
+    return QString::fromStdString(hash.ToString());
+}
+
+bool SharedSigCollector::setTransaction(const QString& tx_hex, QString& error)
+{
+    const QString trimmed{tx_hex.trimmed()};
+    uint256 hash;
+    if (!ComputeSharedSignHash(m_kind, m_protx_hash, m_shares.size(), trimmed, hash, error)) {
+        return false;
+    }
+    if (!m_tx_hex.isEmpty() && m_tx_hex != trimmed) {
+        error = tr("The imported session carries a different transaction than the one already adopted — one of the two copies is stale. Discard the stale one and re-import.");
+        return false;
+    }
+    if (m_tx_hex == trimmed) return true;
+    m_tx_hex = trimmed;
+    refreshUi();
+    Q_EMIT changed();
+    return true;
+}
+
+int SharedSigCollector::addSignatures(const UniValue& entries, QString& error)
+{
+    QStringList problems;
+    if (m_tx_hex.isEmpty()) {
+        error = tr("Import the session with its prepared transaction before importing signatures.");
+        return 0;
+    }
+    uint256 sign_hash;
+    if (QString hash_err; !ComputeSharedSignHash(m_kind, m_protx_hash, m_shares.size(), m_tx_hex, sign_hash, hash_err)) {
+        error = hash_err;
+        return 0;
+    }
+    if (!entries.isArray()) {
+        error = tr("Expected an array of {shareIndex, signature} entries.");
+        return 0;
+    }
+
+    int absorbed{0};
+    for (const UniValue& entry : entries.getValues()) {
+        if (!entry.isObject() || !entry.exists("shareIndex") || !entry.exists("signature")) {
+            problems << tr("An entry is missing shareIndex or signature.");
+            continue;
+        }
+        int index{-1};
+        try {
+            index = entry.find_value("shareIndex").getInt<int>();
+        } catch (const std::exception&) {
+            problems << tr("An entry has a non-numeric shareIndex.");
+            continue;
+        }
+        if (index < 0 || static_cast<size_t>(index) >= m_shares.size()) {
+            problems << tr("Share index %1 is out of range.").arg(index);
+            continue;
+        }
+        const QString sig_b64{QString::fromStdString(entry.find_value("signature").isStr() ? entry.find_value("signature").get_str() : std::string{})};
+        const auto sig{DecodeBase64(sig_b64.toStdString())};
+        if (!sig || sig->size() != 65) {
+            problems << tr("Share #%1: the signature is not a base64 65-byte compact signature.").arg(index);
+            continue;
+        }
+        if (std::string str_error; !CHashSigner::VerifyHashCanonical(sign_hash, m_shares[index].keyIDOwner, *sig, str_error)) {
+            problems << tr("Share #%1: the signature does not verify against the share owner key (%2) — it was probably made for an older version of the transaction. Ask the owner to re-sign the current one.")
+                            .arg(index)
+                            .arg(OwnerAddress(m_shares[index]));
+            continue;
+        }
+        const auto it = m_sigs.find(index);
+        if (it != m_sigs.end()) {
+            if (DecodeBase64(it->second.toStdString()) == sig) continue; // byte-identical duplicate
+            problems << tr("Share #%1: a different valid signature is already stored; keeping the existing one.").arg(index);
+            continue;
+        }
+        m_sigs.emplace(index, sig_b64);
+        ++absorbed;
+    }
+    error = problems.join(QLatin1Char('\n'));
+    if (absorbed > 0) {
+        refreshUi();
+        Q_EMIT changed();
+    }
+    return absorbed;
+}
+
+UniValue SharedSigCollector::signaturesArray() const
+{
+    UniValue arr(UniValue::VARR);
+    for (const auto& [index, sig] : m_sigs) {
+        UniValue entry(UniValue::VOBJ);
+        entry.pushKV("shareIndex", index);
+        entry.pushKV("signature", sig.toStdString());
+        arr.push_back(entry);
+    }
+    return arr;
+}
+
+UniValue SharedSigCollector::envelopeJson() const
+{
+    UniValue json(UniValue::VOBJ);
+    json.pushKV("type", SIG_ENVELOPE_TYPE);
+    json.pushKV("version", SIG_ENVELOPE_VERSION);
+    json.pushKV("network", Params().NetworkIDString());
+    json.pushKV("kind", m_kind == Kind::Dissolve ? "dissolve" : "registrar");
+    json.pushKV("proTxHash", m_protx_hash.toStdString());
+    json.pushKV("tx", m_tx_hex.toStdString());
+    json.pushKV("signatures", signaturesArray());
+    return json;
+}
+
+bool SharedSigCollector::importEnvelope(const QString& text, QString& error)
+{
+    UniValue json;
+    if (!json.read(text.trimmed().toStdString())) {
+        error = tr("The import is not valid JSON.");
+        return false;
+    }
+    try {
+        return importEnvelopeChecked(json, error);
+    } catch (const std::exception&) {
+        // UniValue accessors throw on unexpectedly typed fields
+        error = tr("The import is not a valid shared masternode signing session.");
+        return false;
+    }
+}
+
+bool SharedSigCollector::importEnvelopeChecked(const UniValue& json, QString& error)
+{
+    // A bare array is accepted as signature entries for the already-adopted transaction
+    if (json.isArray()) {
+        QString sig_error;
+        const int absorbed{addSignatures(json, sig_error)};
+        error = sig_error;
+        return absorbed > 0 || sig_error.isEmpty();
+    }
+    if (!json.isObject() || !json.exists("type") || json.find_value("type").get_str() != SIG_ENVELOPE_TYPE) {
+        error = tr("The import is not a shared masternode signing session.");
+        return false;
+    }
+    const std::string our_network{Params().NetworkIDString()};
+    const std::string their_network{json.exists("network") ? json.find_value("network").get_str() : std::string{}};
+    if (their_network != our_network) {
+        error = tr("The session belongs to the %1 network but this node runs %2.")
+                    .arg(QString::fromStdString(their_network), QString::fromStdString(our_network));
+        return false;
+    }
+    const std::string expected_kind{m_kind == Kind::Dissolve ? "dissolve" : "registrar"};
+    if (!json.exists("kind") || json.find_value("kind").get_str() != expected_kind) {
+        error = tr("The session is for a different kind of shared masternode transaction.");
+        return false;
+    }
+    if (!json.exists("proTxHash") ||
+        QString::fromStdString(json.find_value("proTxHash").get_str()).compare(m_protx_hash, Qt::CaseInsensitive) != 0) {
+        error = tr("The session belongs to a different masternode.");
+        return false;
+    }
+    if (json.exists("tx") && !json.find_value("tx").get_str().empty()) {
+        if (!setTransaction(QString::fromStdString(json.find_value("tx").get_str()), error)) {
+            return false;
+        }
+    }
+    if (json.exists("signatures")) {
+        QString sig_error;
+        addSignatures(json.find_value("signatures"), sig_error);
+        error = sig_error;
+    }
+    return true;
+}
+
+void SharedSigCollector::copyEnvelope()
+{
+    GUIUtil::setClipboard(QString::fromStdString(envelopeJson().write(/*prettyIndent=*/2)));
+    showStatus(tr("Session copied to clipboard. Also save it to a file — the session is the only shared state, and any participant with the latest copy can continue it."), /*error=*/false);
+}
+
+void SharedSigCollector::saveEnvelope()
+{
+    const QString filename{GUIUtil::getSaveFileName(this, tr("Save Signing Session"), QString{},
+                                                    tr("Shared masternode session (*.json)"), nullptr)};
+    if (filename.isEmpty()) return;
+    QFile file(filename);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        showStatus(tr("Could not write to %1.").arg(filename), /*error=*/true);
+        return;
+    }
+    QTextStream out(&file);
+    out << QString::fromStdString(envelopeJson().write(/*prettyIndent=*/2));
+    file.close();
+    showStatus(tr("Session saved to %1. Send it to the other participants.").arg(filename), /*error=*/false);
+}
+
+void SharedSigCollector::pasteEnvelope()
+{
+    QString error;
+    const bool ok{importEnvelope(QApplication::clipboard()->text(), error)};
+    if (!ok) {
+        showStatus(error, /*error=*/true);
+    } else {
+        showStatus(error.isEmpty() ? tr("Session imported.") : error, /*error=*/!error.isEmpty());
+    }
+}
+
+void SharedSigCollector::loadEnvelope()
+{
+    const QString filename{GUIUtil::getOpenFileName(this, tr("Import Signing Session"), QString{},
+                                                    tr("Shared masternode session (*.json);;All files (*)"), nullptr)};
+    if (filename.isEmpty()) return;
+    QFile file(filename);
+    if (!file.open(QIODevice::ReadOnly) || file.size() > MAX_ENVELOPE_FILE_BYTES) {
+        showStatus(tr("Could not read %1.").arg(filename), /*error=*/true);
+        return;
+    }
+    const QString text{QString::fromUtf8(file.readAll())};
+    file.close();
+    QString error;
+    const bool ok{importEnvelope(text, error)};
+    if (!ok) {
+        showStatus(error, /*error=*/true);
+    } else {
+        showStatus(error.isEmpty() ? tr("Session imported.") : error, /*error=*/!error.isEmpty());
+    }
+}
+
+void SharedSigCollector::refreshUi()
+{
+    m_tx_view->setPlainText(m_tx_hex);
+    const QString hash_hex{signHashHex()};
+    m_phrase_label->setText(hash_hex.isEmpty() ? QStringLiteral("--------") : hash_hex.left(8).toUpper());
+
+    QStringList lines;
+    for (size_t i = 0; i < m_shares.size(); ++i) {
+        const bool signed_here{m_sigs.count(static_cast<int>(i)) > 0};
+        lines << tr("Share #%1 — %2 — %3").arg(i).arg(OwnerAddress(m_shares[i]),
+                                                      signed_here ? tr("signed") : tr("waiting for signature"));
+    }
+    lines << tr("%1 of %2 signatures collected").arg(m_sigs.size()).arg(m_shares.size());
+    m_checklist_label->setText(lines.join(QLatin1Char('\n')));
+
+    m_copy_button->setEnabled(hasTransaction());
+    m_save_button->setEnabled(hasTransaction());
+}
+
+void SharedSigCollector::showStatus(const QString& message, bool error)
+{
+    m_status_label->setStyleSheet(GUIUtil::getThemedStyleQString(error ? GUIUtil::ThemedStyle::TS_ERROR
+                                                                       : GUIUtil::ThemedStyle::TS_SUCCESS));
+    m_status_label->setText(message);
+    m_status_label->setVisible(!message.isEmpty());
+}
+
+// ----------------------------------------------------------------------------
+// SharedMnDialog
+// ----------------------------------------------------------------------------
+
+SharedMnDialog::SharedMnDialog(interfaces::Node& node, WalletModel* wallet_model, const MasternodeEntry& entry, QWidget* parent) :
+    QDialog(parent),
+    m_node{node},
+    m_wallet_model{wallet_model},
+    m_protx_hash{entry.proTxHash()},
+    m_shares{entry.shares()},
+    m_early_penalty{entry.earlyPenalty()},
+    m_early_period_blocks{entry.earlyPeriodBlocks()},
+    m_registered_height{entry.registeredHeight()},
+    m_v24_active{node.isV24Active()},
+    m_sender{new ProTxSender(node, this)}
+{
+}
+
+bool SharedMnDialog::canSign() const
+{
+    return m_wallet_model != nullptr && !m_wallet_model->wallet().privateKeysDisabled();
+}
+
+bool SharedMnDialog::gateButton(QPushButton* button) const
+{
+    if (!m_wallet_model) {
+        button->setEnabled(false);
+        button->setToolTip(tr("No wallet is available."));
+        return false;
+    }
+    if (m_wallet_model->wallet().privateKeysDisabled()) {
+        button->setEnabled(false);
+        button->setToolTip(tr("This wallet is watch-only and cannot sign transactions."));
+        return false;
+    }
+    if (!m_v24_active) {
+        button->setEnabled(false);
+        button->setToolTip(tr("Shared masternode maintenance requires the v24 hard fork to be active."));
+        return false;
+    }
+    return true;
+}
+
+bool SharedMnDialog::runCommand(const QString& method, const UniValue& params, ProTxResult& result, QString& error)
+{
+    if (m_busy) {
+        error = tr("Another command is still running.");
+        return false;
+    }
+    if (!canSign()) {
+        error = tr("No wallet able to sign transactions is available.");
+        return false;
+    }
+
+    WalletModel::UnlockContext ctx(m_wallet_model->requestUnlock());
+    if (!ctx.isValid()) {
+        error = tr("Wallet unlock was cancelled.");
+        return false;
+    }
+
+    m_busy = true;
+    setEnabled(false);
+    QApplication::setOverrideCursor(Qt::WaitCursor);
+
+    ProTxResult outcome;
+    QEventLoop loop;
+    connect(m_sender, &ProTxSender::finished, &loop, [&](const ProTxResult& r) {
+        outcome = r;
+        loop.quit();
+    });
+    const bool started{m_sender->execute(method, params, m_wallet_model)};
+    if (started) {
+        // The unlock context cannot be moved, so wait here on the GUI thread to
+        // keep it alive until the worker thread reports back
+        loop.exec();
+    }
+
+    QApplication::restoreOverrideCursor();
+    setEnabled(true);
+    m_busy = false;
+
+    if (!started) {
+        error = tr("Another command is still running.");
+        return false;
+    }
+    if (!outcome.ok) {
+        error = outcome.message;
+        return false;
+    }
+    result = outcome;
+    return true;
+}
+
+bool SharedMnDialog::txInputsUnspent(const QString& tx_hex, QString& error)
+{
+    CMutableTransaction tx;
+    if (!DecodeHexTx(tx, tx_hex.toStdString())) {
+        error = tr("The transaction is not valid transaction hex.");
+        return false;
+    }
+    for (const CTxIn& txin : tx.vin) {
+        Coin coin;
+        if (!m_node.getUnspentOutput(txin.prevout, coin)) {
+            error = tr("Input %1:%2 of the prepared transaction has been spent — this session is dead and cannot be continued. Start a new one.")
+                        .arg(QString::fromStdString(txin.prevout.hash.ToString()))
+                        .arg(txin.prevout.n);
+            return false;
+        }
+    }
+    return true;
+}
+
+std::vector<int> SharedMnDialog::myShareIndexes() const
+{
+    std::vector<int> ret;
+    if (!canSign()) return ret;
+    for (size_t i = 0; i < m_shares.size(); ++i) {
+        if (m_wallet_model->wallet().isSpendable(PKHash(m_shares[i].keyIDOwner))) {
+            ret.push_back(static_cast<int>(i));
+        }
+    }
+    return ret;
+}
+
+QComboBox* SharedMnDialog::makeMyShareCombo(QWidget* parent)
+{
+    auto* combo = new QComboBox(parent);
+    for (const int i : myShareIndexes()) {
+        combo->addItem(tr("Share #%1 — %2 — %3").arg(i).arg(FormatDash(m_shares[i].amount), OwnerAddress(m_shares[i])), i);
+    }
+    if (combo->count() == 0) {
+        combo->setToolTip(tr("This wallet does not hold any of this masternode's share owner keys."));
+    }
+    return combo;
+}
+
+// ----------------------------------------------------------------------------
+// DissolveDialog
+// ----------------------------------------------------------------------------
+
+DissolveDialog::DissolveDialog(interfaces::Node& node, WalletModel* wallet_model, const MasternodeEntry& entry,
+                               int current_height, QWidget* parent) :
+    SharedMnDialog(node, wallet_model, entry, parent),
+    m_current_height{current_height}
+{
+    setWindowTitle(tr("Dissolve Shared Masternode"));
+    setMinimumWidth(760);
+
+    auto* layout = new QVBoxLayout(this);
+
+    auto* protx_label = new QLabel(tr("Masternode: %1").arg(m_protx_hash), this);
+    protx_label->setWordWrap(true);
+    protx_label->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    layout->addWidget(protx_label);
+
+    // A ProDisTx spending the collateral in the block that created it would be
+    // rejected; every flow below builds against the confirmed masternode list
+    if (m_current_height <= m_registered_height) {
+        auto* wait_label = new QLabel(tr("This masternode registered at height %1 and the chain is still at height %2. Wait for one confirmation of the registration, then reopen this dialog.")
+                                          .arg(m_registered_height)
+                                          .arg(m_current_height),
+                                      this);
+        wait_label->setWordWrap(true);
+        layout->addWidget(wait_label);
+    } else {
+        auto* tabs = new QTabWidget(this);
+        tabs->addTab(buildNowTab(), tr("Dissolve now"));
+        tabs->addTab(buildUnanimousTab(), tr("Unanimous"));
+        tabs->addTab(buildStandbyTab(), tr("Standby"));
+        layout->addWidget(tabs);
+    }
+
+    auto* buttons = new QDialogButtonBox(QDialogButtonBox::Close, this);
+    connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    layout->addWidget(buttons);
+
+    GUIUtil::updateFonts();
+    if (m_now_actor) updateNowPreview();
+    refreshUnanimousUi();
+}
+
+bool DissolveDialog::StandbyStored(const QString& pro_tx_hash)
+{
+    return QSettings().value(QStringLiteral("mnStandbyStored/") + pro_tx_hash, false).toBool();
+}
+
+QWidget* DissolveDialog::buildNowTab()
+{
+    auto* tab = new QWidget(this);
+    auto* layout = new QVBoxLayout(tab);
+
+    auto* intro = new QLabel(tr("Unilaterally dissolve this masternode right now: every participant's principal returns to its immutable refund address in one transaction. During the early period the dissolving participant pays the agreed penalty, which is redistributed pro-rata to the other shares."), tab);
+    intro->setWordWrap(true);
+    layout->addWidget(intro);
+
+    auto* form = new QFormLayout();
+    m_now_actor = makeMyShareCombo(tab);
+    connect(m_now_actor, qOverload<int>(&QComboBox::currentIndexChanged), this, &DissolveDialog::updateNowPreview);
+    form->addRow(tr("Dissolving share:"), m_now_actor);
+
+    m_now_fee = new QSpinBox(tab);
+    m_now_fee->setRange(1000, 10000000);
+    m_now_fee->setValue(DEFAULT_DISSOLVE_FEE);
+    m_now_fee->setSuffix(QLatin1Char(' ') + tr("duffs"));
+    m_now_fee->setToolTip(tr("Transaction fee, paid from the dissolving share's refund."));
+    connect(m_now_fee, qOverload<int>(&QSpinBox::valueChanged), this, &DissolveDialog::updateNowPreview);
+    form->addRow(tr("Fee:"), m_now_fee);
+    layout->addLayout(form);
+
+    m_now_early_label = new QLabel(tab);
+    m_now_early_label->setWordWrap(true);
+    layout->addWidget(m_now_early_label);
+
+    m_now_nudge_label = new QLabel(tab);
+    m_now_nudge_label->setWordWrap(true);
+    m_now_nudge_label->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_WARNING));
+    m_now_nudge_label->setVisible(false);
+    layout->addWidget(m_now_nudge_label);
+
+    m_now_table = new QTableWidget(0, 3, tab);
+    m_now_table->setHorizontalHeaderLabels({tr("Share"), tr("Refund address"), tr("Payout")});
+    m_now_table->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
+    m_now_table->verticalHeader()->setVisible(false);
+    m_now_table->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    m_now_table->setSelectionMode(QAbstractItemView::NoSelection);
+    m_now_table->setMinimumHeight(120);
+    layout->addWidget(m_now_table);
+
+    m_now_error_label = new QLabel(tab);
+    m_now_error_label->setWordWrap(true);
+    m_now_error_label->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
+    m_now_error_label->setVisible(false);
+    layout->addWidget(m_now_error_label);
+
+    m_now_accept = new QCheckBox(tab);
+    m_now_accept->setVisible(false);
+    connect(m_now_accept, &QCheckBox::toggled, this, &DissolveDialog::updateNowPreview);
+    layout->addWidget(m_now_accept);
+
+    auto* submit_row = new QHBoxLayout();
+    m_now_submit = new QPushButton(tr("Dissolve now"), tab);
+    connect(m_now_submit, &QPushButton::clicked, this, &DissolveDialog::submitNow);
+    submit_row->addWidget(m_now_submit);
+    submit_row->addStretch();
+    layout->addLayout(submit_row);
+
+    m_now_result = new QLineEdit(tab);
+    m_now_result->setReadOnly(true);
+    m_now_result->setPlaceholderText(tr("Transaction ID"));
+    m_now_result->setVisible(false);
+    layout->addWidget(m_now_result);
+
+    m_now_status = new QLabel(tab);
+    m_now_status->setWordWrap(true);
+    m_now_status->setVisible(false);
+    layout->addWidget(m_now_status);
+
+    layout->addStretch();
+    return tab;
+}
+
+void DissolveDialog::updateNowPreview()
+{
+    const bool usable{gateButton(m_now_submit) && m_now_actor->count() > 0};
+    if (m_now_actor->count() == 0) {
+        m_now_submit->setEnabled(false);
+        m_now_submit->setToolTip(tr("This wallet does not hold any of this masternode's share owner keys."));
+    }
+
+    const int actor{m_now_actor->currentIndex() >= 0 ? m_now_actor->currentData().toInt() : -1};
+    if (actor < 0) {
+        m_now_table->setRowCount(0);
+        return;
+    }
+
+    std::vector<CAmount> amounts;
+    amounts.reserve(m_shares.size());
+    for (const auto& share : m_shares) {
+        amounts.push_back(share.amount);
+    }
+    const auto preview{MnShareSession::PenaltyPreviewFor(amounts, actor, m_early_penalty, m_early_period_blocks,
+                                                         m_now_fee->value(), m_current_height, m_registered_height)};
+
+    m_now_error_label->setVisible(!preview.valid);
+    if (!preview.valid) {
+        m_now_error_label->setText(preview.error);
+        m_now_table->setRowCount(0);
+        m_now_accept->setVisible(false);
+        m_now_nudge_label->setVisible(false);
+        m_now_early_label->clear();
+        m_now_submit->setEnabled(false);
+        return;
+    }
+
+    // Penalty-free once the transaction would confirm at the boundary height
+    const int blocks_left{preview.penaltyFreeHeight - m_current_height - 1};
+    if (preview.early) {
+        m_now_early_label->setText(tr("Early exit: dissolving now pays the %1 penalty. A unilateral dissolution is penalty-free after block %2 (%3 from now, ~%4).")
+                                       .arg(FormatDash(preview.penalty))
+                                       .arg(preview.penaltyFreeHeight)
+                                       .arg(MnShareSession::HumanEarlyPeriod(static_cast<uint32_t>(std::max(blocks_left, 0))),
+                                            ApproxBlockDate(std::max(blocks_left, 0))));
+        m_now_accept->setText(tr("I accept paying the %1 early-exit penalty").arg(FormatDash(preview.penalty)));
+        m_now_accept->setVisible(true);
+        m_now_nudge_label->setVisible(blocks_left <= NUDGE_BOUNDARY_BLOCKS);
+        m_now_nudge_label->setText(tr("The penalty-free boundary is only %1 away. Consider waiting, or use the Unanimous tab: with every participant's signature the masternode dissolves penalty-free at any height.")
+                                       .arg(MnShareSession::HumanEarlyPeriod(static_cast<uint32_t>(std::max(blocks_left, 0)))));
+    } else {
+        m_now_early_label->setText(tr("The early period has ended — dissolving now is penalty-free."));
+        m_now_accept->setVisible(false);
+        m_now_accept->setChecked(false);
+        m_now_nudge_label->setVisible(false);
+    }
+
+    m_now_table->setRowCount(static_cast<int>(m_shares.size()));
+    for (size_t i = 0; i < m_shares.size(); ++i) {
+        const bool is_actor{static_cast<int>(i) == actor};
+        auto* share_item = new QTableWidgetItem(is_actor ? tr("Share #%1 (dissolving)").arg(i) : tr("Share #%1").arg(i));
+        auto* refund_item = new QTableWidgetItem(ScriptAddress(m_shares[i].scriptRefund));
+        auto* payout_item = new QTableWidgetItem(FormatDash(preview.payouts[i]));
+        if (is_actor) {
+            QFont bold{share_item->font()};
+            bold.setBold(true);
+            share_item->setFont(bold);
+            refund_item->setFont(bold);
+            payout_item->setFont(bold);
+        }
+        m_now_table->setItem(static_cast<int>(i), 0, share_item);
+        m_now_table->setItem(static_cast<int>(i), 1, refund_item);
+        m_now_table->setItem(static_cast<int>(i), 2, payout_item);
+    }
+
+    if (usable) {
+        m_now_submit->setEnabled(!preview.early || m_now_accept->isChecked());
+        m_now_submit->setToolTip(preview.early && !m_now_accept->isChecked() ? tr("Accept the early-exit penalty first.") : QString{});
+    }
+}
+
+void DissolveDialog::submitNow()
+{
+    if (m_now_actor->currentIndex() < 0) return;
+    const int actor{m_now_actor->currentData().toInt()};
+
+    // Re-derive the early decision the RPC will make so payPenalty is explicit
+    const bool early{static_cast<int64_t>(m_current_height) + 1 - m_registered_height <
+                     static_cast<int64_t>(m_early_period_blocks)};
+    if (early && !m_now_accept->isChecked()) return;
+
+    if (QMessageBox::question(this, windowTitle(),
+                              tr("Dissolve this shared masternode now? Every participant's principal returns to its refund address; the masternode stops earning immediately. This cannot be undone.")) !=
+        QMessageBox::Yes) {
+        return;
+    }
+
+    UniValue params(UniValue::VOBJ);
+    params.pushKV("proTxHash", m_protx_hash.toStdString());
+    params.pushKV("actorIndex", actor);
+    params.pushKV("fee", static_cast<int64_t>(m_now_fee->value()));
+    params.pushKV("submit", true);
+    params.pushKV("payPenalty", early);
+
+    ProTxResult result;
+    QString error;
+    if (!runCommand(QStringLiteral("protx dissolve"), params, result, error)) {
+        m_now_status->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
+        m_now_status->setText(error);
+        m_now_status->setVisible(true);
+        return;
+    }
+
+    m_now_result->setText(QString::fromStdString(result.value.get_str()));
+    m_now_result->setVisible(true);
+    m_now_status->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_SUCCESS));
+    m_now_status->setText(tr("The dissolution was sent successfully."));
+    m_now_status->setVisible(true);
+    m_now_submit->setEnabled(false);
+    m_now_actor->setEnabled(false);
+    m_now_fee->setEnabled(false);
+    m_now_accept->setEnabled(false);
+}
+
+QWidget* DissolveDialog::buildUnanimousTab()
+{
+    auto* tab = new QWidget(this);
+    auto* layout = new QVBoxLayout(tab);
+
+    auto* intro = new QLabel(tr("A unanimous dissolution is penalty-free at any height, even during the early period, but needs every participant's signature. One participant starts it here; the session below is then passed around (file or clipboard) until every share has signed, and anyone can submit the result."), tab);
+    intro->setWordWrap(true);
+    layout->addWidget(intro);
+
+    auto* form = new QFormLayout();
+    m_un_actor = makeMyShareCombo(tab);
+    m_un_actor->setToolTip(tr("The share the transaction fee is deducted from."));
+    form->addRow(tr("Fee-paying share:"), m_un_actor);
+    m_un_fee = new QSpinBox(tab);
+    m_un_fee->setRange(1000, 10000000);
+    m_un_fee->setValue(DEFAULT_DISSOLVE_FEE);
+    m_un_fee->setSuffix(QLatin1Char(' ') + tr("duffs"));
+    form->addRow(tr("Fee:"), m_un_fee);
+    layout->addLayout(form);
+
+    auto* buttons = new QHBoxLayout();
+    m_un_start = new QPushButton(tr("Start unanimous dissolution"), tab);
+    connect(m_un_start, &QPushButton::clicked, this, &DissolveDialog::startUnanimous);
+    buttons->addWidget(m_un_start);
+    m_un_sign = new QPushButton(tr("Sign with this wallet"), tab);
+    connect(m_un_sign, &QPushButton::clicked, this, &DissolveDialog::signUnanimous);
+    buttons->addWidget(m_un_sign);
+    m_un_combine = new QPushButton(tr("Combine && submit"), tab);
+    connect(m_un_combine, &QPushButton::clicked, this, &DissolveDialog::combineUnanimous);
+    buttons->addWidget(m_un_combine);
+    buttons->addStretch();
+    layout->addLayout(buttons);
+
+    m_un_collector = new SharedSigCollector(SharedSigCollector::Kind::Dissolve, m_protx_hash, m_shares, tab);
+    connect(m_un_collector, &SharedSigCollector::changed, this, &DissolveDialog::refreshUnanimousUi);
+    layout->addWidget(m_un_collector);
+
+    m_un_result = new QLineEdit(tab);
+    m_un_result->setReadOnly(true);
+    m_un_result->setPlaceholderText(tr("Transaction ID"));
+    m_un_result->setVisible(false);
+    layout->addWidget(m_un_result);
+
+    m_un_status = new QLabel(tab);
+    m_un_status->setWordWrap(true);
+    m_un_status->setVisible(false);
+    layout->addWidget(m_un_status);
+
+    layout->addStretch();
+    return tab;
+}
+
+void DissolveDialog::refreshUnanimousUi()
+{
+    if (!m_un_start) return;
+    // A8 liveness: a spent input (the collateral — the masternode was already
+    // dissolved) makes the session permanently dead
+    if (m_un_collector->hasTransaction()) {
+        if (QString liveness_error; !txInputsUnspent(m_un_collector->txHex(), liveness_error)) {
+            m_un_status->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
+            m_un_status->setText(liveness_error);
+            m_un_status->setVisible(true);
+            m_un_start->setEnabled(false);
+            m_un_sign->setEnabled(false);
+            m_un_combine->setEnabled(false);
+            return;
+        }
+    }
+    if (gateButton(m_un_start)) {
+        m_un_start->setEnabled(!m_un_collector->hasTransaction() && m_un_actor->count() > 0);
+        if (m_un_actor->count() == 0) m_un_start->setToolTip(tr("This wallet does not hold any of this masternode's share owner keys."));
+    }
+    if (gateButton(m_un_sign)) {
+        m_un_sign->setEnabled(m_un_collector->hasTransaction());
+    }
+    if (gateButton(m_un_combine)) {
+        m_un_combine->setEnabled(m_un_collector->complete());
+        if (!m_un_collector->complete()) {
+            m_un_combine->setToolTip(tr("Every share must be signed first (%1 of %2 so far).")
+                                         .arg(m_un_collector->signedCount())
+                                         .arg(m_shares.size()));
+        }
+    }
+}
+
+void DissolveDialog::startUnanimous()
+{
+    if (m_un_actor->currentIndex() < 0) return;
+
+    UniValue params(UniValue::VOBJ);
+    params.pushKV("proTxHash", m_protx_hash.toStdString());
+    params.pushKV("actorIndex", m_un_actor->currentData().toInt());
+    params.pushKV("fee", static_cast<int64_t>(m_un_fee->value()));
+
+    ProTxResult result;
+    QString error;
+    if (!runCommand(QStringLiteral("protx dissolve_prepare"), params, result, error)) {
+        m_un_status->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
+        m_un_status->setText(error);
+        m_un_status->setVisible(true);
+        return;
+    }
+
+    const QString tx_hex{QString::fromStdString(result.value.find_value("tx").get_str())};
+    if (!m_un_collector->setTransaction(tx_hex, error)) {
+        m_un_status->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
+        m_un_status->setText(error);
+        m_un_status->setVisible(true);
+        return;
+    }
+    // Cross-check our native sign-hash mirror against the node's answer, so a
+    // drifted mirror can never let a bad signature through verification
+    const QString rpc_hash{QString::fromStdString(result.value.find_value("signHash").get_str())};
+    if (m_un_collector->signHashHex().compare(rpc_hash, Qt::CaseInsensitive) != 0) {
+        m_un_status->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
+        m_un_status->setText(tr("Internal error: the locally computed signing digest does not match the node's. Do not sign; please report this."));
+        m_un_status->setVisible(true);
+        return;
+    }
+    m_un_status->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_SUCCESS));
+    m_un_status->setText(tr("Prepared. Sign with this wallet, then pass the session to the other participants."));
+    m_un_status->setVisible(true);
+    m_un_fee->setEnabled(false);
+    m_un_actor->setEnabled(false);
+    refreshUnanimousUi();
+}
+
+void DissolveDialog::signUnanimous()
+{
+    if (!m_un_collector->hasTransaction()) return;
+
+    UniValue params(UniValue::VOBJ);
+    params.pushKV("tx", m_un_collector->txHex().toStdString());
+
+    ProTxResult result;
+    QString error;
+    if (!runCommand(QStringLiteral("protx shared_sign"), params, result, error)) {
+        m_un_status->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
+        m_un_status->setText(error);
+        m_un_status->setVisible(true);
+        return;
+    }
+
+    QString sig_error;
+    const int absorbed{m_un_collector->addSignatures(result.value, sig_error)};
+    const bool problems{!sig_error.isEmpty()};
+    m_un_status->setStyleSheet(GUIUtil::getThemedStyleQString(problems ? GUIUtil::ThemedStyle::TS_ERROR
+                                                                       : GUIUtil::ThemedStyle::TS_SUCCESS));
+    m_un_status->setText(problems ? sig_error
+                                  : tr("Signed %n share(s). Now copy or save the session and send it to the other participants.",
+                                       nullptr, absorbed));
+    m_un_status->setVisible(true);
+}
+
+void DissolveDialog::combineUnanimous()
+{
+    if (!m_un_collector->complete()) return;
+
+    UniValue params(UniValue::VOBJ);
+    params.pushKV("tx", m_un_collector->txHex().toStdString());
+    params.pushKV("signatures", m_un_collector->signaturesArray());
+    params.pushKV("submit", true);
+
+    ProTxResult result;
+    QString error;
+    if (!runCommand(QStringLiteral("protx shared_combine"), params, result, error)) {
+        m_un_status->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
+        m_un_status->setText(error);
+        m_un_status->setVisible(true);
+        return;
+    }
+
+    m_un_result->setText(QString::fromStdString(result.value.get_str()));
+    m_un_result->setVisible(true);
+    m_un_status->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_SUCCESS));
+    m_un_status->setText(tr("The dissolution was sent successfully."));
+    m_un_status->setVisible(true);
+    m_un_sign->setEnabled(false);
+    m_un_combine->setEnabled(false);
+}
+
+QWidget* DissolveDialog::buildStandbyTab()
+{
+    auto* tab = new QWidget(this);
+    auto* layout = new QVBoxLayout(tab);
+
+    auto* intro = new QLabel(tr("A standby dissolution is a fully signed transaction kept offline instead of broadcast. Its validity is monotone: once valid it stays valid forever, so a standby never expires. Store both variants below together with your refund key backup, separately from the share owner key — if the owner key is ever lost, broadcasting a standby recovers your principal without anyone else's cooperation."), tab);
+    intro->setWordWrap(true);
+    layout->addWidget(intro);
+
+    auto* form = new QFormLayout();
+    m_sb_actor = makeMyShareCombo(tab);
+    connect(m_sb_actor, qOverload<int>(&QComboBox::currentIndexChanged), tab, [this] {
+        m_sb_view_a->clear();
+        m_sb_view_b->clear();
+        m_sb_saved_a = m_sb_saved_b = false;
+    });
+    form->addRow(tr("My share:"), m_sb_actor);
+    m_sb_fee = new QSpinBox(tab);
+    m_sb_fee->setRange(1000, 10000000);
+    m_sb_fee->setValue(DEFAULT_DISSOLVE_FEE);
+    m_sb_fee->setSuffix(QLatin1Char(' ') + tr("duffs"));
+    form->addRow(tr("Fee:"), m_sb_fee);
+    layout->addLayout(form);
+
+    const int penalty_free_height{m_registered_height + static_cast<int>(m_early_period_blocks)};
+    const int blocks_left{std::max(penalty_free_height - m_current_height - 1, 0)};
+
+    auto* generate_a = new QPushButton(tr("Generate Standby A — pays the %1 penalty, broadcastable immediately (it pays the penalty forever, even after the early period ends)")
+                                           .arg(FormatDash(m_early_penalty)),
+                                       tab);
+    connect(generate_a, &QPushButton::clicked, tab, [this] { generateStandby(/*pay_penalty=*/true); });
+    gateButton(generate_a);
+    layout->addWidget(generate_a);
+
+    m_sb_view_a = new QPlainTextEdit(tab);
+    m_sb_view_a->setReadOnly(true);
+    m_sb_view_a->setFont(GUIUtil::fixedPitchFont());
+    m_sb_view_a->setMaximumHeight(70);
+    m_sb_view_a->setPlaceholderText(tr("Standby A transaction hex"));
+    layout->addWidget(m_sb_view_a);
+
+    auto* row_a = new QHBoxLayout();
+    auto* copy_a = new QPushButton(tr("Copy A"), tab);
+    connect(copy_a, &QPushButton::clicked, tab, [this] {
+        if (!m_sb_view_a->toPlainText().isEmpty()) GUIUtil::setClipboard(m_sb_view_a->toPlainText());
+    });
+    row_a->addWidget(copy_a);
+    auto* save_a = new QPushButton(tr("Save A to file…"), tab);
+    connect(save_a, &QPushButton::clicked, tab, [this] { saveStandby(/*pay_penalty=*/true); });
+    row_a->addWidget(save_a);
+    row_a->addStretch();
+    layout->addLayout(row_a);
+
+    const QString b_when{blocks_left > 0 ? tr("valid only from block %1 (~%2)").arg(penalty_free_height).arg(ApproxBlockDate(blocks_left)) :
+                                           tr("already valid — the early period has ended")};
+    auto* generate_b = new QPushButton(tr("Generate Standby B — full principal, %1").arg(b_when), tab);
+    connect(generate_b, &QPushButton::clicked, tab, [this] { generateStandby(/*pay_penalty=*/false); });
+    gateButton(generate_b);
+    layout->addWidget(generate_b);
+
+    m_sb_view_b = new QPlainTextEdit(tab);
+    m_sb_view_b->setReadOnly(true);
+    m_sb_view_b->setFont(GUIUtil::fixedPitchFont());
+    m_sb_view_b->setMaximumHeight(70);
+    m_sb_view_b->setPlaceholderText(tr("Standby B transaction hex"));
+    layout->addWidget(m_sb_view_b);
+
+    auto* row_b = new QHBoxLayout();
+    auto* copy_b = new QPushButton(tr("Copy B"), tab);
+    connect(copy_b, &QPushButton::clicked, tab, [this] {
+        if (!m_sb_view_b->toPlainText().isEmpty()) GUIUtil::setClipboard(m_sb_view_b->toPlainText());
+    });
+    row_b->addWidget(copy_b);
+    auto* save_b = new QPushButton(tr("Save B to file…"), tab);
+    connect(save_b, &QPushButton::clicked, tab, [this] { saveStandby(/*pay_penalty=*/false); });
+    row_b->addWidget(save_b);
+    row_b->addStretch();
+    layout->addLayout(row_b);
+
+    auto* which = new QLabel(tr("Which one to broadcast later: B whenever the early period is over (full principal); A only when you cannot wait for the boundary."), tab);
+    which->setWordWrap(true);
+    layout->addWidget(which);
+
+    m_sb_stored_label = new QLabel(tab);
+    m_sb_stored_label->setWordWrap(true);
+    m_sb_stored_label->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_SUCCESS));
+    m_sb_stored_label->setVisible(StandbyStored(m_protx_hash));
+    m_sb_stored_label->setText(tr("Both standby dissolutions were saved for this masternode."));
+    layout->addWidget(m_sb_stored_label);
+
+    m_sb_status = new QLabel(tab);
+    m_sb_status->setWordWrap(true);
+    m_sb_status->setVisible(false);
+    layout->addWidget(m_sb_status);
+
+    layout->addStretch();
+    return tab;
+}
+
+void DissolveDialog::generateStandby(bool pay_penalty)
+{
+    if (m_sb_actor->currentIndex() < 0) {
+        m_sb_status->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
+        m_sb_status->setText(tr("This wallet does not hold any of this masternode's share owner keys."));
+        m_sb_status->setVisible(true);
+        return;
+    }
+
+    UniValue params(UniValue::VOBJ);
+    params.pushKV("proTxHash", m_protx_hash.toStdString());
+    params.pushKV("actorIndex", m_sb_actor->currentData().toInt());
+    params.pushKV("fee", static_cast<int64_t>(m_sb_fee->value()));
+    params.pushKV("submit", false);
+    params.pushKV("payPenalty", pay_penalty);
+
+    ProTxResult result;
+    QString error;
+    if (!runCommand(QStringLiteral("protx dissolve"), params, result, error)) {
+        m_sb_status->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
+        m_sb_status->setText(error);
+        m_sb_status->setVisible(true);
+        return;
+    }
+
+    (pay_penalty ? m_sb_view_a : m_sb_view_b)->setPlainText(QString::fromStdString(result.value.get_str()));
+    m_sb_status->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_SUCCESS));
+    m_sb_status->setText(tr("Standby %1 generated — save it to a file now.").arg(pay_penalty ? QStringLiteral("A") : QStringLiteral("B")));
+    m_sb_status->setVisible(true);
+}
+
+void DissolveDialog::saveStandby(bool pay_penalty)
+{
+    const QString hex{(pay_penalty ? m_sb_view_a : m_sb_view_b)->toPlainText()};
+    if (hex.isEmpty()) return;
+    const QString variant{pay_penalty ? QStringLiteral("a") : QStringLiteral("b")};
+    const QString filename{GUIUtil::getSaveFileName(this, tr("Save Standby Dissolution"),
+                                                    QStringLiteral("standby-%1-%2.txt").arg(variant, m_protx_hash.left(8)),
+                                                    tr("Text file (*.txt)"), nullptr)};
+    if (filename.isEmpty()) return;
+    QFile file(filename);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        m_sb_status->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
+        m_sb_status->setText(tr("Could not write to %1.").arg(filename));
+        m_sb_status->setVisible(true);
+        return;
+    }
+    QTextStream out(&file);
+    out << hex << '\n';
+    file.close();
+
+    (pay_penalty ? m_sb_saved_a : m_sb_saved_b) = true;
+    m_sb_status->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_SUCCESS));
+    m_sb_status->setText(tr("Standby %1 saved to %2.").arg(pay_penalty ? QStringLiteral("A") : QStringLiteral("B"), filename));
+    m_sb_status->setVisible(true);
+    maybeMarkStandbyStored();
+}
+
+void DissolveDialog::maybeMarkStandbyStored()
+{
+    if (!m_sb_saved_a || !m_sb_saved_b) return;
+    QSettings().setValue(QStringLiteral("mnStandbyStored/") + m_protx_hash, true);
+    m_sb_stored_label->setVisible(true);
+}
+
+// ----------------------------------------------------------------------------
+// RotateSharedKeysDialog
+// ----------------------------------------------------------------------------
+
+RotateSharedKeysDialog::RotateSharedKeysDialog(interfaces::Node& node, WalletModel* wallet_model,
+                                               const MasternodeEntry& entry, QWidget* parent) :
+    SharedMnDialog(node, wallet_model, entry, parent)
+{
+    setWindowTitle(tr("Rotate Shared Masternode Keys"));
+    setMinimumWidth(760);
+
+    auto* layout = new QVBoxLayout(this);
+
+    auto* intro = new QLabel(tr("Change this shared masternode's operator key and/or voting key. Like the original registration this needs every participant's signature: prepare here, sign, pass the session around, and finish below."), this);
+    intro->setWordWrap(true);
+    layout->addWidget(intro);
+
+    auto* protx_label = new QLabel(tr("Masternode: %1").arg(m_protx_hash), this);
+    protx_label->setWordWrap(true);
+    protx_label->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    layout->addWidget(protx_label);
+
+    auto* banner = new QLabel(tr("Finish on this wallet: the prepared transaction's fee inputs belong to it, and combining re-signs those inputs, which only this wallet can do. Participants on other wallets only import, sign and export the session."), this);
+    banner->setWordWrap(true);
+    banner->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_WARNING));
+    layout->addWidget(banner);
+
+    auto* form = new QFormLayout();
+    m_operator_edit = new QLineEdit(this);
+    m_operator_edit->setPlaceholderText(tr("Leave blank to keep the current operator key"));
+    connect(m_operator_edit, &QLineEdit::textChanged, this, &RotateSharedKeysDialog::validateForm);
+    form->addRow(tr("New operator public key:"), m_operator_edit);
+
+    m_pose_warning = new QLabel(tr("Changing the operator key immediately PoSe-bans the masternode. It stays banned until the new operator sends a provider update service transaction."), this);
+    m_pose_warning->setWordWrap(true);
+    m_pose_warning->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_WARNING));
+    m_pose_warning->setVisible(false);
+    form->addRow(m_pose_warning);
+
+    m_voting_edit = new QValidatedLineEdit(this);
+    GUIUtil::setupAddressWidget(m_voting_edit, this);
+    m_voting_edit->setPlaceholderText(tr("Leave blank to keep the current voting address"));
+    connect(m_voting_edit, &QLineEdit::textChanged, this, &RotateSharedKeysDialog::validateForm);
+    form->addRow(tr("New voting address:"), m_voting_edit);
+
+    m_fee_source = new FeeSourcePicker(this);
+    m_fee_source->setWalletModel(wallet_model);
+    m_fee_source->refresh();
+    connect(m_fee_source, qOverload<int>(&QComboBox::currentIndexChanged), this, &RotateSharedKeysDialog::validateForm);
+    form->addRow(tr("Fee source:"), m_fee_source);
+    layout->addLayout(form);
+
+    auto* buttons = new QHBoxLayout();
+    m_prepare_button = new QPushButton(tr("Prepare on this wallet"), this);
+    connect(m_prepare_button, &QPushButton::clicked, this, &RotateSharedKeysDialog::prepare);
+    buttons->addWidget(m_prepare_button);
+    m_sign_button = new QPushButton(tr("Sign with this wallet"), this);
+    connect(m_sign_button, &QPushButton::clicked, this, &RotateSharedKeysDialog::signMine);
+    buttons->addWidget(m_sign_button);
+    m_combine_button = new QPushButton(tr("Combine && submit"), this);
+    connect(m_combine_button, &QPushButton::clicked, this, &RotateSharedKeysDialog::combineAndSend);
+    buttons->addWidget(m_combine_button);
+    buttons->addStretch();
+    layout->addLayout(buttons);
+
+    m_collector = new SharedSigCollector(SharedSigCollector::Kind::Registrar, m_protx_hash, m_shares, this);
+    connect(m_collector, &SharedSigCollector::changed, this, &RotateSharedKeysDialog::validateForm);
+    layout->addWidget(m_collector);
+
+    m_result_edit = new QLineEdit(this);
+    m_result_edit->setReadOnly(true);
+    m_result_edit->setPlaceholderText(tr("Transaction ID"));
+    m_result_edit->setVisible(false);
+    layout->addWidget(m_result_edit);
+
+    m_status_label = new QLabel(this);
+    m_status_label->setWordWrap(true);
+    m_status_label->setVisible(false);
+    layout->addWidget(m_status_label);
+
+    auto* close_buttons = new QDialogButtonBox(QDialogButtonBox::Close, this);
+    connect(close_buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    layout->addWidget(close_buttons);
+
+    GUIUtil::updateFonts();
+    validateForm();
+}
+
+void RotateSharedKeysDialog::validateForm()
+{
+    m_pose_warning->setVisible(!m_operator_edit->text().trimmed().isEmpty());
+    refreshButtons();
+}
+
+void RotateSharedKeysDialog::refreshButtons()
+{
+    // A8 liveness: a spent fee input makes the prepared transaction
+    // permanently unbroadcastable
+    if (m_collector->hasTransaction()) {
+        if (QString liveness_error; !txInputsUnspent(m_collector->txHex(), liveness_error)) {
+            m_status_label->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
+            m_status_label->setText(liveness_error);
+            m_status_label->setVisible(true);
+            m_prepare_button->setEnabled(false);
+            m_sign_button->setEnabled(false);
+            m_combine_button->setEnabled(false);
+            return;
+        }
+    }
+    if (gateButton(m_prepare_button)) {
+        const QString operator_key{m_operator_edit->text().trimmed()};
+        const bool operator_ok{operator_key.isEmpty() ||
+                               (operator_key.size() == 96 &&
+                                QRegularExpression(QStringLiteral("^[0-9a-fA-F]+$")).match(operator_key).hasMatch())};
+        const bool any_change{!operator_key.isEmpty() || !m_voting_edit->text().isEmpty()};
+        const bool voting_ok{m_voting_edit->text().isEmpty() || m_voting_edit->isValid()};
+        m_prepare_button->setEnabled(!m_collector->hasTransaction() && any_change && operator_ok && voting_ok &&
+                                     !m_fee_source->selectedAddress().isEmpty());
+    }
+    if (gateButton(m_sign_button)) {
+        m_sign_button->setEnabled(m_collector->hasTransaction());
+    }
+    if (gateButton(m_combine_button)) {
+        m_combine_button->setEnabled(m_collector->complete());
+        if (!m_collector->complete()) {
+            m_combine_button->setToolTip(tr("Every share must be signed first (%1 of %2 so far).")
+                                             .arg(m_collector->signedCount())
+                                             .arg(m_shares.size()));
+        }
+    }
+}
+
+void RotateSharedKeysDialog::prepare()
+{
+    UniValue params(UniValue::VOBJ);
+    params.pushKV("proTxHash", m_protx_hash.toStdString());
+    // Empty strings keep the current values
+    params.pushKV("operatorPubKey", m_operator_edit->text().trimmed().toStdString());
+    params.pushKV("votingAddress", m_voting_edit->text().trimmed().toStdString());
+    params.pushKV("feeSourceAddress", m_fee_source->selectedAddress().toStdString());
+
+    ProTxResult result;
+    QString error;
+    if (!runCommand(QStringLiteral("protx update_shared_registrar_prepare"), params, result, error)) {
+        m_status_label->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
+        m_status_label->setText(error);
+        m_status_label->setVisible(true);
+        return;
+    }
+
+    const QString tx_hex{QString::fromStdString(result.value.find_value("tx").get_str())};
+    if (!m_collector->setTransaction(tx_hex, error)) {
+        m_status_label->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
+        m_status_label->setText(error);
+        m_status_label->setVisible(true);
+        return;
+    }
+    const QString rpc_hash{QString::fromStdString(result.value.find_value("signHash").get_str())};
+    if (m_collector->signHashHex().compare(rpc_hash, Qt::CaseInsensitive) != 0) {
+        m_status_label->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
+        m_status_label->setText(tr("Internal error: the locally computed signing digest does not match the node's. Do not sign; please report this."));
+        m_status_label->setVisible(true);
+        return;
+    }
+
+    m_operator_edit->setEnabled(false);
+    m_voting_edit->setEnabled(false);
+    m_fee_source->setEnabled(false);
+    m_status_label->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_SUCCESS));
+    m_status_label->setText(tr("Prepared. Sign with this wallet, pass the session to the other participants, then finish here once every share has signed."));
+    m_status_label->setVisible(true);
+    refreshButtons();
+}
+
+void RotateSharedKeysDialog::signMine()
+{
+    if (!m_collector->hasTransaction()) return;
+
+    UniValue params(UniValue::VOBJ);
+    params.pushKV("tx", m_collector->txHex().toStdString());
+
+    ProTxResult result;
+    QString error;
+    if (!runCommand(QStringLiteral("protx shared_sign"), params, result, error)) {
+        m_status_label->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
+        m_status_label->setText(error);
+        m_status_label->setVisible(true);
+        return;
+    }
+
+    QString sig_error;
+    const int absorbed{m_collector->addSignatures(result.value, sig_error)};
+    const bool problems{!sig_error.isEmpty()};
+    m_status_label->setStyleSheet(GUIUtil::getThemedStyleQString(problems ? GUIUtil::ThemedStyle::TS_ERROR
+                                                                          : GUIUtil::ThemedStyle::TS_SUCCESS));
+    m_status_label->setText(problems ? sig_error
+                                     : tr("Signed %n share(s). Now copy or save the session and send it to the other participants.",
+                                          nullptr, absorbed));
+    m_status_label->setVisible(true);
+}
+
+void RotateSharedKeysDialog::combineAndSend()
+{
+    if (!m_collector->complete()) return;
+
+    UniValue params(UniValue::VOBJ);
+    params.pushKV("tx", m_collector->txHex().toStdString());
+    params.pushKV("signatures", m_collector->signaturesArray());
+    params.pushKV("submit", true);
+
+    ProTxResult result;
+    QString error;
+    if (!runCommand(QStringLiteral("protx shared_combine"), params, result, error)) {
+        m_status_label->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
+        // Combining re-signs the fee inputs, which only the preparing wallet can do
+        m_status_label->setText(error + QLatin1Char('\n') +
+                                tr("If the error mentions signing the transaction inputs, this is not the wallet that prepared it — finish on that wallet."));
+        m_status_label->setVisible(true);
+        return;
+    }
+
+    m_result_edit->setText(QString::fromStdString(result.value.get_str()));
+    m_result_edit->setVisible(true);
+    m_status_label->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_SUCCESS));
+    m_status_label->setText(tr("The key rotation was sent successfully."));
+    m_status_label->setVisible(true);
+    m_sign_button->setEnabled(false);
+    m_combine_button->setEnabled(false);
+}

--- a/src/qt/sharedmndialogs.cpp
+++ b/src/qt/sharedmndialogs.cpp
@@ -88,6 +88,28 @@ QString FormatDash(CAmount amount)
     return BitcoinUnits::formatWithUnit(BitcoinUnits::Unit::DASH, amount);
 }
 
+void ShowStatusLabel(QLabel* label, const QString& message, bool error)
+{
+    label->setStyleSheet(GUIUtil::getThemedStyleQString(error ? GUIUtil::ThemedStyle::TS_ERROR
+                                                              : GUIUtil::ThemedStyle::TS_SUCCESS));
+    label->setText(message);
+    label->setVisible(!message.isEmpty());
+}
+
+//! Fill `combo` with the shares whose owner key `wallet_model` can sign with;
+//! the item data is the share index
+void FillMyShareCombo(QComboBox* combo, const std::vector<interfaces::MnShare>& shares, WalletModel* wallet_model)
+{
+    if (!wallet_model || wallet_model->wallet().privateKeysDisabled()) return;
+    for (size_t i = 0; i < shares.size(); ++i) {
+        if (!wallet_model->wallet().isSpendable(PKHash(shares[i].keyIDOwner))) continue;
+        combo->addItem(QCoreApplication::translate("SharedMnDialog", "Share #%1 — %2 — %3")
+                           .arg(i)
+                           .arg(FormatDash(shares[i].amount), OwnerAddress(shares[i])),
+                       static_cast<int>(i));
+    }
+}
+
 //! "block N (~date)" for a block `blocks_ahead` past the current tip
 QString ApproxBlockDate(int blocks_ahead)
 {
@@ -160,13 +182,7 @@ UpdateShareDialog::UpdateShareDialog(interfaces::Node& node, WalletModel* wallet
     auto* form = new QFormLayout();
 
     m_share_combo = new QComboBox(this);
-    const auto& shares = entry.shares();
-    for (size_t i = 0; i < shares.size(); ++i) {
-        if (!wallet_model || wallet_model->wallet().privateKeysDisabled()) break;
-        if (!wallet_model->wallet().isSpendable(PKHash(shares[i].keyIDOwner))) continue;
-        m_share_combo->addItem(tr("Share #%1 — %2 — %3").arg(i).arg(FormatDash(shares[i].amount), OwnerAddress(shares[i])),
-                               static_cast<int>(i));
-    }
+    FillMyShareCombo(m_share_combo, entry.shares(), wallet_model);
     connect(m_share_combo, qOverload<int>(&QComboBox::currentIndexChanged), this, &UpdateShareDialog::validate);
     form->addRow(tr("My share:"), m_share_combo);
 
@@ -483,11 +499,7 @@ void SharedSigCollector::pasteEnvelope()
 {
     QString error;
     const bool ok{importEnvelope(QApplication::clipboard()->text(), error)};
-    if (!ok) {
-        showStatus(error, /*error=*/true);
-    } else {
-        showStatus(error.isEmpty() ? tr("Session imported.") : error, /*error=*/!error.isEmpty());
-    }
+    showStatus(ok && error.isEmpty() ? tr("Session imported.") : error, /*error=*/!ok || !error.isEmpty());
 }
 
 void SharedSigCollector::loadEnvelope()
@@ -504,11 +516,7 @@ void SharedSigCollector::loadEnvelope()
     file.close();
     QString error;
     const bool ok{importEnvelope(text, error)};
-    if (!ok) {
-        showStatus(error, /*error=*/true);
-    } else {
-        showStatus(error.isEmpty() ? tr("Session imported.") : error, /*error=*/!error.isEmpty());
-    }
+    showStatus(ok && error.isEmpty() ? tr("Session imported.") : error, /*error=*/!ok || !error.isEmpty());
 }
 
 void SharedSigCollector::refreshUi()
@@ -532,10 +540,7 @@ void SharedSigCollector::refreshUi()
 
 void SharedSigCollector::showStatus(const QString& message, bool error)
 {
-    m_status_label->setStyleSheet(GUIUtil::getThemedStyleQString(error ? GUIUtil::ThemedStyle::TS_ERROR
-                                                                       : GUIUtil::ThemedStyle::TS_SUCCESS));
-    m_status_label->setText(message);
-    m_status_label->setVisible(!message.isEmpty());
+    ShowStatusLabel(m_status_label, message, error);
 }
 
 // ----------------------------------------------------------------------------
@@ -554,6 +559,15 @@ SharedMnDialog::SharedMnDialog(interfaces::Node& node, WalletModel* wallet_model
     m_v24_active{node.isV24Active()},
     m_sender{new ProTxSender(node, this)}
 {
+}
+
+void SharedMnDialog::reject()
+{
+    // Esc or the window-manager close button must not dismiss the dialog
+    // while runCommand() waits on an in-flight command; QDialog::closeEvent
+    // keeps the window open when reject() leaves it visible
+    if (m_busy) return;
+    QDialog::reject();
 }
 
 bool SharedMnDialog::canSign() const
@@ -640,38 +654,127 @@ bool SharedMnDialog::txInputsUnspent(const QString& tx_hex, QString& error)
     }
     for (const CTxIn& txin : tx.vin) {
         Coin coin;
-        if (!m_node.getUnspentOutput(txin.prevout, coin)) {
-            error = tr("Input %1:%2 of the prepared transaction has been spent — this session is dead and cannot be continued. Start a new one.")
-                        .arg(QString::fromStdString(txin.prevout.hash.ToString()))
-                        .arg(txin.prevout.n);
-            return false;
+        if (m_node.getUnspentOutput(txin.prevout, coin)) continue;
+        // Not in the confirmed UTXO set. A fee input funded from a
+        // still-unconfirmed output of this wallet (e.g. fresh change selected
+        // by the prepare call) is unspent and merely waiting for a
+        // confirmation — only a positively spent input kills the session.
+        if (m_wallet_model) {
+            const auto coins{m_wallet_model->wallet().getCoins({txin.prevout})};
+            if (coins.size() == 1 && !coins[0].is_spent && coins[0].depth_in_main_chain >= 0) continue;
         }
+        error = tr("Input %1:%2 of the prepared transaction has been spent — this session is dead and cannot be continued. Start a new one.")
+                    .arg(QString::fromStdString(txin.prevout.hash.ToString()))
+                    .arg(txin.prevout.n);
+        return false;
     }
     return true;
-}
-
-std::vector<int> SharedMnDialog::myShareIndexes() const
-{
-    std::vector<int> ret;
-    if (!canSign()) return ret;
-    for (size_t i = 0; i < m_shares.size(); ++i) {
-        if (m_wallet_model->wallet().isSpendable(PKHash(m_shares[i].keyIDOwner))) {
-            ret.push_back(static_cast<int>(i));
-        }
-    }
-    return ret;
 }
 
 QComboBox* SharedMnDialog::makeMyShareCombo(QWidget* parent)
 {
     auto* combo = new QComboBox(parent);
-    for (const int i : myShareIndexes()) {
-        combo->addItem(tr("Share #%1 — %2 — %3").arg(i).arg(FormatDash(m_shares[i].amount), OwnerAddress(m_shares[i])), i);
-    }
+    FillMyShareCombo(combo, m_shares, m_wallet_model);
     if (combo->count() == 0) {
         combo->setToolTip(tr("This wallet does not hold any of this masternode's share owner keys."));
     }
     return combo;
+}
+
+bool SharedMnDialog::adoptPreparedTx(SharedSigCollector* collector, const ProTxResult& result, QLabel* status)
+{
+    QString error;
+    const QString tx_hex{QString::fromStdString(result.value.find_value("tx").get_str())};
+    if (!collector->setTransaction(tx_hex, error)) {
+        ShowStatusLabel(status, error, /*error=*/true);
+        return false;
+    }
+    // Cross-check our native sign-hash mirror against the node's answer, so a
+    // drifted mirror can never let a bad signature through verification
+    const QString rpc_hash{QString::fromStdString(result.value.find_value("signHash").get_str())};
+    if (collector->signHashHex().compare(rpc_hash, Qt::CaseInsensitive) != 0) {
+        ShowStatusLabel(status, tr("Internal error: the locally computed signing digest does not match the node's. Do not sign; please report this."), /*error=*/true);
+        return false;
+    }
+    return true;
+}
+
+void SharedMnDialog::signWithWallet(SharedSigCollector* collector, QLabel* status)
+{
+    if (!collector->hasTransaction()) return;
+
+    UniValue params(UniValue::VOBJ);
+    params.pushKV("tx", collector->txHex().toStdString());
+
+    ProTxResult result;
+    QString error;
+    if (!runCommand(QStringLiteral("protx shared_sign"), params, result, error)) {
+        ShowStatusLabel(status, error, /*error=*/true);
+        return;
+    }
+
+    QString sig_error;
+    const int absorbed{collector->addSignatures(result.value, sig_error)};
+    const bool problems{!sig_error.isEmpty()};
+    ShowStatusLabel(status,
+                    problems ? sig_error
+                             : tr("Signed %n share(s). Now copy or save the session and send it to the other participants.",
+                                  nullptr, absorbed),
+                    problems);
+}
+
+void SharedMnDialog::combineAndSubmit(SharedSigCollector* collector, QLabel* status, QLineEdit* result_edit,
+                                      QPushButton* sign_button, QPushButton* combine_button,
+                                      const QString& success_text, const QString& failure_hint)
+{
+    if (!collector->complete()) return;
+
+    UniValue params(UniValue::VOBJ);
+    params.pushKV("tx", collector->txHex().toStdString());
+    params.pushKV("signatures", collector->signaturesArray());
+    params.pushKV("submit", true);
+
+    ProTxResult result;
+    QString error;
+    if (!runCommand(QStringLiteral("protx shared_combine"), params, result, error)) {
+        ShowStatusLabel(status, failure_hint.isEmpty() ? error : error + QLatin1Char('\n') + failure_hint,
+                        /*error=*/true);
+        return;
+    }
+
+    result_edit->setText(QString::fromStdString(result.value.get_str()));
+    result_edit->setVisible(true);
+    ShowStatusLabel(status, success_text, /*error=*/false);
+    sign_button->setEnabled(false);
+    combine_button->setEnabled(false);
+}
+
+bool SharedMnDialog::gateSessionButtons(SharedSigCollector* collector, QLabel* status, QPushButton* primary_button,
+                                        QPushButton* sign_button, QPushButton* combine_button)
+{
+    // A8 liveness: a spent input makes the prepared transaction permanently
+    // unbroadcastable, so the session is dead
+    if (collector->hasTransaction()) {
+        if (QString liveness_error; !txInputsUnspent(collector->txHex(), liveness_error)) {
+            ShowStatusLabel(status, liveness_error, /*error=*/true);
+            primary_button->setEnabled(false);
+            sign_button->setEnabled(false);
+            combine_button->setEnabled(false);
+            return false;
+        }
+    }
+    if (gateButton(sign_button)) {
+        sign_button->setEnabled(collector->hasTransaction());
+    }
+    if (gateButton(combine_button)) {
+        combine_button->setEnabled(collector->complete());
+        if (!collector->complete()) {
+            combine_button->setToolTip(tr("Every share must be signed first (%1 of %2 so far).")
+                                           .arg(collector->signedCount())
+                                           .arg(m_shares.size()));
+        }
+    }
+    return true;
 }
 
 // ----------------------------------------------------------------------------
@@ -881,9 +984,28 @@ void DissolveDialog::submitNow()
     if (m_now_actor->currentIndex() < 0) return;
     const int actor{m_now_actor->currentData().toInt()};
 
-    // Re-derive the early decision the RPC will make so payPenalty is explicit
-    const bool early{static_cast<int64_t>(m_current_height) + 1 - m_registered_height <
-                     static_cast<int64_t>(m_early_period_blocks)};
+    // Re-derive the early decision the RPC will make so payPenalty is
+    // explicit — from a fresh tip height, not the height captured at dialog
+    // open: crossing the penalty-free boundary while the dialog was open must
+    // never submit an avoidable payPenalty=true.
+    const auto is_early = [this](int height) {
+        return static_cast<int64_t>(height) + 1 - m_registered_height < static_cast<int64_t>(m_early_period_blocks);
+    };
+    const auto refresh_on_boundary_crossing = [this, &is_early](int fresh_height) {
+        const bool crossed{is_early(fresh_height) != is_early(m_current_height)};
+        if (fresh_height != m_current_height) {
+            m_current_height = fresh_height;
+            updateNowPreview();
+        }
+        if (crossed) {
+            ShowStatusLabel(m_now_status,
+                            tr("The chain crossed the penalty-free boundary while this dialog was open. The preview above has been refreshed — review it and click Dissolve now again."),
+                            /*error=*/false);
+        }
+        return crossed;
+    };
+    if (refresh_on_boundary_crossing(m_node.getNumBlocks())) return;
+    const bool early{is_early(m_current_height)};
     if (early && !m_now_accept->isChecked()) return;
 
     if (QMessageBox::question(this, windowTitle(),
@@ -891,6 +1013,9 @@ void DissolveDialog::submitNow()
         QMessageBox::Yes) {
         return;
     }
+
+    // The confirmation prompt can also stay open across the boundary
+    if (refresh_on_boundary_crossing(m_node.getNumBlocks())) return;
 
     UniValue params(UniValue::VOBJ);
     params.pushKV("proTxHash", m_protx_hash.toStdString());
@@ -902,17 +1027,13 @@ void DissolveDialog::submitNow()
     ProTxResult result;
     QString error;
     if (!runCommand(QStringLiteral("protx dissolve"), params, result, error)) {
-        m_now_status->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
-        m_now_status->setText(error);
-        m_now_status->setVisible(true);
+        ShowStatusLabel(m_now_status, error, /*error=*/true);
         return;
     }
 
     m_now_result->setText(QString::fromStdString(result.value.get_str()));
     m_now_result->setVisible(true);
-    m_now_status->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_SUCCESS));
-    m_now_status->setText(tr("The dissolution was sent successfully."));
-    m_now_status->setVisible(true);
+    ShowStatusLabel(m_now_status, tr("The dissolution was sent successfully."), /*error=*/false);
     m_now_submit->setEnabled(false);
     m_now_actor->setEnabled(false);
     m_now_fee->setEnabled(false);
@@ -974,33 +1095,10 @@ QWidget* DissolveDialog::buildUnanimousTab()
 void DissolveDialog::refreshUnanimousUi()
 {
     if (!m_un_start) return;
-    // A8 liveness: a spent input (the collateral — the masternode was already
-    // dissolved) makes the session permanently dead
-    if (m_un_collector->hasTransaction()) {
-        if (QString liveness_error; !txInputsUnspent(m_un_collector->txHex(), liveness_error)) {
-            m_un_status->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
-            m_un_status->setText(liveness_error);
-            m_un_status->setVisible(true);
-            m_un_start->setEnabled(false);
-            m_un_sign->setEnabled(false);
-            m_un_combine->setEnabled(false);
-            return;
-        }
-    }
+    if (!gateSessionButtons(m_un_collector, m_un_status, m_un_start, m_un_sign, m_un_combine)) return;
     if (gateButton(m_un_start)) {
         m_un_start->setEnabled(!m_un_collector->hasTransaction() && m_un_actor->count() > 0);
         if (m_un_actor->count() == 0) m_un_start->setToolTip(tr("This wallet does not hold any of this masternode's share owner keys."));
-    }
-    if (gateButton(m_un_sign)) {
-        m_un_sign->setEnabled(m_un_collector->hasTransaction());
-    }
-    if (gateButton(m_un_combine)) {
-        m_un_combine->setEnabled(m_un_collector->complete());
-        if (!m_un_collector->complete()) {
-            m_un_combine->setToolTip(tr("Every share must be signed first (%1 of %2 so far).")
-                                         .arg(m_un_collector->signedCount())
-                                         .arg(m_shares.size()));
-        }
     }
 }
 
@@ -1016,31 +1114,12 @@ void DissolveDialog::startUnanimous()
     ProTxResult result;
     QString error;
     if (!runCommand(QStringLiteral("protx dissolve_prepare"), params, result, error)) {
-        m_un_status->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
-        m_un_status->setText(error);
-        m_un_status->setVisible(true);
+        ShowStatusLabel(m_un_status, error, /*error=*/true);
         return;
     }
 
-    const QString tx_hex{QString::fromStdString(result.value.find_value("tx").get_str())};
-    if (!m_un_collector->setTransaction(tx_hex, error)) {
-        m_un_status->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
-        m_un_status->setText(error);
-        m_un_status->setVisible(true);
-        return;
-    }
-    // Cross-check our native sign-hash mirror against the node's answer, so a
-    // drifted mirror can never let a bad signature through verification
-    const QString rpc_hash{QString::fromStdString(result.value.find_value("signHash").get_str())};
-    if (m_un_collector->signHashHex().compare(rpc_hash, Qt::CaseInsensitive) != 0) {
-        m_un_status->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
-        m_un_status->setText(tr("Internal error: the locally computed signing digest does not match the node's. Do not sign; please report this."));
-        m_un_status->setVisible(true);
-        return;
-    }
-    m_un_status->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_SUCCESS));
-    m_un_status->setText(tr("Prepared. Sign with this wallet, then pass the session to the other participants."));
-    m_un_status->setVisible(true);
+    if (!adoptPreparedTx(m_un_collector, result, m_un_status)) return;
+    ShowStatusLabel(m_un_status, tr("Prepared. Sign with this wallet, then pass the session to the other participants."), /*error=*/false);
     m_un_fee->setEnabled(false);
     m_un_actor->setEnabled(false);
     refreshUnanimousUi();
@@ -1048,56 +1127,13 @@ void DissolveDialog::startUnanimous()
 
 void DissolveDialog::signUnanimous()
 {
-    if (!m_un_collector->hasTransaction()) return;
-
-    UniValue params(UniValue::VOBJ);
-    params.pushKV("tx", m_un_collector->txHex().toStdString());
-
-    ProTxResult result;
-    QString error;
-    if (!runCommand(QStringLiteral("protx shared_sign"), params, result, error)) {
-        m_un_status->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
-        m_un_status->setText(error);
-        m_un_status->setVisible(true);
-        return;
-    }
-
-    QString sig_error;
-    const int absorbed{m_un_collector->addSignatures(result.value, sig_error)};
-    const bool problems{!sig_error.isEmpty()};
-    m_un_status->setStyleSheet(GUIUtil::getThemedStyleQString(problems ? GUIUtil::ThemedStyle::TS_ERROR
-                                                                       : GUIUtil::ThemedStyle::TS_SUCCESS));
-    m_un_status->setText(problems ? sig_error
-                                  : tr("Signed %n share(s). Now copy or save the session and send it to the other participants.",
-                                       nullptr, absorbed));
-    m_un_status->setVisible(true);
+    signWithWallet(m_un_collector, m_un_status);
 }
 
 void DissolveDialog::combineUnanimous()
 {
-    if (!m_un_collector->complete()) return;
-
-    UniValue params(UniValue::VOBJ);
-    params.pushKV("tx", m_un_collector->txHex().toStdString());
-    params.pushKV("signatures", m_un_collector->signaturesArray());
-    params.pushKV("submit", true);
-
-    ProTxResult result;
-    QString error;
-    if (!runCommand(QStringLiteral("protx shared_combine"), params, result, error)) {
-        m_un_status->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
-        m_un_status->setText(error);
-        m_un_status->setVisible(true);
-        return;
-    }
-
-    m_un_result->setText(QString::fromStdString(result.value.get_str()));
-    m_un_result->setVisible(true);
-    m_un_status->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_SUCCESS));
-    m_un_status->setText(tr("The dissolution was sent successfully."));
-    m_un_status->setVisible(true);
-    m_un_sign->setEnabled(false);
-    m_un_combine->setEnabled(false);
+    combineAndSubmit(m_un_collector, m_un_status, m_un_result, m_un_sign, m_un_combine,
+                     tr("The dissolution was sent successfully."), /*failure_hint=*/QString{});
 }
 
 QWidget* DissolveDialog::buildStandbyTab()
@@ -1114,7 +1150,6 @@ QWidget* DissolveDialog::buildStandbyTab()
     connect(m_sb_actor, qOverload<int>(&QComboBox::currentIndexChanged), tab, [this] {
         m_sb_view_a->clear();
         m_sb_view_b->clear();
-        m_sb_saved_a = m_sb_saved_b = false;
     });
     form->addRow(tr("My share:"), m_sb_actor);
     m_sb_fee = new QSpinBox(tab);
@@ -1127,57 +1162,46 @@ QWidget* DissolveDialog::buildStandbyTab()
     const int penalty_free_height{m_registered_height + static_cast<int>(m_early_period_blocks)};
     const int blocks_left{std::max(penalty_free_height - m_current_height - 1, 0)};
 
-    auto* generate_a = new QPushButton(tr("Generate Standby A — pays the %1 penalty, broadcastable immediately (it pays the penalty forever, even after the early period ends)")
-                                           .arg(FormatDash(m_early_penalty)),
-                                       tab);
-    connect(generate_a, &QPushButton::clicked, tab, [this] { generateStandby(/*pay_penalty=*/true); });
-    gateButton(generate_a);
-    layout->addWidget(generate_a);
+    // One column group per standby variant: generate button, transaction hex
+    // view, copy/save row
+    const auto build_variant = [this, tab, layout](bool pay_penalty, const QString& generate_text,
+                                                   const QString& placeholder, const QString& copy_text,
+                                                   const QString& save_text) {
+        auto* generate = new QPushButton(generate_text, tab);
+        connect(generate, &QPushButton::clicked, tab, [this, pay_penalty] { generateStandby(pay_penalty); });
+        gateButton(generate);
+        layout->addWidget(generate);
 
-    m_sb_view_a = new QPlainTextEdit(tab);
-    m_sb_view_a->setReadOnly(true);
-    m_sb_view_a->setFont(GUIUtil::fixedPitchFont());
-    m_sb_view_a->setMaximumHeight(70);
-    m_sb_view_a->setPlaceholderText(tr("Standby A transaction hex"));
-    layout->addWidget(m_sb_view_a);
+        auto* view = new QPlainTextEdit(tab);
+        view->setReadOnly(true);
+        view->setFont(GUIUtil::fixedPitchFont());
+        view->setMaximumHeight(70);
+        view->setPlaceholderText(placeholder);
+        layout->addWidget(view);
 
-    auto* row_a = new QHBoxLayout();
-    auto* copy_a = new QPushButton(tr("Copy A"), tab);
-    connect(copy_a, &QPushButton::clicked, tab, [this] {
-        if (!m_sb_view_a->toPlainText().isEmpty()) GUIUtil::setClipboard(m_sb_view_a->toPlainText());
-    });
-    row_a->addWidget(copy_a);
-    auto* save_a = new QPushButton(tr("Save A to file…"), tab);
-    connect(save_a, &QPushButton::clicked, tab, [this] { saveStandby(/*pay_penalty=*/true); });
-    row_a->addWidget(save_a);
-    row_a->addStretch();
-    layout->addLayout(row_a);
+        auto* row = new QHBoxLayout();
+        auto* copy = new QPushButton(copy_text, tab);
+        connect(copy, &QPushButton::clicked, tab, [view] {
+            if (!view->toPlainText().isEmpty()) GUIUtil::setClipboard(view->toPlainText());
+        });
+        row->addWidget(copy);
+        auto* save = new QPushButton(save_text, tab);
+        connect(save, &QPushButton::clicked, tab, [this, pay_penalty] { saveStandby(pay_penalty); });
+        row->addWidget(save);
+        row->addStretch();
+        layout->addLayout(row);
+        return view;
+    };
+
+    m_sb_view_a = build_variant(/*pay_penalty=*/true,
+                                tr("Generate Standby A — pays the %1 penalty, broadcastable immediately (it pays the penalty forever, even after the early period ends)")
+                                    .arg(FormatDash(m_early_penalty)),
+                                tr("Standby A transaction hex"), tr("Copy A"), tr("Save A to file…"));
 
     const QString b_when{blocks_left > 0 ? tr("valid only from block %1 (~%2)").arg(penalty_free_height).arg(ApproxBlockDate(blocks_left)) :
                                            tr("already valid — the early period has ended")};
-    auto* generate_b = new QPushButton(tr("Generate Standby B — full principal, %1").arg(b_when), tab);
-    connect(generate_b, &QPushButton::clicked, tab, [this] { generateStandby(/*pay_penalty=*/false); });
-    gateButton(generate_b);
-    layout->addWidget(generate_b);
-
-    m_sb_view_b = new QPlainTextEdit(tab);
-    m_sb_view_b->setReadOnly(true);
-    m_sb_view_b->setFont(GUIUtil::fixedPitchFont());
-    m_sb_view_b->setMaximumHeight(70);
-    m_sb_view_b->setPlaceholderText(tr("Standby B transaction hex"));
-    layout->addWidget(m_sb_view_b);
-
-    auto* row_b = new QHBoxLayout();
-    auto* copy_b = new QPushButton(tr("Copy B"), tab);
-    connect(copy_b, &QPushButton::clicked, tab, [this] {
-        if (!m_sb_view_b->toPlainText().isEmpty()) GUIUtil::setClipboard(m_sb_view_b->toPlainText());
-    });
-    row_b->addWidget(copy_b);
-    auto* save_b = new QPushButton(tr("Save B to file…"), tab);
-    connect(save_b, &QPushButton::clicked, tab, [this] { saveStandby(/*pay_penalty=*/false); });
-    row_b->addWidget(save_b);
-    row_b->addStretch();
-    layout->addLayout(row_b);
+    m_sb_view_b = build_variant(/*pay_penalty=*/false, tr("Generate Standby B — full principal, %1").arg(b_when),
+                                tr("Standby B transaction hex"), tr("Copy B"), tr("Save B to file…"));
 
     auto* which = new QLabel(tr("Which one to broadcast later: B whenever the early period is over (full principal); A only when you cannot wait for the boundary."), tab);
     which->setWordWrap(true);
@@ -1202,9 +1226,7 @@ QWidget* DissolveDialog::buildStandbyTab()
 void DissolveDialog::generateStandby(bool pay_penalty)
 {
     if (m_sb_actor->currentIndex() < 0) {
-        m_sb_status->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
-        m_sb_status->setText(tr("This wallet does not hold any of this masternode's share owner keys."));
-        m_sb_status->setVisible(true);
+        ShowStatusLabel(m_sb_status, tr("This wallet does not hold any of this masternode's share owner keys."), /*error=*/true);
         return;
     }
 
@@ -1218,16 +1240,14 @@ void DissolveDialog::generateStandby(bool pay_penalty)
     ProTxResult result;
     QString error;
     if (!runCommand(QStringLiteral("protx dissolve"), params, result, error)) {
-        m_sb_status->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
-        m_sb_status->setText(error);
-        m_sb_status->setVisible(true);
+        ShowStatusLabel(m_sb_status, error, /*error=*/true);
         return;
     }
 
     (pay_penalty ? m_sb_view_a : m_sb_view_b)->setPlainText(QString::fromStdString(result.value.get_str()));
-    m_sb_status->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_SUCCESS));
-    m_sb_status->setText(tr("Standby %1 generated — save it to a file now.").arg(pay_penalty ? QStringLiteral("A") : QStringLiteral("B")));
-    m_sb_status->setVisible(true);
+    ShowStatusLabel(m_sb_status,
+                    tr("Standby %1 generated — save it to a file now.").arg(pay_penalty ? QStringLiteral("A") : QStringLiteral("B")),
+                    /*error=*/false);
 }
 
 void DissolveDialog::saveStandby(bool pay_penalty)
@@ -1241,26 +1261,29 @@ void DissolveDialog::saveStandby(bool pay_penalty)
     if (filename.isEmpty()) return;
     QFile file(filename);
     if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
-        m_sb_status->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
-        m_sb_status->setText(tr("Could not write to %1.").arg(filename));
-        m_sb_status->setVisible(true);
+        ShowStatusLabel(m_sb_status, tr("Could not write to %1.").arg(filename), /*error=*/true);
         return;
     }
     QTextStream out(&file);
     out << hex << '\n';
     file.close();
 
-    (pay_penalty ? m_sb_saved_a : m_sb_saved_b) = true;
-    m_sb_status->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_SUCCESS));
-    m_sb_status->setText(tr("Standby %1 saved to %2.").arg(pay_penalty ? QStringLiteral("A") : QStringLiteral("B"), filename));
-    m_sb_status->setVisible(true);
+    // Persist the per-variant flag so saving A and B in different dialog
+    // sessions still counts as "both stored"
+    QSettings().setValue((pay_penalty ? QStringLiteral("mnStandbySavedA/") : QStringLiteral("mnStandbySavedB/")) + m_protx_hash,
+                         true);
+    ShowStatusLabel(m_sb_status,
+                    tr("Standby %1 saved to %2.").arg(pay_penalty ? QStringLiteral("A") : QStringLiteral("B"), filename),
+                    /*error=*/false);
     maybeMarkStandbyStored();
 }
 
 void DissolveDialog::maybeMarkStandbyStored()
 {
-    if (!m_sb_saved_a || !m_sb_saved_b) return;
-    QSettings().setValue(QStringLiteral("mnStandbyStored/") + m_protx_hash, true);
+    QSettings settings;
+    if (!settings.value(QStringLiteral("mnStandbySavedA/") + m_protx_hash, false).toBool()) return;
+    if (!settings.value(QStringLiteral("mnStandbySavedB/") + m_protx_hash, false).toBool()) return;
+    settings.setValue(QStringLiteral("mnStandbyStored/") + m_protx_hash, true);
     m_sb_stored_label->setVisible(true);
 }
 
@@ -1360,19 +1383,7 @@ void RotateSharedKeysDialog::validateForm()
 
 void RotateSharedKeysDialog::refreshButtons()
 {
-    // A8 liveness: a spent fee input makes the prepared transaction
-    // permanently unbroadcastable
-    if (m_collector->hasTransaction()) {
-        if (QString liveness_error; !txInputsUnspent(m_collector->txHex(), liveness_error)) {
-            m_status_label->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
-            m_status_label->setText(liveness_error);
-            m_status_label->setVisible(true);
-            m_prepare_button->setEnabled(false);
-            m_sign_button->setEnabled(false);
-            m_combine_button->setEnabled(false);
-            return;
-        }
-    }
+    if (!gateSessionButtons(m_collector, m_status_label, m_prepare_button, m_sign_button, m_combine_button)) return;
     if (gateButton(m_prepare_button)) {
         const QString operator_key{m_operator_edit->text().trimmed()};
         const bool operator_ok{operator_key.isEmpty() ||
@@ -1382,17 +1393,6 @@ void RotateSharedKeysDialog::refreshButtons()
         const bool voting_ok{m_voting_edit->text().isEmpty() || m_voting_edit->isValid()};
         m_prepare_button->setEnabled(!m_collector->hasTransaction() && any_change && operator_ok && voting_ok &&
                                      !m_fee_source->selectedAddress().isEmpty());
-    }
-    if (gateButton(m_sign_button)) {
-        m_sign_button->setEnabled(m_collector->hasTransaction());
-    }
-    if (gateButton(m_combine_button)) {
-        m_combine_button->setEnabled(m_collector->complete());
-        if (!m_collector->complete()) {
-            m_combine_button->setToolTip(tr("Every share must be signed first (%1 of %2 so far).")
-                                             .arg(m_collector->signedCount())
-                                             .arg(m_shares.size()));
-        }
     }
 }
 
@@ -1408,88 +1408,30 @@ void RotateSharedKeysDialog::prepare()
     ProTxResult result;
     QString error;
     if (!runCommand(QStringLiteral("protx update_shared_registrar_prepare"), params, result, error)) {
-        m_status_label->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
-        m_status_label->setText(error);
-        m_status_label->setVisible(true);
+        ShowStatusLabel(m_status_label, error, /*error=*/true);
         return;
     }
 
-    const QString tx_hex{QString::fromStdString(result.value.find_value("tx").get_str())};
-    if (!m_collector->setTransaction(tx_hex, error)) {
-        m_status_label->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
-        m_status_label->setText(error);
-        m_status_label->setVisible(true);
-        return;
-    }
-    const QString rpc_hash{QString::fromStdString(result.value.find_value("signHash").get_str())};
-    if (m_collector->signHashHex().compare(rpc_hash, Qt::CaseInsensitive) != 0) {
-        m_status_label->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
-        m_status_label->setText(tr("Internal error: the locally computed signing digest does not match the node's. Do not sign; please report this."));
-        m_status_label->setVisible(true);
-        return;
-    }
+    if (!adoptPreparedTx(m_collector, result, m_status_label)) return;
 
     m_operator_edit->setEnabled(false);
     m_voting_edit->setEnabled(false);
     m_fee_source->setEnabled(false);
-    m_status_label->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_SUCCESS));
-    m_status_label->setText(tr("Prepared. Sign with this wallet, pass the session to the other participants, then finish here once every share has signed."));
-    m_status_label->setVisible(true);
+    ShowStatusLabel(m_status_label,
+                    tr("Prepared. Sign with this wallet, pass the session to the other participants, then finish here once every share has signed."),
+                    /*error=*/false);
     refreshButtons();
 }
 
 void RotateSharedKeysDialog::signMine()
 {
-    if (!m_collector->hasTransaction()) return;
-
-    UniValue params(UniValue::VOBJ);
-    params.pushKV("tx", m_collector->txHex().toStdString());
-
-    ProTxResult result;
-    QString error;
-    if (!runCommand(QStringLiteral("protx shared_sign"), params, result, error)) {
-        m_status_label->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
-        m_status_label->setText(error);
-        m_status_label->setVisible(true);
-        return;
-    }
-
-    QString sig_error;
-    const int absorbed{m_collector->addSignatures(result.value, sig_error)};
-    const bool problems{!sig_error.isEmpty()};
-    m_status_label->setStyleSheet(GUIUtil::getThemedStyleQString(problems ? GUIUtil::ThemedStyle::TS_ERROR
-                                                                          : GUIUtil::ThemedStyle::TS_SUCCESS));
-    m_status_label->setText(problems ? sig_error
-                                     : tr("Signed %n share(s). Now copy or save the session and send it to the other participants.",
-                                          nullptr, absorbed));
-    m_status_label->setVisible(true);
+    signWithWallet(m_collector, m_status_label);
 }
 
 void RotateSharedKeysDialog::combineAndSend()
 {
-    if (!m_collector->complete()) return;
-
-    UniValue params(UniValue::VOBJ);
-    params.pushKV("tx", m_collector->txHex().toStdString());
-    params.pushKV("signatures", m_collector->signaturesArray());
-    params.pushKV("submit", true);
-
-    ProTxResult result;
-    QString error;
-    if (!runCommand(QStringLiteral("protx shared_combine"), params, result, error)) {
-        m_status_label->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_ERROR));
-        // Combining re-signs the fee inputs, which only the preparing wallet can do
-        m_status_label->setText(error + QLatin1Char('\n') +
-                                tr("If the error mentions signing the transaction inputs, this is not the wallet that prepared it — finish on that wallet."));
-        m_status_label->setVisible(true);
-        return;
-    }
-
-    m_result_edit->setText(QString::fromStdString(result.value.get_str()));
-    m_result_edit->setVisible(true);
-    m_status_label->setStyleSheet(GUIUtil::getThemedStyleQString(GUIUtil::ThemedStyle::TS_SUCCESS));
-    m_status_label->setText(tr("The key rotation was sent successfully."));
-    m_status_label->setVisible(true);
-    m_sign_button->setEnabled(false);
-    m_combine_button->setEnabled(false);
+    // Combining re-signs the fee inputs, which only the preparing wallet can do
+    combineAndSubmit(m_collector, m_status_label, m_result_edit, m_sign_button, m_combine_button,
+                     tr("The key rotation was sent successfully."),
+                     tr("If the error mentions signing the transaction inputs, this is not the wallet that prepared it — finish on that wallet."));
 }

--- a/src/qt/sharedmndialogs.h
+++ b/src/qt/sharedmndialogs.h
@@ -1,0 +1,270 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_SHAREDMNDIALOGS_H
+#define BITCOIN_QT_SHAREDMNDIALOGS_H
+
+#include <qt/masternodedialogs.h>
+
+#include <consensus/amount.h>
+#include <interfaces/node.h>
+
+#include <QDialog>
+#include <QString>
+#include <QWidget>
+
+#include <map>
+#include <vector>
+
+struct ProTxResult;
+
+QT_BEGIN_NAMESPACE
+class QCheckBox;
+class QPlainTextEdit;
+class QSpinBox;
+class QTableWidget;
+QT_END_NAMESPACE
+
+//! Send a ProUpShareTx ("protx update_share"): change the reward address of one
+//! collateral share of a shared masternode. Only shares whose owner key this
+//! wallet holds are offered; every other share field is immutable.
+class UpdateShareDialog : public MasternodeActionDialog
+{
+    Q_OBJECT
+
+public:
+    UpdateShareDialog(interfaces::Node& node, WalletModel* wallet_model, const MasternodeEntry& entry, QWidget* parent = nullptr);
+
+protected:
+    void validate() override;
+    void submit() override;
+
+private:
+    const bool m_v24_active;
+
+    QComboBox* m_share_combo{nullptr};
+    QValidatedLineEdit* m_reward_edit{nullptr};
+    FeeSourcePicker* m_fee_source{nullptr};
+};
+
+//! Collects share owner signatures for a multi-party shared masternode
+//! transaction (unanimous ProDisTx or ProUpSharedRegTx): shows the prepared
+//! transaction and its check phrase, exports/imports a small session envelope
+//! via clipboard and file, and verifies every imported signature natively
+//! against the share owner keys (an unverifiable signature is never counted).
+class SharedSigCollector : public QWidget
+{
+    Q_OBJECT
+
+public:
+    enum class Kind {
+        Dissolve,  //!< unanimous ProDisTx from "protx dissolve_prepare"
+        Registrar, //!< ProUpSharedRegTx from "protx update_shared_registrar_prepare"
+    };
+
+    SharedSigCollector(Kind kind, const QString& pro_tx_hash, const std::vector<interfaces::MnShare>& shares,
+                       QWidget* parent = nullptr);
+
+    bool hasTransaction() const { return !m_tx_hex.isEmpty(); }
+    const QString& txHex() const { return m_tx_hex; }
+    //! Lowercase hex of the digest every share owner signs, recomputed natively
+    //! from the adopted transaction (empty when no transaction is adopted)
+    QString signHashHex() const;
+    //! Adopt the prepared transaction (rejects a different transaction than
+    //! the one already adopted; signatures collected so far are kept)
+    bool setTransaction(const QString& tx_hex, QString& error);
+
+    //! Verify and absorb an array of {shareIndex, signature} entries (the
+    //! "protx shared_sign" result shape). Returns the number of newly absorbed
+    //! signatures; `error` collects per-entry rejections.
+    int addSignatures(const UniValue& entries, QString& error);
+
+    int signedCount() const { return static_cast<int>(m_sigs.size()); }
+    bool complete() const { return m_sigs.size() == m_shares.size(); }
+    //! Signature entries in the shape "protx shared_combine" expects
+    UniValue signaturesArray() const;
+
+Q_SIGNALS:
+    //! The transaction or the signature set changed
+    void changed();
+
+private Q_SLOTS:
+    void copyEnvelope();
+    void saveEnvelope();
+    void pasteEnvelope();
+    void loadEnvelope();
+
+private:
+    UniValue envelopeJson() const;
+    bool importEnvelope(const QString& text, QString& error);
+    bool importEnvelopeChecked(const UniValue& json, QString& error);
+    void refreshUi();
+    void showStatus(const QString& message, bool error);
+
+    const Kind m_kind;
+    const QString m_protx_hash;
+    const std::vector<interfaces::MnShare> m_shares;
+    QString m_tx_hex;
+    std::map<int, QString> m_sigs; //!< shareIndex -> base64 signature
+
+    QPlainTextEdit* m_tx_view{nullptr};
+    QLabel* m_phrase_label{nullptr};
+    QLabel* m_checklist_label{nullptr};
+    QLabel* m_status_label{nullptr};
+    QPushButton* m_copy_button{nullptr};
+    QPushButton* m_save_button{nullptr};
+};
+
+//! Scaffolding for the larger shared masternode dialogs that run several RPC
+//! commands over their lifetime: wallet/watch-only gating and the unlock +
+//! busy-state + ProTxSender round trip with the result returned to the caller.
+class SharedMnDialog : public QDialog
+{
+    Q_OBJECT
+
+protected:
+    SharedMnDialog(interfaces::Node& node, WalletModel* wallet_model, const MasternodeEntry& entry, QWidget* parent);
+
+    //! True when a wallet able to sign transactions is available
+    bool canSign() const;
+    //! Disable `button` with an explanatory tooltip when no signing wallet is
+    //! available or the v24 hard fork is not active yet; returns true when the
+    //! button stays usable
+    bool gateButton(QPushButton* button) const;
+    //! Unlock the wallet, execute `method` with named `params` on the RPC
+    //! bridge and wait in a local event loop (the dialog is disabled
+    //! meanwhile). Returns false with a user-displayable `error` when the
+    //! command could not run or failed.
+    bool runCommand(const QString& method, const UniValue& params, ProTxResult& result, QString& error);
+
+    //! True when every input of `tx_hex` is still unspent. A spent input makes
+    //! the transaction permanently unbroadcastable: the session is dead and a
+    //! new one must be started.
+    bool txInputsUnspent(const QString& tx_hex, QString& error);
+
+    //! Indexes into m_shares whose owner key this wallet can sign with
+    std::vector<int> myShareIndexes() const;
+    //! Combo box over myShareIndexes(): "Share #i — amount — owner address"
+    QComboBox* makeMyShareCombo(QWidget* parent);
+
+    interfaces::Node& m_node;
+    WalletModel* const m_wallet_model;
+    const QString m_protx_hash;
+    const std::vector<interfaces::MnShare> m_shares;
+    const CAmount m_early_penalty;
+    const uint32_t m_early_period_blocks;
+    const int m_registered_height;
+    const bool m_v24_active;
+
+private:
+    ProTxSender* m_sender;
+    bool m_busy{false};
+};
+
+//! Dissolution of a shared masternode ("protx dissolve" / "protx
+//! dissolve_prepare" + "protx shared_sign" + "protx shared_combine"):
+//! - Dissolve now: unilateral, with a live penalty preview mirroring the real
+//!   transaction's outputs;
+//! - Unanimous: penalty-free at any height, needs every share owner's
+//!   signature, collected via a SharedSigCollector envelope;
+//! - Standby: generate and store both offline dissolution variants
+//!   (payPenalty true/false) next to the refund key backup.
+class DissolveDialog : public SharedMnDialog
+{
+    Q_OBJECT
+
+public:
+    DissolveDialog(interfaces::Node& node, WalletModel* wallet_model, const MasternodeEntry& entry, int current_height,
+                   QWidget* parent = nullptr);
+
+    //! Whether both standby variants for this masternode were ever saved to
+    //! file from this GUI (per-proTx QSettings flag)
+    static bool StandbyStored(const QString& pro_tx_hash);
+
+private Q_SLOTS:
+    void updateNowPreview();
+    void submitNow();
+    void startUnanimous();
+    void signUnanimous();
+    void combineUnanimous();
+
+private:
+    QWidget* buildNowTab();
+    QWidget* buildUnanimousTab();
+    QWidget* buildStandbyTab();
+    void generateStandby(bool pay_penalty);
+    void saveStandby(bool pay_penalty);
+    void maybeMarkStandbyStored();
+    void refreshUnanimousUi();
+
+    const int m_current_height;
+
+    // Dissolve now
+    QComboBox* m_now_actor{nullptr};
+    QSpinBox* m_now_fee{nullptr};
+    QLabel* m_now_early_label{nullptr};
+    QLabel* m_now_nudge_label{nullptr};
+    QLabel* m_now_error_label{nullptr};
+    QTableWidget* m_now_table{nullptr};
+    QCheckBox* m_now_accept{nullptr};
+    QPushButton* m_now_submit{nullptr};
+    QLineEdit* m_now_result{nullptr};
+    QLabel* m_now_status{nullptr};
+
+    // Unanimous
+    QComboBox* m_un_actor{nullptr};
+    QSpinBox* m_un_fee{nullptr};
+    QPushButton* m_un_start{nullptr};
+    QPushButton* m_un_sign{nullptr};
+    QPushButton* m_un_combine{nullptr};
+    SharedSigCollector* m_un_collector{nullptr};
+    QLineEdit* m_un_result{nullptr};
+    QLabel* m_un_status{nullptr};
+
+    // Standby
+    QComboBox* m_sb_actor{nullptr};
+    QSpinBox* m_sb_fee{nullptr};
+    QPlainTextEdit* m_sb_view_a{nullptr};
+    QPlainTextEdit* m_sb_view_b{nullptr};
+    QLabel* m_sb_stored_label{nullptr};
+    QLabel* m_sb_status{nullptr};
+    bool m_sb_saved_a{false};
+    bool m_sb_saved_b{false};
+};
+
+//! Rotate a shared masternode's operator and/or voting key ("protx
+//! update_shared_registrar_prepare" + "protx shared_sign" + "protx
+//! shared_combine"). The prepare and the final combine must run on the same
+//! wallet, whose coins pay the fee; other participants open this dialog only
+//! to import the envelope, sign and export.
+class RotateSharedKeysDialog : public SharedMnDialog
+{
+    Q_OBJECT
+
+public:
+    RotateSharedKeysDialog(interfaces::Node& node, WalletModel* wallet_model, const MasternodeEntry& entry,
+                           QWidget* parent = nullptr);
+
+private Q_SLOTS:
+    void validateForm();
+    void prepare();
+    void signMine();
+    void combineAndSend();
+
+private:
+    void refreshButtons();
+
+    QLineEdit* m_operator_edit{nullptr};
+    QValidatedLineEdit* m_voting_edit{nullptr};
+    FeeSourcePicker* m_fee_source{nullptr};
+    QLabel* m_pose_warning{nullptr};
+    QPushButton* m_prepare_button{nullptr};
+    QPushButton* m_sign_button{nullptr};
+    QPushButton* m_combine_button{nullptr};
+    SharedSigCollector* m_collector{nullptr};
+    QLineEdit* m_result_edit{nullptr};
+    QLabel* m_status_label{nullptr};
+};
+
+#endif // BITCOIN_QT_SHAREDMNDIALOGS_H

--- a/src/qt/sharedmndialogs.h
+++ b/src/qt/sharedmndialogs.h
@@ -123,6 +123,11 @@ class SharedMnDialog : public QDialog
 {
     Q_OBJECT
 
+public:
+    //! Ignores Esc and window-close while a command runs in runCommand()'s
+    //! nested event loop, so a flow cannot be dismissed mid-flight
+    void reject() override;
+
 protected:
     SharedMnDialog(interfaces::Node& node, WalletModel* wallet_model, const MasternodeEntry& entry, QWidget* parent);
 
@@ -138,14 +143,31 @@ protected:
     //! command could not run or failed.
     bool runCommand(const QString& method, const UniValue& params, ProTxResult& result, QString& error);
 
-    //! True when every input of `tx_hex` is still unspent. A spent input makes
-    //! the transaction permanently unbroadcastable: the session is dead and a
-    //! new one must be started.
+    //! True when no input of `tx_hex` is positively spent. An input that is
+    //! merely waiting for its confirmation (an unconfirmed own-wallet fee
+    //! input) counts as unspent; a spent input makes the transaction
+    //! permanently unbroadcastable: the session is dead and a new one must be
+    //! started.
     bool txInputsUnspent(const QString& tx_hex, QString& error);
 
-    //! Indexes into m_shares whose owner key this wallet can sign with
-    std::vector<int> myShareIndexes() const;
-    //! Combo box over myShareIndexes(): "Share #i — amount — owner address"
+    //! Adopt a "..._prepare" result into `collector` and cross-check the
+    //! locally computed signing digest against the node's; reports into
+    //! `status` and returns false when the transaction must not be signed
+    bool adoptPreparedTx(SharedSigCollector* collector, const ProTxResult& result, QLabel* status);
+    //! "protx shared_sign" the collector's transaction with every share owner
+    //! key this wallet holds and absorb the resulting signatures
+    void signWithWallet(SharedSigCollector* collector, QLabel* status);
+    //! "protx shared_combine" the fully signed transaction and submit it
+    void combineAndSubmit(SharedSigCollector* collector, QLabel* status, QLineEdit* result_edit,
+                          QPushButton* sign_button, QPushButton* combine_button, const QString& success_text,
+                          const QString& failure_hint);
+    //! Session liveness guard plus the shared sign/combine gating; disables
+    //! all three buttons and returns false when the session is dead
+    bool gateSessionButtons(SharedSigCollector* collector, QLabel* status, QPushButton* primary_button,
+                            QPushButton* sign_button, QPushButton* combine_button);
+
+    //! Combo box over the shares whose owner key this wallet can sign with:
+    //! "Share #i — amount — owner address"
     QComboBox* makeMyShareCombo(QWidget* parent);
 
     interfaces::Node& m_node;
@@ -198,7 +220,8 @@ private:
     void maybeMarkStandbyStored();
     void refreshUnanimousUi();
 
-    const int m_current_height;
+    //! Height captured at dialog open, refreshed from the tip in submitNow()
+    int m_current_height;
 
     // Dissolve now
     QComboBox* m_now_actor{nullptr};
@@ -229,8 +252,6 @@ private:
     QPlainTextEdit* m_sb_view_b{nullptr};
     QLabel* m_sb_stored_label{nullptr};
     QLabel* m_sb_status{nullptr};
-    bool m_sb_saved_a{false};
-    bool m_sb_saved_b{false};
 };
 
 //! Rotate a shared masternode's operator and/or voting key ("protx

--- a/src/qt/test/mnsharesessiontests.cpp
+++ b/src/qt/test/mnsharesessiontests.cpp
@@ -6,6 +6,7 @@
 
 #include <qt/mnsharesession.h>
 
+#include <bls/bls.h>
 #include <chainparams.h>
 #include <consensus/amount.h>
 #include <core_io.h>
@@ -182,6 +183,11 @@ void MnShareSessionTests::signatureVerification()
     BasicTestingSetup setup{CBaseChainParams::REGTEST};
     std::vector<CKey> owner_keys;
     MnShareSession session{ValidSession(owner_keys)};
+    // The operator key is a first-class term; register_shared_prepare would put
+    // it in the payload, so the session must carry the matching pubkey
+    CBLSSecretKey operator_secret;
+    operator_secret.MakeNewKey();
+    session.terms().operatorPubKey = QString::fromStdString(operator_secret.GetPublicKey().ToString(/*specificLegacyScheme=*/false));
 
     // Build the shared registration the way register_shared_prepare would:
     // the transaction spends the funding inputs directly and carries the
@@ -198,6 +204,9 @@ void MnShareSessionTests::signatureVerification()
                                     ToKeyID(std::get<PKHash>(owner_dest)));
     }
     payload.vchJoinSigs.assign(payload.shares.size(), std::vector<unsigned char>(CPubKey::COMPACT_SIGNATURE_SIZE));
+    payload.keyIDVoting = ToKeyID(std::get<PKHash>(DecodeDestination(session.terms().votingAddress.toStdString())));
+    payload.pubKeyOperator.Set(operator_secret.GetPublicKey(), /*bls_legacy_scheme=*/false);
+    payload.nOperatorReward = session.terms().operatorReward;
     payload.nEarlyPeriodBlocks = session.terms().earlyPeriodBlocks;
     payload.nEarlyPenalty = session.terms().earlyPenalty;
 
@@ -247,4 +256,30 @@ void MnShareSessionTests::signatureVerification()
     QCOMPARE(int(session.stage()), int(MnShareSession::Stage::Draft));
     QCOMPARE(session.signedCount(), 0);
     QVERIFY(session.revision() > revision);
+
+    // A payload that disagrees with the displayed share table must never freeze
+    // or verify: the participant reviews m_shares but the wallet signs the
+    // payload digest, so a mismatch is a money-loss trap
+    MnShareSession tampered{ValidSession(owner_keys)};
+    // The displayed table shows share 0 refunding to its own fresh address,
+    // but the payload refunds share 0 to an attacker address
+    CProRegTx evil{payload};
+    CKey attacker;
+    attacker.MakeNewKey(true);
+    evil.shares[0].scriptRefund = GetScriptForDestination(PKHash(attacker.GetPubKey()));
+    CMutableTransaction evil_tx{tx};
+    SetTxPayload(evil_tx, evil);
+    const uint256 evil_hash{evil.MakeSharedRegConsentHash(CTransaction(evil_tx))};
+    const QString evil_hex{QString::fromStdString(EncodeHexTx(CTransaction(evil_tx)))};
+    QVERIFY(!tampered.freeze(evil_hex, QString::fromStdString(evil_hash.ToString()), 0, error));
+
+    // The same tampered payload delivered through a frozen envelope is rejected
+    // on import. Re-freeze the matching session to get a well-formed envelope,
+    // then swap in the attacker's payload.
+    QVERIFY2(session.freeze(tx_hex, QString::fromStdString(consent_hash.ToString()), 0, error), qPrintable(error));
+    UniValue envelope{session.toJson()};
+    envelope.pushKV("protx", evil_hex.toStdString());
+    envelope.pushKV("consentHash", evil_hash.ToString());
+    MnShareSession imported;
+    QVERIFY(!imported.fromJson(envelope, error));
 }

--- a/src/qt/test/mnsharesessiontests.cpp
+++ b/src/qt/test/mnsharesessiontests.cpp
@@ -1,0 +1,250 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/test/mnsharesessiontests.h>
+
+#include <qt/mnsharesession.h>
+
+#include <chainparams.h>
+#include <consensus/amount.h>
+#include <core_io.h>
+#include <evo/providertx.h>
+#include <evo/specialtx.h>
+#include <key.h>
+#include <key_io.h>
+#include <messagesigner.h>
+#include <primitives/transaction.h>
+#include <test/util/setup_common.h>
+#include <util/strencodings.h>
+
+#include <string>
+#include <vector>
+
+namespace {
+QString FreshP2PKHAddress(CKey& key_out)
+{
+    key_out.MakeNewKey(/*fCompressed=*/true);
+    return QString::fromStdString(EncodeDestination(PKHash(key_out.GetPubKey())));
+}
+
+MnShareSession::Share MakeShare(CAmount amount, const QString& owner, const QString& refund,
+                                const QString& reward = {})
+{
+    MnShareSession::Share share;
+    share.amount = amount;
+    share.ownerAddress = owner;
+    share.refundAddress = refund;
+    share.rewardAddress = reward;
+    return share;
+}
+
+//! A session whose share table passes every draft-side check
+MnShareSession ValidSession(std::vector<CKey>& owner_keys)
+{
+    MnShareSession session;
+    owner_keys.resize(3);
+    CKey dummy;
+    session.shares().push_back(MakeShare(400 * COIN, FreshP2PKHAddress(owner_keys[0]), FreshP2PKHAddress(dummy)));
+    session.shares().push_back(MakeShare(350 * COIN, FreshP2PKHAddress(owner_keys[1]), FreshP2PKHAddress(dummy)));
+    session.shares().push_back(MakeShare(250 * COIN, FreshP2PKHAddress(owner_keys[2]), FreshP2PKHAddress(dummy)));
+    CKey voting_key;
+    session.terms().votingAddress = FreshP2PKHAddress(voting_key);
+    session.terms().earlyPeriodBlocks = 5000;
+    session.terms().earlyPenalty = 5 * COIN;
+    return session;
+}
+} // anonymous namespace
+
+void MnShareSessionTests::validateSharesMirror()
+{
+    BasicTestingSetup setup{CBaseChainParams::REGTEST};
+    std::vector<CKey> keys;
+    MnShareSession session{ValidSession(keys)};
+    QVERIFY(session.validateShares().isEmpty());
+
+    // Too few shares
+    MnShareSession too_few{ValidSession(keys)};
+    too_few.shares().resize(1);
+    QVERIFY(!too_few.validateShares().isEmpty());
+
+    // Sum must be exactly the collateral amount
+    MnShareSession bad_sum{ValidSession(keys)};
+    bad_sum.shares()[0].amount += COIN;
+    QVERIFY(!bad_sum.validateShares().isEmpty());
+
+    // Minimum share amount
+    MnShareSession too_small{ValidSession(keys)};
+    too_small.shares()[0].amount = 950 * COIN;
+    too_small.shares()[1].amount = 25 * COIN; // below the 100 DASH minimum
+    too_small.shares()[2].amount = 25 * COIN;
+    QVERIFY(!too_small.validateShares().isEmpty());
+
+    // Duplicate owner keys
+    MnShareSession dup_owner{ValidSession(keys)};
+    dup_owner.shares()[1].ownerAddress = dup_owner.shares()[0].ownerAddress;
+    QVERIFY(!dup_owner.validateShares().isEmpty());
+
+    // Duplicate refund scripts
+    MnShareSession dup_refund{ValidSession(keys)};
+    dup_refund.shares()[1].refundAddress = dup_refund.shares()[0].refundAddress;
+    QVERIFY(!dup_refund.validateShares().isEmpty());
+
+    // A reward script may not reuse a share owner address
+    MnShareSession payee_reuse{ValidSession(keys)};
+    payee_reuse.shares()[1].rewardAddress = payee_reuse.shares()[0].ownerAddress;
+    QVERIFY(!payee_reuse.validateShares().isEmpty());
+
+    // The early penalty must stay below the smallest share
+    MnShareSession bad_penalty{ValidSession(keys)};
+    bad_penalty.terms().earlyPenalty = 250 * COIN;
+    QVERIFY(!bad_penalty.validateShares().isEmpty());
+
+    // The early period is capped
+    MnShareSession bad_period{ValidSession(keys)};
+    bad_period.terms().earlyPeriodBlocks = CProRegTx::MAX_EARLY_PERIOD_BLOCKS + 1;
+    QVERIFY(!bad_period.validateShares().isEmpty());
+}
+
+void MnShareSessionTests::envelopeRoundTrip()
+{
+    BasicTestingSetup setup{CBaseChainParams::REGTEST};
+    std::vector<CKey> keys;
+    MnShareSession session{ValidSession(keys)};
+    session.shares()[0].label = "alice";
+    session.setOperatorSecretHolder("bob");
+
+    MnShareSession restored;
+    QString error;
+    QVERIFY2(restored.fromJson(session.toJsonString().toStdString(), error), qPrintable(error));
+    QCOMPARE(restored.sessionId(), session.sessionId());
+    QCOMPARE(restored.revision(), session.revision());
+    QCOMPARE(int(restored.stage()), int(MnShareSession::Stage::Draft));
+    QCOMPARE(restored.shares().size(), session.shares().size());
+    QCOMPARE(restored.shares()[0].label, QString("alice"));
+    QCOMPARE(restored.shares()[2].amount, 250 * COIN);
+    QCOMPARE(restored.terms().earlyPenalty, 5 * COIN);
+    QCOMPARE(restored.operatorSecretHolder(), QString("bob"));
+
+    // A different network is a hard error
+    UniValue json{session.toJson()};
+    json.pushKV("network", "main");
+    MnShareSession wrong_network;
+    QVERIFY(!wrong_network.fromJson(json, error));
+    QVERIFY(error.contains("main"));
+
+    // Unknown stages are rejected
+    json = session.toJson();
+    json.pushKV("network", QString::fromStdString(Params().NetworkIDString()).toStdString());
+    json.pushKV("stage", "warp");
+    MnShareSession wrong_stage;
+    QVERIFY(!wrong_stage.fromJson(json, error));
+}
+
+void MnShareSessionTests::penaltyPreviewMath()
+{
+    BasicTestingSetup setup{CBaseChainParams::REGTEST};
+    const std::vector<CAmount> amounts{400 * COIN, 350 * COIN, 250 * COIN};
+    const CAmount penalty{5 * COIN};
+    const CAmount fee{100000};
+    const uint32_t early_period{5000};
+    const int registered{1000};
+
+    // Early: the actor pays the penalty and fee, the others split the penalty
+    // pro-rata with the remainder on the last non-actor share
+    auto preview{MnShareSession::PenaltyPreviewFor(amounts, /*actor_index=*/0, penalty, early_period, fee,
+                                                   /*at_height=*/2000, registered)};
+    QVERIFY2(preview.valid, qPrintable(preview.error));
+    QVERIFY(preview.early);
+    QCOMPARE(preview.penalty, penalty);
+    QCOMPARE(preview.penaltyFreeHeight, registered + int(early_period));
+    QCOMPARE(preview.payouts.size(), amounts.size());
+    QCOMPARE(preview.payouts[0], 400 * COIN - penalty - fee);
+    // 350:250 pro-rata split of 5 DASH = 2.916... : 2.083...; floor to the
+    // first share, remainder to the last
+    const CAmount bonus_1{penalty * 350 / 600};
+    QCOMPARE(preview.payouts[1], 350 * COIN + bonus_1);
+    QCOMPARE(preview.payouts[2], 250 * COIN + (penalty - bonus_1));
+    QCOMPARE(preview.payouts[0] + preview.payouts[1] + preview.payouts[2], 1000 * COIN - fee);
+
+    // Past the boundary: no penalty
+    preview = MnShareSession::PenaltyPreviewFor(amounts, /*actor_index=*/0, penalty, early_period, fee,
+                                                /*at_height=*/registered + int(early_period), registered);
+    QVERIFY2(preview.valid, qPrintable(preview.error));
+    QVERIFY(!preview.early);
+    QCOMPARE(preview.payouts[0], 400 * COIN - fee);
+    QCOMPARE(preview.payouts[1], 350 * COIN);
+    QCOMPARE(preview.payouts[2], 250 * COIN);
+}
+
+void MnShareSessionTests::signatureVerification()
+{
+    BasicTestingSetup setup{CBaseChainParams::REGTEST};
+    std::vector<CKey> owner_keys;
+    MnShareSession session{ValidSession(owner_keys)};
+
+    // Build the shared registration the way register_shared_prepare would:
+    // the transaction spends the funding inputs directly and carries the
+    // share table in its payload
+    CProRegTx payload;
+    payload.nVersion = ProTxVersion::ExtAddr;
+    payload.nType = MnType::Regular;
+    payload.collateralOutpoint = COutPoint(uint256(), 0);
+    payload.netInfo = NetInfoInterface::MakeNetInfo(payload.nVersion);
+    for (const auto& share : session.shares()) {
+        CTxDestination owner_dest{DecodeDestination(share.ownerAddress.toStdString())};
+        CTxDestination refund_dest{DecodeDestination(share.refundAddress.toStdString())};
+        payload.shares.emplace_back(share.amount, GetScriptForDestination(refund_dest), CScript(),
+                                    ToKeyID(std::get<PKHash>(owner_dest)));
+    }
+    payload.vchJoinSigs.assign(payload.shares.size(), std::vector<unsigned char>(CPubKey::COMPACT_SIGNATURE_SIZE));
+    payload.nEarlyPeriodBlocks = session.terms().earlyPeriodBlocks;
+    payload.nEarlyPenalty = session.terms().earlyPenalty;
+
+    CMutableTransaction tx;
+    tx.nVersion = 3;
+    tx.nType = TRANSACTION_PROVIDER_REGISTER;
+    tx.vin.emplace_back(COutPoint(uint256::ONE, 1));
+    tx.vout.emplace_back(1000 * COIN, CScript() << std::vector<unsigned char>{'D', 'S', 'H', 'C'} << OP_DROP << OP_TRUE);
+    SetTxPayload(tx, payload);
+
+    const uint256 consent_hash{payload.MakeSharedRegConsentHash(CTransaction(tx))};
+    const QString tx_hex{QString::fromStdString(EncodeHexTx(CTransaction(tx)))};
+
+    QString error;
+    QVERIFY2(session.freeze(tx_hex, QString::fromStdString(consent_hash.ToString()), 0, error), qPrintable(error));
+    QCOMPARE(int(session.stage()), int(MnShareSession::Stage::Frozen));
+
+    // freeze() rejects a consent hash that does not match the transaction
+    std::vector<CKey> other_keys;
+    MnShareSession session2{ValidSession(other_keys)};
+    QVERIFY(!session2.freeze(tx_hex, QString::fromStdString(uint256::ONE.ToString()), 0, error));
+
+    // A valid signature for share 1 is accepted
+    std::vector<unsigned char> sig;
+    QVERIFY(CHashSigner::SignHash(consent_hash, owner_keys[1], sig));
+    const QString sig_b64{QString::fromStdString(EncodeBase64(sig))};
+    QVERIFY2(session.addSignature(1, sig_b64, error), qPrintable(error));
+    QCOMPARE(session.signedCount(), 1);
+    QCOMPARE(session.missingIndexes(), (std::vector<int>{0, 2}));
+
+    // A byte-identical duplicate is a silent success, and does not double-count
+    QVERIFY(session.addSignature(1, sig_b64, error));
+    QCOMPARE(session.signedCount(), 1);
+
+    // The same signature under the wrong index is rejected
+    QVERIFY(!session.addSignature(0, sig_b64, error));
+
+    // A signature over a different digest (a stale draft) is rejected
+    std::vector<unsigned char> stale_sig;
+    QVERIFY(CHashSigner::SignHash(uint256::ONE, owner_keys[0], stale_sig));
+    QVERIFY(!session.addSignature(0, QString::fromStdString(EncodeBase64(stale_sig)), error));
+    QCOMPARE(session.signedCount(), 1);
+
+    // Unfreezing discards the collected signatures and bumps the revision
+    const int revision{session.revision()};
+    session.unfreeze();
+    QCOMPARE(int(session.stage()), int(MnShareSession::Stage::Draft));
+    QCOMPARE(session.signedCount(), 0);
+    QVERIFY(session.revision() > revision);
+}

--- a/src/qt/test/mnsharesessiontests.h
+++ b/src/qt/test/mnsharesessiontests.h
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 The Dash Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_TEST_MNSHARESESSIONTESTS_H
+#define BITCOIN_QT_TEST_MNSHARESESSIONTESTS_H
+
+#include <QObject>
+#include <QTest>
+
+class MnShareSessionTests : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void validateSharesMirror();
+    void envelopeRoundTrip();
+    void penaltyPreviewMath();
+    void signatureVerification();
+};
+
+#endif // BITCOIN_QT_TEST_MNSHARESESSIONTESTS_H

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -19,6 +19,7 @@
 
 #ifdef ENABLE_WALLET
 #include <qt/test/addressbooktests.h>
+#include <qt/test/mnsharesessiontests.h>
 #include <qt/test/wallettests.h>
 #endif // ENABLE_WALLET
 
@@ -105,6 +106,9 @@ int main(int argc, char* argv[])
 
     AddressBookTests test6(app.node());
     num_test_failures += QTest::qExec(&test6);
+
+    MnShareSessionTests mn_share_session_tests;
+    num_test_failures += QTest::qExec(&mn_share_session_tests);
 #endif
     TrafficGraphDataTests test7;
     num_test_failures += QTest::qExec(&test7);

--- a/src/qt/transactionfilterproxy.h
+++ b/src/qt/transactionfilterproxy.h
@@ -24,7 +24,9 @@ class TransactionFilterProxy : public QSortFilterProxyModel
 public:
     explicit TransactionFilterProxy(QObject *parent = nullptr);
 
-    /** Types to exclude from common transaction lists (CoinJoin internal transactions and dust) */
+    /** Types to exclude from common transaction lists (CoinJoin internal transactions and dust).
+     *  Everything not listed here, including the masternode types, is part of COMMON_TYPES and so
+     *  visible by default. */
     static constexpr quint32 EXCLUDED_TYPES =
         TransactionTypeToBit(TransactionRecord::CoinJoinCollateralPayment) |
         TransactionTypeToBit(TransactionRecord::CoinJoinCreateDenominations) |
@@ -36,6 +38,8 @@ public:
     static constexpr quint32 ALL_TYPES = 0xFFFFFFFF;
     /** Type filter bit field (all types except excluded) */
     static constexpr quint32 COMMON_TYPES = ALL_TYPES & ~EXCLUDED_TYPES;
+    static_assert(TransactionRecord::MasternodeDissolve < 32,
+                  "TransactionRecord::Type no longer fits into the quint32 type filter bit field");
 
     static constexpr quint32 TYPE(int type) { return TransactionTypeToBit(type); }
 

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -8,10 +8,12 @@
 #include <chain.h>
 #include <interfaces/wallet.h>
 #include <interfaces/node.h>
+#include <primitives/transaction.h>
 
 #include <wallet/ismine.h>
 
 #include <cstdint>
+#include <optional>
 
 using wallet::ISMINE_SPENDABLE;
 using wallet::ISMINE_WATCH_ONLY;
@@ -24,6 +26,30 @@ bool TransactionRecord::showTransaction()
     // There are currently no cases where we hide transactions, but
     // we may want to use this in the future for things like RBF.
     return true;
+}
+
+/* Map a provider special transaction onto its record type, or nullopt for anything that is not
+ * masternode related. Non-provider special transactions (asset locks, platform transfers, quorum
+ * commitments, ...) keep their existing classification.
+ */
+static std::optional<TransactionRecord::Type> MasternodeRecordType(const CTransaction& tx)
+{
+    if (!tx.IsSpecialTxVersion()) return std::nullopt;
+
+    switch (tx.nType) {
+    case TRANSACTION_PROVIDER_REGISTER:
+        return TransactionRecord::MasternodeRegistration;
+    case TRANSACTION_PROVIDER_UPDATE_SERVICE:
+    case TRANSACTION_PROVIDER_UPDATE_REGISTRAR:
+    case TRANSACTION_PROVIDER_UPDATE_REVOKE:
+    case TRANSACTION_PROVIDER_UPDATE_SHARE:
+    case TRANSACTION_PROVIDER_UPDATE_SHARED_REGISTRAR:
+        return TransactionRecord::MasternodeUpdate;
+    case TRANSACTION_PROVIDER_DISSOLVE:
+        return TransactionRecord::MasternodeDissolve;
+    default:
+        return std::nullopt;
+    }
 }
 
 /*
@@ -40,6 +66,9 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(interfaces::Nod
     uint256 hash = wtx.tx->GetHash();
     std::map<std::string, std::string> mapValue = wtx.value_map;
     auto& coinJoinOptions = node.coinJoinOptions();
+    // Masternode special transactions get their own record types, otherwise a self-funded
+    // registration is indistinguishable from a payment to yourself
+    const std::optional<TransactionRecord::Type> mn_type = MasternodeRecordType(*wtx.tx);
 
     // Check if any inputs belong to this wallet (for dust detection)
     bool isFromMe = false;
@@ -89,6 +118,12 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(interfaces::Nod
                 {
                     // Withdrawal from platform
                     sub.type = TransactionRecord::PlatformTransfer;
+                }
+                if (mn_type)
+                {
+                    // Collateral received by this wallet (externally funded registration) or a
+                    // share of a dissolved masternode's collateral
+                    sub.type = *mn_type;
                 }
 
                 // Check for dust attack: external receive with small amount
@@ -150,7 +185,14 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(interfaces::Nod
                 sub.strAddress += EncodeDestination(*it);
             }
 
-            if(mapValue["DS"] == "1")
+            if (mn_type)
+            {
+                // Self-funded masternode transaction: the collateral (if any) stays in this wallet,
+                // so the amount below is just the network fee. The type carries the meaning.
+                sub.type = *mn_type;
+                sub.idx = parts.size();
+            }
+            else if(mapValue["DS"] == "1")
             {
                 sub.type = TransactionRecord::CoinJoinSend;
                 CTxDestination address;
@@ -219,7 +261,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(interfaces::Nod
             CAmount nTxFee = nDebit - wtx.tx->GetValueOut();
 
             bool fDone = false;
-            if(wtx.tx->vin.size() == 1 && wtx.tx->vout.size() == 1
+            if(!mn_type && wtx.tx->vin.size() == 1 && wtx.tx->vout.size() == 1
                 && coinJoinOptions.isCollateralAmount(nDebit)
                 && nCredit == 0 // OP_RETURN
                 && coinJoinOptions.isCollateralAmount(-nNet))
@@ -273,6 +315,12 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(interfaces::Nod
                     sub.type = TransactionRecord::CoinJoinSend;
                 }
 
+                if (mn_type)
+                {
+                    // Funded by this wallet, collateral (or the reward destination) is external
+                    sub.type = *mn_type;
+                }
+
                 CAmount nValue = txout.nValue;
                 /* Add fee to first output */
                 if (nTxFee > 0)
@@ -290,7 +338,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(interfaces::Nod
             //
             // Mixed debit transaction, can't break down payees
             //
-            parts.append(TransactionRecord(hash, nTime, TransactionRecord::Other, "", nNet, 0));
+            parts.append(TransactionRecord(hash, nTime, mn_type.value_or(TransactionRecord::Other), "", nNet, 0));
             parts.last().involvesWatchAddress = involvesWatchAddress;
         }
     }

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -70,7 +70,9 @@ struct TransactionStatus {
 class TransactionRecord
 {
 public:
-    // Update EXCLUDED_TYPES in TransactionFilterProxy when adding a new type
+    // Update EXCLUDED_TYPES in TransactionFilterProxy when adding a new type.
+    // New types must be appended at the end: the values double as bit positions in
+    // TransactionFilterProxy's type filter and are persisted as combo box indices.
     enum Type
     {
         Other,
@@ -89,6 +91,13 @@ public:
         PlatformTransfer,
         DustReceive,
         DataTransaction,
+        /// ProRegTx: creates a masternode and locks its collateral
+        MasternodeRegistration,
+        /// ProUpServTx/ProUpRegTx/ProUpRevTx and their shared-masternode variants: metadata-only
+        /// updates to an existing masternode, they only ever cost the network fee
+        MasternodeUpdate,
+        /// ProDisTx: dissolves a shared masternode and releases its collateral
+        MasternodeDissolve,
     };
 
     /** Number of confirmation recommended for accepting a transaction */

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -437,6 +437,12 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
         return tr("Data Transaction");
     case TransactionRecord::DustReceive:
         return tr("Dust Receive");
+    case TransactionRecord::MasternodeRegistration:
+        return tr("Masternode Registration");
+    case TransactionRecord::MasternodeUpdate:
+        return tr("Masternode Update");
+    case TransactionRecord::MasternodeDissolve:
+        return tr("Masternode Dissolution");
 
     case TransactionRecord::CoinJoinMixing:
         return tr("%1 Mixing").arg(QString::fromStdString(gCoinJoinName));
@@ -486,12 +492,16 @@ QString TransactionTableModel::formatTxToAddress(const TransactionRecord *wtx, b
     case TransactionRecord::SendToOther:
         return QString::fromStdString(wtx->strAddress) + watchAddress;
     case TransactionRecord::SendToSelf:
+    case TransactionRecord::MasternodeRegistration:
+    case TransactionRecord::MasternodeDissolve:
         return formatAddressLabel(wtx->strAddress, wtx->label, tooltip) + watchAddress;
     case TransactionRecord::CoinJoinMixing:
     case TransactionRecord::CoinJoinCollateralPayment:
     case TransactionRecord::CoinJoinMakeCollaterals:
     case TransactionRecord::CoinJoinCreateDenominations:
     case TransactionRecord::DataTransaction:
+    // An update only ever pays a fee, it has no payee to show
+    case TransactionRecord::MasternodeUpdate:
     case TransactionRecord::Other:
         break; // use fail-over here
     } // no default case, so the compiler can warn about missing cases
@@ -521,6 +531,9 @@ QVariant TransactionTableModel::addressColor(const TransactionRecord *wtx) const
     case TransactionRecord::CoinJoinMakeCollaterals:
     case TransactionRecord::CoinJoinCollateralPayment:
     case TransactionRecord::DataTransaction:
+    case TransactionRecord::MasternodeRegistration:
+    case TransactionRecord::MasternodeUpdate:
+    case TransactionRecord::MasternodeDissolve:
         return GUIUtil::getThemedQColor(GUIUtil::ThemedColor::BAREADDRESS);
     case TransactionRecord::SendToOther:
     case TransactionRecord::RecvFromOther:
@@ -551,6 +564,7 @@ QVariant TransactionTableModel::amountColor(const TransactionRecord *rec) const
     case TransactionRecord::RecvWithAddress:
     case TransactionRecord::RecvFromOther:
     case TransactionRecord::PlatformTransfer:
+    case TransactionRecord::MasternodeDissolve:
         return GUIUtil::getThemedQColor(GUIUtil::ThemedColor::GREEN);
     case TransactionRecord::CoinJoinSend:
     case TransactionRecord::SendToAddress:
@@ -564,6 +578,8 @@ QVariant TransactionTableModel::amountColor(const TransactionRecord *rec) const
     case TransactionRecord::CoinJoinMakeCollaterals:
     case TransactionRecord::CoinJoinCreateDenominations:
     case TransactionRecord::DustReceive:
+    case TransactionRecord::MasternodeRegistration:
+    case TransactionRecord::MasternodeUpdate:
         return GUIUtil::getThemedQColor(GUIUtil::ThemedColor::ORANGE);
     }
     return GUIUtil::getThemedQColor(GUIUtil::ThemedColor::DEFAULT);
@@ -617,6 +633,19 @@ QString TransactionTableModel::formatTooltip(const TransactionRecord *rec) const
        rec->type==TransactionRecord::SendToAddress || rec->type==TransactionRecord::RecvWithAddress)
     {
         tooltip += QString(" ") + formatTxToAddress(rec, true);
+    }
+    switch (rec->type) {
+    case TransactionRecord::MasternodeRegistration:
+        tooltip += QString("\n") + tr("Registers a masternode and locks its collateral. The amount is the change in this wallet's balance, so it only shows the network fee when the collateral stays in this wallet.");
+        break;
+    case TransactionRecord::MasternodeUpdate:
+        tooltip += QString("\n") + tr("Updates the registration of an existing masternode. Only the network fee is spent.");
+        break;
+    case TransactionRecord::MasternodeDissolve:
+        tooltip += QString("\n") + tr("Dissolves a shared masternode and releases its collateral to the shareholders.");
+        break;
+    default:
+        break;
     }
     return tooltip;
 }

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -96,6 +96,9 @@ TransactionView::TransactionView(QWidget* parent) :
     typeWidget->addItem(tr("To yourself"), TransactionFilterProxy::TYPE(TransactionRecord::SendToSelf));
     typeWidget->addItem(tr("Mined"), TransactionFilterProxy::TYPE(TransactionRecord::Generated));
     typeWidget->addItem(tr("Platform Transfer"), TransactionFilterProxy::TYPE(TransactionRecord::PlatformTransfer));
+    typeWidget->addItem(tr("Masternode"), TransactionFilterProxy::TYPE(TransactionRecord::MasternodeRegistration) |
+                                     TransactionFilterProxy::TYPE(TransactionRecord::MasternodeUpdate) |
+                                     TransactionFilterProxy::TYPE(TransactionRecord::MasternodeDissolve));
     typeWidget->addItem(tr("Data Transaction"), TransactionFilterProxy::TYPE(TransactionRecord::DataTransaction));
     typeWidget->addItem(tr("Dust Receive"), TransactionFilterProxy::TYPE(TransactionRecord::DustReceive));
     typeWidget->addItem(tr("Other"), TransactionFilterProxy::TYPE(TransactionRecord::Other));
@@ -790,10 +793,17 @@ void TransactionView::updateCoinJoinVisibility()
     int idx = fEnabled ? 0 : 1;
     chooseType(idx);
     typeWidget->setCurrentIndex(idx);
-    // Hide all CoinJoin related filters
+    // Hide all CoinJoin related filters. Look the entries up by their filter mask instead of by
+    // row index so that adding or reordering entries above cannot silently break this.
     QListView* typeList = qobject_cast<QListView*>(typeWidget->view());
-    std::vector<int> vecRows{4, 5, 6, 7, 8};
-    for (auto nRow : vecRows) {
-        typeList->setRowHidden(nRow, !fEnabled);
+    for (const quint32 nTypeFilter : {TransactionFilterProxy::TYPE(TransactionRecord::CoinJoinSend),
+                                      TransactionFilterProxy::TYPE(TransactionRecord::CoinJoinMakeCollaterals),
+                                      TransactionFilterProxy::TYPE(TransactionRecord::CoinJoinCreateDenominations),
+                                      TransactionFilterProxy::TYPE(TransactionRecord::CoinJoinMixing),
+                                      TransactionFilterProxy::TYPE(TransactionRecord::CoinJoinCollateralPayment)}) {
+        const int nRow = typeWidget->findData(nTypeFilter);
+        if (nRow >= 0) {
+            typeList->setRowHidden(nRow, !fEnabled);
+        }
     }
 }

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -256,6 +256,48 @@ public:
         return true;
     }
     bool canStoreMasternodeOperatorKey() override { return m_wallet->CanStoreMasternodeOperatorKey(); }
+    bool canDeriveMasternodeOperatorKey() override { return m_wallet->CanDeriveMasternodeOperatorKey(); }
+    bool deriveMasternodeOperatorKey(std::vector<unsigned char>& secret, std::string& path, std::string& error) override
+    {
+        if (!m_wallet->CanDeriveMasternodeOperatorKey()) {
+            error = _("This wallet cannot derive masternode operator keys from its recovery phrase.").translated;
+            return false;
+        }
+        CBLSSecretKey sk;
+        uint32_t index{0};
+        if (!m_wallet->DeriveNextMasternodeOperatorKey(sk, index)) {
+            error = _("Failed to derive the masternode operator key, please make sure the wallet is unlocked.").translated;
+            return false;
+        }
+        auto secret_bytes{sk.ToBytes(/*specificLegacyScheme=*/false)};
+        secret.assign(secret_bytes.begin(), secret_bytes.end());
+        memory_cleanse(secret_bytes.data(), secret_bytes.size());
+        path = m_wallet->GetMasternodeOperatorKeyPath(index);
+        return true;
+    }
+    bool getMasternodeOperatorKey(const std::vector<unsigned char>& pubkey, std::vector<unsigned char>& secret,
+                                  std::string& path, std::string& error) override
+    {
+        CBLSPublicKey pk;
+        pk.SetBytes(pubkey, /*specificLegacyScheme=*/false);
+        if (!pk.IsValid()) {
+            error = _("The masternode operator key is not valid.").translated;
+            return false;
+        }
+        CBLSSecretKey sk;
+        if (!m_wallet->GetMasternodeOperatorKey(pk, sk, &path)) {
+            error = _("Failed to read the masternode operator key, please make sure the wallet is unlocked.").translated;
+            return false;
+        }
+        auto secret_bytes{sk.ToBytes(/*specificLegacyScheme=*/false)};
+        secret.assign(secret_bytes.begin(), secret_bytes.end());
+        memory_cleanse(secret_bytes.data(), secret_bytes.size());
+        return true;
+    }
+    std::vector<std::vector<unsigned char>> listMasternodeOperatorKeys() override
+    {
+        return m_wallet->ListMasternodeOperatorKeys();
+    }
     bool isSpendable(const CScript& script) override
     {
         LOCK(m_wallet->cs_wallet);

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -238,26 +238,10 @@ public:
     {
         return m_wallet->SignSpecialTxPayload(hash, keyid, vchSig);
     }
-    bool addMasternodeOperatorKey(const std::vector<unsigned char>& secret, std::string& error) override
-    {
-        if (!m_wallet->CanStoreMasternodeOperatorKey()) {
-            error = _("This wallet cannot store masternode operator keys.").translated;
-            return false;
-        }
-        const CBLSSecretKey sk{secret};
-        if (secret.size() != CBLSSecretKey::SerSize || !sk.IsValid() || !sk.GetPublicKey().IsValid()) {
-            error = _("The masternode operator key is not valid.").translated;
-            return false;
-        }
-        if (!m_wallet->AddMasternodeOperatorKey(sk)) {
-            error = _("Failed to store the masternode operator key, please make sure the wallet is unlocked.").translated;
-            return false;
-        }
-        return true;
-    }
-    bool canStoreMasternodeOperatorKey() override { return m_wallet->CanStoreMasternodeOperatorKey(); }
     bool canDeriveMasternodeOperatorKey() override { return m_wallet->CanDeriveMasternodeOperatorKey(); }
-    bool deriveMasternodeOperatorKey(std::vector<unsigned char>& secret, std::string& path, std::string& error) override
+    bool deriveMasternodeOperatorKey(const std::vector<std::vector<unsigned char>>& in_use,
+                                     std::vector<unsigned char>& secret, std::string& path,
+                                     std::string& error) override
     {
         if (!m_wallet->CanDeriveMasternodeOperatorKey()) {
             error = _("This wallet cannot derive masternode operator keys from its recovery phrase.").translated;
@@ -265,7 +249,7 @@ public:
         }
         CBLSSecretKey sk;
         uint32_t index{0};
-        if (!m_wallet->DeriveNextMasternodeOperatorKey(sk, index)) {
+        if (!m_wallet->DeriveNextMasternodeOperatorKey(in_use, sk, index)) {
             error = _("Failed to derive the masternode operator key, please make sure the wallet is unlocked.").translated;
             return false;
         }
@@ -274,6 +258,12 @@ public:
         memory_cleanse(secret_bytes.data(), secret_bytes.size());
         path = m_wallet->GetMasternodeOperatorKeyPath(index);
         return true;
+    }
+    bool haveMasternodeOperatorKey(const std::vector<unsigned char>& pubkey) override
+    {
+        CBLSPublicKey pk;
+        pk.SetBytes(pubkey, /*specificLegacyScheme=*/false);
+        return pk.IsValid() && m_wallet->HaveMasternodeOperatorKey(pk);
     }
     bool getMasternodeOperatorKey(const std::vector<unsigned char>& pubkey, std::vector<unsigned char>& secret,
                                   std::string& path, std::string& error) override
@@ -293,10 +283,6 @@ public:
         secret.assign(secret_bytes.begin(), secret_bytes.end());
         memory_cleanse(secret_bytes.data(), secret_bytes.size());
         return true;
-    }
-    std::vector<std::vector<unsigned char>> listMasternodeOperatorKeys() override
-    {
-        return m_wallet->ListMasternodeOperatorKeys();
     }
     bool isSpendable(const CScript& script) override
     {

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -4,6 +4,7 @@
 
 #include <interfaces/wallet.h>
 
+#include <bls/bls.h>
 #include <chain.h>
 #include <coinjoin/client.h>
 #include <consensus/amount.h>
@@ -237,6 +238,24 @@ public:
     {
         return m_wallet->SignSpecialTxPayload(hash, keyid, vchSig);
     }
+    bool addMasternodeOperatorKey(const std::vector<unsigned char>& secret, std::string& error) override
+    {
+        if (!m_wallet->CanStoreMasternodeOperatorKey()) {
+            error = _("This wallet cannot store masternode operator keys.").translated;
+            return false;
+        }
+        const CBLSSecretKey sk{secret};
+        if (secret.size() != CBLSSecretKey::SerSize || !sk.IsValid() || !sk.GetPublicKey().IsValid()) {
+            error = _("The masternode operator key is not valid.").translated;
+            return false;
+        }
+        if (!m_wallet->AddMasternodeOperatorKey(sk)) {
+            error = _("Failed to store the masternode operator key, please make sure the wallet is unlocked.").translated;
+            return false;
+        }
+        return true;
+    }
+    bool canStoreMasternodeOperatorKey() override { return m_wallet->CanStoreMasternodeOperatorKey(); }
     bool isSpendable(const CScript& script) override
     {
         LOCK(m_wallet->cs_wallet);

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -768,6 +768,24 @@ bool LegacyScriptPubKeyMan::SignSpecialTxPayload(const uint256& hash, const CKey
     return CHashSigner::SignHash(hash, key, vchSig);
 }
 
+bool LegacyScriptPubKeyMan::HasBIP39Seed() const
+{
+    CHDChain hd_chain;
+    return GetHDChain(hd_chain);
+}
+
+bool LegacyScriptPubKeyMan::GetBIP39Seed(SecureVector& seed) const
+{
+    CHDChain hd_chain;
+    if (!GetDecryptedHDChain(hd_chain)) return false;
+
+    SecureVector chain_seed{hd_chain.GetSeed()};
+    if (chain_seed.empty()) return false;
+
+    seed = std::move(chain_seed);
+    return true;
+}
+
 TransactionError LegacyScriptPubKeyMan::FillPSBT(PartiallySignedTransaction& psbtx, const PrecomputedTransactionData& txdata, int sighash_type, bool sign, bool bip32derivs, int* n_signed, bool finalize) const
 {
     if (n_signed) {
@@ -2714,6 +2732,23 @@ bool DescriptorScriptPubKeyMan::SignSpecialTxPayload(const uint256& hash, const 
     }
 
     return CHashSigner::SignHash(hash, key, vchSig);
+}
+
+bool DescriptorScriptPubKeyMan::HasBIP39Seed() const
+{
+    LOCK(cs_desc_man);
+    // More than one mnemonic cannot be matched to a single seed, see GetMnemonicString()
+    return m_mnemonics.size() + m_crypted_mnemonics.size() == 1;
+}
+
+bool DescriptorScriptPubKeyMan::GetBIP39Seed(SecureVector& seed) const
+{
+    SecureString mnemonic;
+    SecureString mnemonic_passphrase;
+    if (!GetMnemonicString(mnemonic, mnemonic_passphrase) || mnemonic.empty()) return false;
+
+    CMnemonic::ToSeed(mnemonic, mnemonic_passphrase, seed);
+    return !seed.empty();
 }
 
 TransactionError DescriptorScriptPubKeyMan::FillPSBT(PartiallySignedTransaction& psbtx, const PrecomputedTransactionData& txdata, int sighash_type, bool sign, bool bip32derivs, int* n_signed, bool finalize) const

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -234,6 +234,13 @@ public:
     /** Sign a message with the given script */
     virtual SigningResult SignMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) const { return SigningResult::SIGNING_FAILED; };
     virtual bool SignSpecialTxPayload(const uint256& hash, const CKeyID& keyid, std::vector<unsigned char>& vchSig) const { return false; }
+    /** Whether this ScriptPubKeyMan derives its keys from a BIP39 seed, i.e. whether
+      * GetBIP39Seed() can succeed once the wallet is unlocked. Answering this does not
+      * require an unlocked wallet, so it can drive what the UI offers. */
+    virtual bool HasBIP39Seed() const { return false; }
+    /** The 64 byte BIP39 seed this ScriptPubKeyMan derives its keys from. Requires an
+      * unlocked wallet. */
+    virtual bool GetBIP39Seed(SecureVector& seed) const { return false; }
     /** Adds script and derivation path information to a PSBT, and optionally signs it. */
     virtual TransactionError FillPSBT(PartiallySignedTransaction& psbt, const PrecomputedTransactionData& txdata, int sighash_type = 1 /* SIGHASH_ALL */, bool sign = true, bool bip32derivs = false, int* n_signed = nullptr, bool finalize = true) const { return TransactionError::INVALID_PSBT; }
 
@@ -384,6 +391,8 @@ public:
     bool SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, bilingual_str>& input_errors) const override;
     SigningResult SignMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) const override;
     bool SignSpecialTxPayload(const uint256& hash, const CKeyID& keyid, std::vector<unsigned char>& vchSig) const override;
+    bool HasBIP39Seed() const override;
+    bool GetBIP39Seed(SecureVector& seed) const override;
     TransactionError FillPSBT(PartiallySignedTransaction& psbt, const PrecomputedTransactionData& txdata, int sighash_type = 1 /* SIGHASH_ALL */, bool sign = true, bool bip32derivs = false, int* n_signed = nullptr, bool finalize = true) const override;
 
     uint256 GetID() const override;
@@ -643,6 +652,8 @@ public:
     bool SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, bilingual_str>& input_errors) const override;
     SigningResult SignMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) const override;
     bool SignSpecialTxPayload(const uint256& hash, const CKeyID& keyid, std::vector<unsigned char>& vchSig) const override;
+    bool HasBIP39Seed() const override;
+    bool GetBIP39Seed(SecureVector& seed) const override;
     TransactionError FillPSBT(PartiallySignedTransaction& psbt, const PrecomputedTransactionData& txdata, int sighash_type = 1 /* SIGHASH_ALL */, bool sign = true, bool bip32derivs = false, int* n_signed = nullptr, bool finalize = true) const override;
 
     uint256 GetID() const override;

--- a/src/wallet/test/walletdb_tests.cpp
+++ b/src/wallet/test/walletdb_tests.cpp
@@ -92,66 +92,6 @@ static size_t CountRecords(CWallet& wallet, const std::string& type)
     return count;
 }
 
-BOOST_AUTO_TEST_CASE(walletdb_masternode_operator_key)
-{
-    CBLSSecretKey secret;
-    secret.MakeNewKey();
-    const CBLSPublicKey pubkey{secret.GetPublicKey()};
-
-    BOOST_CHECK(m_wallet.CanStoreMasternodeOperatorKey());
-    BOOST_CHECK(!m_wallet.HaveMasternodeOperatorKey(pubkey));
-    BOOST_CHECK(m_wallet.AddMasternodeOperatorKey(secret));
-    BOOST_CHECK(m_wallet.HaveMasternodeOperatorKey(pubkey));
-    // Storing the same key again is a no-op success, so a retry cannot fail
-    BOOST_CHECK(m_wallet.AddMasternodeOperatorKey(secret));
-
-    CBLSSecretKey read;
-    BOOST_CHECK(m_wallet.GetMasternodeOperatorKey(pubkey, read));
-    BOOST_CHECK(read == secret);
-
-    // While the wallet is unencrypted the secret is stored in the clear, as
-    // private keys are
-    BOOST_CHECK_EQUAL(CountRecords(m_wallet, DBKeys::MASTERNODE_OPERATOR_KEY), 1U);
-    BOOST_CHECK_EQUAL(CountRecords(m_wallet, DBKeys::CRYPTED_MASTERNODE_OPERATOR_KEY), 0U);
-
-    // Encrypting the wallet must convert it: leaving a plaintext record behind
-    // would leak the operator key of every masternode registered before the
-    // user encrypted their wallet
-    BOOST_CHECK(m_wallet.EncryptWallet("passphrase"));
-    BOOST_CHECK_EQUAL(CountRecords(m_wallet, DBKeys::MASTERNODE_OPERATOR_KEY), 0U);
-    BOOST_CHECK_EQUAL(CountRecords(m_wallet, DBKeys::CRYPTED_MASTERNODE_OPERATOR_KEY), 1U);
-    BOOST_CHECK(m_wallet.HaveMasternodeOperatorKey(pubkey));
-
-    // A locked wallet neither hands out nor accepts secrets
-    BOOST_CHECK(m_wallet.IsLocked());
-    CBLSSecretKey locked_read;
-    BOOST_CHECK(!m_wallet.GetMasternodeOperatorKey(pubkey, locked_read));
-    CBLSSecretKey other;
-    other.MakeNewKey();
-    BOOST_CHECK(!m_wallet.AddMasternodeOperatorKey(other));
-
-    BOOST_CHECK(m_wallet.Unlock("passphrase"));
-    CBLSSecretKey unlocked_read;
-    BOOST_CHECK(m_wallet.GetMasternodeOperatorKey(pubkey, unlocked_read));
-    BOOST_CHECK(unlocked_read == secret);
-    BOOST_CHECK(m_wallet.AddMasternodeOperatorKey(other));
-    BOOST_CHECK_EQUAL(CountRecords(m_wallet, DBKeys::CRYPTED_MASTERNODE_OPERATOR_KEY), 2U);
-}
-
-/**
- * The masternode operator key derivation path uses coin type 5 on mainnet and 1 on every
- * other network, so a wallet on regtest derives exactly what DashSync derives on testnet.
- * That is what makes the known-answer test below applicable.
- */
-struct DerivingWalletTestingSetup : public WalletTestingSetup {
-    DerivingWalletTestingSetup() : WalletTestingSetup(CBaseChainParams::REGTEST)
-    {
-        // None of these tests spend, and a default sized keypool costs a couple of thousand
-        // key derivations whenever the wallet tops up
-        gArgs.ForceSetArg("-keypool", "1");
-    }
-};
-
 /**
  * Recovery phrase from DashSync's testCollateralProviderRegistrationTransaction
  * (Example/Tests/DSProviderTransactionsTests.m). That test builds a ProRegTx whose payload
@@ -185,6 +125,32 @@ static void SetupHDWallet(CWallet& wallet, const SecureString& mnemonic)
     BOOST_REQUIRE(spk_man != nullptr);
     BOOST_REQUIRE(spk_man->LoadHDChain(chain));
 }
+
+/**
+ * The masternode operator key derivation path uses coin type 5 on mainnet and 1 on every
+ * other network, so a wallet on regtest derives exactly what DashSync derives on testnet.
+ * That is what makes the known-answer test below applicable.
+ */
+struct DerivingWalletTestingSetup : public WalletTestingSetup {
+    DerivingWalletTestingSetup() : WalletTestingSetup(CBaseChainParams::REGTEST)
+    {
+        // None of these tests spend, and a default sized keypool costs a couple of thousand
+        // key derivations whenever the wallet tops up
+        gArgs.ForceSetArg("-keypool", "1");
+    }
+
+    //! A second wallet holding the same recovery phrase and nothing else, which is exactly what a
+    //! wallet restored from that phrase is: the same seed, and no record of the keys the original
+    //! wallet handed out
+    std::unique_ptr<CWallet> MakeRestoredWallet()
+    {
+        auto wallet{std::make_unique<CWallet>(m_node.chain.get(), m_coinjoin_loader.get(), "", m_args,
+                                              CreateMockWalletDatabase())};
+        BOOST_REQUIRE(wallet->LoadWallet() == DBErrors::LOAD_OK);
+        SetupHDWallet(*wallet, DASHSYNC_MNEMONIC);
+        return wallet;
+    }
+};
 
 //! Derived operator key records as they sit in the database, keyed by public key
 static std::map<std::vector<unsigned char>, uint32_t> ReadOperatorIndexRecords(CWallet& wallet)
@@ -235,54 +201,144 @@ BOOST_FIXTURE_TEST_CASE(walletdb_masternode_operator_key_dashsync_vector, Derivi
     BOOST_CHECK(!(next == secret));
 }
 
+//! Nothing is registered on chain yet, so no operator key is taken
+static const std::vector<std::vector<unsigned char>> NO_KEYS_IN_USE;
+
+//! Operator public key the way the wallet records it and the masternode list reports it
+static std::vector<unsigned char> OperatorPubKeyBytes(const CBLSSecretKey& secret)
+{
+    return secret.GetPublicKey().ToByteVector(/*specificLegacyScheme=*/false);
+}
+
 BOOST_FIXTURE_TEST_CASE(walletdb_masternode_operator_key_derived, DerivingWalletTestingSetup)
 {
     SetupHDWallet(m_wallet, DASHSYNC_MNEMONIC);
 
     CBLSSecretKey first;
     uint32_t first_index{std::numeric_limits<uint32_t>::max()};
-    BOOST_REQUIRE(m_wallet.DeriveNextMasternodeOperatorKey(first, first_index));
+    BOOST_REQUIRE(m_wallet.DeriveNextMasternodeOperatorKey(NO_KEYS_IN_USE, first, first_index));
     BOOST_CHECK_EQUAL(first_index, 0U);
 
     // A derived key is only recorded by its index: the seed regenerates the secret, and
     // storing it again would put a second copy of it on disk for no gain
     BOOST_CHECK_EQUAL(CountRecords(m_wallet, DBKeys::MASTERNODE_OPERATOR_INDEX), 1U);
-    BOOST_CHECK_EQUAL(CountRecords(m_wallet, DBKeys::MASTERNODE_OPERATOR_KEY), 0U);
-    BOOST_CHECK_EQUAL(CountRecords(m_wallet, DBKeys::CRYPTED_MASTERNODE_OPERATOR_KEY), 0U);
 
     const CBLSPublicKey pubkey{first.GetPublicKey()};
     BOOST_CHECK(m_wallet.HaveMasternodeOperatorKey(pubkey));
     CBLSSecretKey read;
-    BOOST_CHECK(m_wallet.GetMasternodeOperatorKey(pubkey, read));
+    std::string path;
+    BOOST_CHECK(m_wallet.GetMasternodeOperatorKey(pubkey, read, &path));
     BOOST_CHECK(read == first);
+    BOOST_CHECK_EQUAL(path, "m/9'/1'/3'/3'/0");
 
-    // The next derive must not hand out the same index again
+    // Running a second masternode off the same wallet must get its own index and its own key:
+    // two masternodes sharing an operator key would sign for each other
     CBLSSecretKey second;
     uint32_t second_index{std::numeric_limits<uint32_t>::max()};
-    BOOST_REQUIRE(m_wallet.DeriveNextMasternodeOperatorKey(second, second_index));
+    BOOST_REQUIRE(m_wallet.DeriveNextMasternodeOperatorKey(NO_KEYS_IN_USE, second, second_index));
     BOOST_CHECK_EQUAL(second_index, 1U);
     BOOST_CHECK(!(second == first));
-    BOOST_CHECK_EQUAL(m_wallet.ListMasternodeOperatorKeys().size(), 2U);
+
+    CBLSSecretKey third;
+    uint32_t third_index{std::numeric_limits<uint32_t>::max()};
+    BOOST_REQUIRE(m_wallet.DeriveNextMasternodeOperatorKey(NO_KEYS_IN_USE, third, third_index));
+    BOOST_CHECK_EQUAL(third_index, 2U);
+    BOOST_CHECK(!(third == first));
+    BOOST_CHECK(!(third == second));
+    BOOST_CHECK_EQUAL(CountRecords(m_wallet, DBKeys::MASTERNODE_OPERATOR_INDEX), 3U);
 
     // Reloading the wallet: a wallet with the same seed that reads the recorded indexes back
     // returns the very same secrets, without any secret having been written to disk
     const auto records{ReadOperatorIndexRecords(m_wallet)};
-    BOOST_CHECK_EQUAL(records.size(), 2U);
+    BOOST_CHECK_EQUAL(records.size(), 3U);
 
-    CWallet reloaded{m_node.chain.get(), m_coinjoin_loader.get(), "", m_args, CreateMockWalletDatabase()};
-    reloaded.LoadWallet();
-    SetupHDWallet(reloaded, DASHSYNC_MNEMONIC);
+    const auto reloaded{MakeRestoredWallet()};
     {
-        LOCK(reloaded.cs_wallet);
+        LOCK(reloaded->cs_wallet);
         for (const auto& record : records) {
-            BOOST_CHECK(reloaded.LoadMasternodeOperatorIndex(record.first, record.second));
+            BOOST_CHECK(reloaded->LoadMasternodeOperatorIndex(record.first, record.second));
         }
     }
     CBLSSecretKey reloaded_read;
-    BOOST_CHECK(reloaded.GetMasternodeOperatorKey(pubkey, reloaded_read));
+    BOOST_CHECK(reloaded->GetMasternodeOperatorKey(pubkey, reloaded_read));
     BOOST_CHECK(reloaded_read == first);
-    BOOST_CHECK(reloaded.GetMasternodeOperatorKey(second.GetPublicKey(), reloaded_read));
+    BOOST_CHECK(reloaded->GetMasternodeOperatorKey(second.GetPublicKey(), reloaded_read));
     BOOST_CHECK(reloaded_read == second);
+}
+
+/**
+ * A wallet restored from its recovery phrase has the seed back but no record of the indexes it
+ * handed out, so only the keys registered on chain say which ones are taken. Handing out a key
+ * one of its own masternodes already uses would make the two sign for each other.
+ */
+BOOST_FIXTURE_TEST_CASE(walletdb_masternode_operator_key_in_use, DerivingWalletTestingSetup)
+{
+    SetupHDWallet(m_wallet, DASHSYNC_MNEMONIC);
+
+    CBLSSecretKey registered;
+    uint32_t registered_index{std::numeric_limits<uint32_t>::max()};
+    BOOST_REQUIRE(m_wallet.DeriveNextMasternodeOperatorKey(NO_KEYS_IN_USE, registered, registered_index));
+    BOOST_CHECK_EQUAL(registered_index, 0U);
+
+    const auto restored{MakeRestoredWallet()};
+    BOOST_CHECK_EQUAL(CountRecords(*restored, DBKeys::MASTERNODE_OPERATOR_INDEX), 0U);
+
+    const std::vector<std::vector<unsigned char>> in_use{OperatorPubKeyBytes(registered)};
+    CBLSSecretKey next;
+    uint32_t next_index{std::numeric_limits<uint32_t>::max()};
+    BOOST_REQUIRE(restored->DeriveNextMasternodeOperatorKey(in_use, next, next_index));
+    BOOST_CHECK_EQUAL(next_index, 1U);
+    BOOST_CHECK(!(next == registered));
+
+    // Without the in-use set the restored wallet has nothing to go on and hands out index 0 again,
+    // which is exactly the collision the set is there to prevent
+    const auto blind{MakeRestoredWallet()};
+    CBLSSecretKey collision;
+    uint32_t collision_index{std::numeric_limits<uint32_t>::max()};
+    BOOST_REQUIRE(blind->DeriveNextMasternodeOperatorKey(NO_KEYS_IN_USE, collision, collision_index));
+    BOOST_CHECK_EQUAL(collision_index, 0U);
+    BOOST_CHECK(collision == registered);
+}
+
+/**
+ * Restoring the recovery phrase has to bring back the operator keys of the masternodes the wallet
+ * registered, and nothing on disk points at them any more, so they are found by walking the path.
+ */
+BOOST_FIXTURE_TEST_CASE(walletdb_masternode_operator_key_recovery_walk, DerivingWalletTestingSetup)
+{
+    SetupHDWallet(m_wallet, DASHSYNC_MNEMONIC);
+
+    CBLSSecretKey first;
+    CBLSSecretKey second;
+    uint32_t index{std::numeric_limits<uint32_t>::max()};
+    BOOST_REQUIRE(m_wallet.DeriveNextMasternodeOperatorKey(NO_KEYS_IN_USE, first, index));
+    BOOST_REQUIRE(m_wallet.DeriveNextMasternodeOperatorKey(NO_KEYS_IN_USE, second, index));
+
+    const auto restored{MakeRestoredWallet()};
+    BOOST_CHECK_EQUAL(CountRecords(*restored, DBKeys::MASTERNODE_OPERATOR_INDEX), 0U);
+    // Nothing says this key is the wallet's, but the wallet can derive, so it says it might be
+    BOOST_CHECK(restored->HaveMasternodeOperatorKey(second.GetPublicKey()));
+
+    CBLSSecretKey found;
+    std::string path;
+    BOOST_CHECK(restored->GetMasternodeOperatorKey(second.GetPublicKey(), found, &path));
+    BOOST_CHECK(found == second);
+    BOOST_CHECK_EQUAL(path, "m/9'/1'/3'/3'/1");
+
+    // The walk records what it found, so the next lookup goes straight to the index
+    BOOST_CHECK_EQUAL(CountRecords(*restored, DBKeys::MASTERNODE_OPERATOR_INDEX), 1U);
+    const auto records{ReadOperatorIndexRecords(*restored)};
+    BOOST_CHECK_EQUAL(records.size(), 1U);
+    const auto record{records.find(OperatorPubKeyBytes(second))};
+    BOOST_REQUIRE(record != records.end());
+    BOOST_CHECK_EQUAL(record->second, 1U);
+
+    // The walk is bounded, so a key far past the end of the range is reported as not ours instead
+    // of walking forever
+    CBLSSecretKey far_away;
+    BOOST_REQUIRE(restored->DeriveMasternodeOperatorKey(/*index=*/1000, far_away));
+    CBLSSecretKey not_found;
+    BOOST_CHECK(!restored->GetMasternodeOperatorKey(far_away.GetPublicKey(), not_found));
 }
 
 BOOST_FIXTURE_TEST_CASE(walletdb_masternode_operator_key_derive_locked, DerivingWalletTestingSetup)
@@ -291,34 +347,39 @@ BOOST_FIXTURE_TEST_CASE(walletdb_masternode_operator_key_derive_locked, Deriving
     BOOST_REQUIRE(m_wallet.EncryptWallet("passphrase"));
     BOOST_REQUIRE(m_wallet.IsLocked());
 
-    // The wallet still knows it could derive, it just cannot reach the seed while locked, so
-    // the caller is told to unlock instead of being pushed onto the random-key path
+    // The wallet still knows it could derive, it just cannot reach the seed while locked, so the
+    // caller is told to unlock instead of being told the key is not theirs
     BOOST_CHECK(m_wallet.CanDeriveMasternodeOperatorKey());
     SecureVector seed;
     BOOST_CHECK(!m_wallet.GetHDSeed(seed));
     CBLSSecretKey locked;
     BOOST_CHECK(!m_wallet.DeriveMasternodeOperatorKey(/*index=*/0, locked));
     uint32_t index{std::numeric_limits<uint32_t>::max()};
-    BOOST_CHECK(!m_wallet.DeriveNextMasternodeOperatorKey(locked, index));
+    BOOST_CHECK(!m_wallet.DeriveNextMasternodeOperatorKey(NO_KEYS_IN_USE, locked, index));
     BOOST_CHECK_EQUAL(CountRecords(m_wallet, DBKeys::MASTERNODE_OPERATOR_INDEX), 0U);
 
     BOOST_REQUIRE(m_wallet.Unlock("passphrase"));
-    BOOST_CHECK(m_wallet.DeriveNextMasternodeOperatorKey(locked, index));
+    BOOST_CHECK(m_wallet.DeriveNextMasternodeOperatorKey(NO_KEYS_IN_USE, locked, index));
     BOOST_CHECK_EQUAL(index, 0U);
     // Encryption must not have disturbed the seed, so the vector still holds
     BOOST_CHECK_EQUAL(HexStr(locked.ToByteVector(/*specificLegacyScheme=*/false)), DASHSYNC_OPERATOR_SECRET);
 }
 
-//! A wallet without an HD seed cannot derive, and must keep the stored-random-key path
+//! A wallet without an HD seed has no operator keys at all, and says so without deriving anything
 BOOST_AUTO_TEST_CASE(walletdb_masternode_operator_key_no_seed)
 {
     BOOST_CHECK(!m_wallet.CanDeriveMasternodeOperatorKey());
-    BOOST_CHECK(m_wallet.CanStoreMasternodeOperatorKey());
     SecureVector seed;
     BOOST_CHECK(!m_wallet.GetHDSeed(seed));
+
     CBLSSecretKey secret;
+    secret.MakeNewKey();
+    BOOST_CHECK(!m_wallet.HaveMasternodeOperatorKey(secret.GetPublicKey()));
+    CBLSSecretKey read;
+    BOOST_CHECK(!m_wallet.GetMasternodeOperatorKey(secret.GetPublicKey(), read));
+
     uint32_t index{std::numeric_limits<uint32_t>::max()};
-    BOOST_CHECK(!m_wallet.DeriveNextMasternodeOperatorKey(secret, index));
+    BOOST_CHECK(!m_wallet.DeriveNextMasternodeOperatorKey(NO_KEYS_IN_USE, secret, index));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/test/walletdb_tests.cpp
+++ b/src/wallet/test/walletdb_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <test/util/setup_common.h>
+#include <bls/bls.h>
 #include <clientversion.h>
 #include <streams.h>
 #include <uint256.h>
@@ -59,6 +60,73 @@ BOOST_AUTO_TEST_CASE(walletdb_hdchain_type_mismatch)
     strErr.clear();
     BOOST_CHECK(!TryReadHDChainRecord(m_wallet, DBKeys::CRYPTED_HDCHAIN, /*fCrypted=*/false, strErr));
     BOOST_CHECK_EQUAL(strErr, "Error reading wallet database: HD chain type mismatch");
+}
+
+//! Number of records of the given type currently in the wallet database
+static size_t CountRecords(CWallet& wallet, const std::string& type)
+{
+    std::unique_ptr<DatabaseBatch> batch{wallet.GetDatabase().MakeBatch()};
+    BOOST_REQUIRE(batch);
+    BOOST_REQUIRE(batch->StartCursor());
+    size_t count{0};
+    while (true) {
+        CDataStream key(SER_DISK, CLIENT_VERSION);
+        CDataStream value(SER_DISK, CLIENT_VERSION);
+        bool complete{false};
+        BOOST_REQUIRE(batch->ReadAtCursor(key, value, complete));
+        if (complete) break;
+        std::string record_type;
+        key >> record_type;
+        if (record_type == type) ++count;
+    }
+    batch->CloseCursor();
+    return count;
+}
+
+BOOST_AUTO_TEST_CASE(walletdb_masternode_operator_key)
+{
+    CBLSSecretKey secret;
+    secret.MakeNewKey();
+    const CBLSPublicKey pubkey{secret.GetPublicKey()};
+
+    BOOST_CHECK(m_wallet.CanStoreMasternodeOperatorKey());
+    BOOST_CHECK(!m_wallet.HaveMasternodeOperatorKey(pubkey));
+    BOOST_CHECK(m_wallet.AddMasternodeOperatorKey(secret));
+    BOOST_CHECK(m_wallet.HaveMasternodeOperatorKey(pubkey));
+    // Storing the same key again is a no-op success, so a retry cannot fail
+    BOOST_CHECK(m_wallet.AddMasternodeOperatorKey(secret));
+
+    CBLSSecretKey read;
+    BOOST_CHECK(m_wallet.GetMasternodeOperatorKey(pubkey, read));
+    BOOST_CHECK(read == secret);
+
+    // While the wallet is unencrypted the secret is stored in the clear, as
+    // private keys are
+    BOOST_CHECK_EQUAL(CountRecords(m_wallet, DBKeys::MASTERNODE_OPERATOR_KEY), 1U);
+    BOOST_CHECK_EQUAL(CountRecords(m_wallet, DBKeys::CRYPTED_MASTERNODE_OPERATOR_KEY), 0U);
+
+    // Encrypting the wallet must convert it: leaving a plaintext record behind
+    // would leak the operator key of every masternode registered before the
+    // user encrypted their wallet
+    BOOST_CHECK(m_wallet.EncryptWallet("passphrase"));
+    BOOST_CHECK_EQUAL(CountRecords(m_wallet, DBKeys::MASTERNODE_OPERATOR_KEY), 0U);
+    BOOST_CHECK_EQUAL(CountRecords(m_wallet, DBKeys::CRYPTED_MASTERNODE_OPERATOR_KEY), 1U);
+    BOOST_CHECK(m_wallet.HaveMasternodeOperatorKey(pubkey));
+
+    // A locked wallet neither hands out nor accepts secrets
+    BOOST_CHECK(m_wallet.IsLocked());
+    CBLSSecretKey locked_read;
+    BOOST_CHECK(!m_wallet.GetMasternodeOperatorKey(pubkey, locked_read));
+    CBLSSecretKey other;
+    other.MakeNewKey();
+    BOOST_CHECK(!m_wallet.AddMasternodeOperatorKey(other));
+
+    BOOST_CHECK(m_wallet.Unlock("passphrase"));
+    CBLSSecretKey unlocked_read;
+    BOOST_CHECK(m_wallet.GetMasternodeOperatorKey(pubkey, unlocked_read));
+    BOOST_CHECK(unlocked_read == secret);
+    BOOST_CHECK(m_wallet.AddMasternodeOperatorKey(other));
+    BOOST_CHECK_EQUAL(CountRecords(m_wallet, DBKeys::CRYPTED_MASTERNODE_OPERATOR_KEY), 2U);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/test/walletdb_tests.cpp
+++ b/src/wallet/test/walletdb_tests.cpp
@@ -7,11 +7,20 @@
 #include <clientversion.h>
 #include <streams.h>
 #include <uint256.h>
+#include <util/strencodings.h>
 #include <wallet/hdchain.h>
+#include <wallet/scriptpubkeyman.h>
 #include <wallet/test/wallet_test_fixture.h>
+#include <wallet/wallet.h>
 #include <wallet/walletdb.h>
 
 #include <boost/test/unit_test.hpp>
+
+#include <limits>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
 
 namespace wallet {
 BOOST_FIXTURE_TEST_SUITE(walletdb_tests, WalletTestingSetup)
@@ -127,6 +136,189 @@ BOOST_AUTO_TEST_CASE(walletdb_masternode_operator_key)
     BOOST_CHECK(unlocked_read == secret);
     BOOST_CHECK(m_wallet.AddMasternodeOperatorKey(other));
     BOOST_CHECK_EQUAL(CountRecords(m_wallet, DBKeys::CRYPTED_MASTERNODE_OPERATOR_KEY), 2U);
+}
+
+/**
+ * The masternode operator key derivation path uses coin type 5 on mainnet and 1 on every
+ * other network, so a wallet on regtest derives exactly what DashSync derives on testnet.
+ * That is what makes the known-answer test below applicable.
+ */
+struct DerivingWalletTestingSetup : public WalletTestingSetup {
+    DerivingWalletTestingSetup() : WalletTestingSetup(CBaseChainParams::REGTEST)
+    {
+        // None of these tests spend, and a default sized keypool costs a couple of thousand
+        // key derivations whenever the wallet tops up
+        gArgs.ForceSetArg("-keypool", "1");
+    }
+};
+
+/**
+ * Recovery phrase from DashSync's testCollateralProviderRegistrationTransaction
+ * (Example/Tests/DSProviderTransactionsTests.m). That test builds a ProRegTx whose payload
+ * carries the operator public key this phrase derives at index 0 on testnet:
+ *
+ *   0100 0000 0000 <collateral> ... <keyIDOwner>
+ *   157b10706659e25eb362b5d902d809f9160b1688e201ee6e94b40f9b5062d7074683ef05a2d5efb7793c47059c878dfa
+ *
+ * The payload serializes the operator key in the legacy scheme (its operatorKeyVersion is 1),
+ * which is why the legacy serialization is what gets compared here. Reproducing these bytes is
+ * the only thing that proves Dash Core and DashSync agree on the derivation, so do not
+ * "fix" this vector: if it fails, the derivation changed and mobile compatibility is broken.
+ */
+const SecureString DASHSYNC_MNEMONIC{
+    "enemy check owner stumble unaware debris suffer peanut good fabric bleak outside"};
+const std::string DASHSYNC_OPERATOR_SECRET{
+    "344e7bf67fddf1c2d2f629f2392ce2b4af99393cd8a4c70d4bbaef7aaf4c364b"};
+const std::string DASHSYNC_OPERATOR_PUBKEY_LEGACY{
+    "157b10706659e25eb362b5d902d809f9160b1688e201ee6e94b40f9b5062d7074683ef05a2d5efb7793c47059c878dfa"};
+
+//! Give a wallet the legacy HD chain a known recovery phrase produces, the way loading a
+//! wallet file does. Loading it rather than generating it keeps the keypool out of the way.
+static void SetupHDWallet(CWallet& wallet, const SecureString& mnemonic)
+{
+    CHDChain chain;
+    BOOST_REQUIRE(chain.SetMnemonic(mnemonic, /*ssMnemonicPassphrase=*/"", /*fUpdateID=*/true));
+    chain.AddAccount(); // as GenerateNewHDChain() does, so key derivation off this chain works
+
+    LOCK(wallet.cs_wallet);
+    LegacyScriptPubKeyMan* spk_man{wallet.GetOrCreateLegacyScriptPubKeyMan()};
+    BOOST_REQUIRE(spk_man != nullptr);
+    BOOST_REQUIRE(spk_man->LoadHDChain(chain));
+}
+
+//! Derived operator key records as they sit in the database, keyed by public key
+static std::map<std::vector<unsigned char>, uint32_t> ReadOperatorIndexRecords(CWallet& wallet)
+{
+    std::unique_ptr<DatabaseBatch> batch{wallet.GetDatabase().MakeBatch()};
+    BOOST_REQUIRE(batch);
+    BOOST_REQUIRE(batch->StartCursor());
+    std::map<std::vector<unsigned char>, uint32_t> records;
+    while (true) {
+        CDataStream key(SER_DISK, CLIENT_VERSION);
+        CDataStream value(SER_DISK, CLIENT_VERSION);
+        bool complete{false};
+        BOOST_REQUIRE(batch->ReadAtCursor(key, value, complete));
+        if (complete) break;
+        std::string record_type;
+        key >> record_type;
+        if (record_type != DBKeys::MASTERNODE_OPERATOR_INDEX) continue;
+        std::vector<unsigned char> pubkey;
+        uint32_t index{0};
+        key >> pubkey;
+        value >> index;
+        records.emplace(pubkey, index);
+    }
+    batch->CloseCursor();
+    return records;
+}
+
+BOOST_FIXTURE_TEST_CASE(walletdb_masternode_operator_key_dashsync_vector, DerivingWalletTestingSetup)
+{
+    SetupHDWallet(m_wallet, DASHSYNC_MNEMONIC);
+    BOOST_CHECK(m_wallet.CanDeriveMasternodeOperatorKey());
+    BOOST_CHECK_EQUAL(m_wallet.GetMasternodeOperatorKeyPath(0), "m/9'/1'/3'/3'/0");
+
+    CBLSSecretKey secret;
+    BOOST_REQUIRE(m_wallet.DeriveMasternodeOperatorKey(/*index=*/0, secret));
+    BOOST_CHECK_EQUAL(HexStr(secret.ToByteVector(/*specificLegacyScheme=*/false)), DASHSYNC_OPERATOR_SECRET);
+    BOOST_CHECK_EQUAL(HexStr(secret.GetPublicKey().ToByteVector(/*specificLegacyScheme=*/true)),
+                      DASHSYNC_OPERATOR_PUBKEY_LEGACY);
+
+    // Deriving the same index twice gives the same key, which is what lets a wallet
+    // restored from the phrase alone recover its operator keys
+    CBLSSecretKey again;
+    BOOST_REQUIRE(m_wallet.DeriveMasternodeOperatorKey(/*index=*/0, again));
+    BOOST_CHECK(again == secret);
+
+    CBLSSecretKey next;
+    BOOST_REQUIRE(m_wallet.DeriveMasternodeOperatorKey(/*index=*/1, next));
+    BOOST_CHECK(!(next == secret));
+}
+
+BOOST_FIXTURE_TEST_CASE(walletdb_masternode_operator_key_derived, DerivingWalletTestingSetup)
+{
+    SetupHDWallet(m_wallet, DASHSYNC_MNEMONIC);
+
+    CBLSSecretKey first;
+    uint32_t first_index{std::numeric_limits<uint32_t>::max()};
+    BOOST_REQUIRE(m_wallet.DeriveNextMasternodeOperatorKey(first, first_index));
+    BOOST_CHECK_EQUAL(first_index, 0U);
+
+    // A derived key is only recorded by its index: the seed regenerates the secret, and
+    // storing it again would put a second copy of it on disk for no gain
+    BOOST_CHECK_EQUAL(CountRecords(m_wallet, DBKeys::MASTERNODE_OPERATOR_INDEX), 1U);
+    BOOST_CHECK_EQUAL(CountRecords(m_wallet, DBKeys::MASTERNODE_OPERATOR_KEY), 0U);
+    BOOST_CHECK_EQUAL(CountRecords(m_wallet, DBKeys::CRYPTED_MASTERNODE_OPERATOR_KEY), 0U);
+
+    const CBLSPublicKey pubkey{first.GetPublicKey()};
+    BOOST_CHECK(m_wallet.HaveMasternodeOperatorKey(pubkey));
+    CBLSSecretKey read;
+    BOOST_CHECK(m_wallet.GetMasternodeOperatorKey(pubkey, read));
+    BOOST_CHECK(read == first);
+
+    // The next derive must not hand out the same index again
+    CBLSSecretKey second;
+    uint32_t second_index{std::numeric_limits<uint32_t>::max()};
+    BOOST_REQUIRE(m_wallet.DeriveNextMasternodeOperatorKey(second, second_index));
+    BOOST_CHECK_EQUAL(second_index, 1U);
+    BOOST_CHECK(!(second == first));
+    BOOST_CHECK_EQUAL(m_wallet.ListMasternodeOperatorKeys().size(), 2U);
+
+    // Reloading the wallet: a wallet with the same seed that reads the recorded indexes back
+    // returns the very same secrets, without any secret having been written to disk
+    const auto records{ReadOperatorIndexRecords(m_wallet)};
+    BOOST_CHECK_EQUAL(records.size(), 2U);
+
+    CWallet reloaded{m_node.chain.get(), m_coinjoin_loader.get(), "", m_args, CreateMockWalletDatabase()};
+    reloaded.LoadWallet();
+    SetupHDWallet(reloaded, DASHSYNC_MNEMONIC);
+    {
+        LOCK(reloaded.cs_wallet);
+        for (const auto& record : records) {
+            BOOST_CHECK(reloaded.LoadMasternodeOperatorIndex(record.first, record.second));
+        }
+    }
+    CBLSSecretKey reloaded_read;
+    BOOST_CHECK(reloaded.GetMasternodeOperatorKey(pubkey, reloaded_read));
+    BOOST_CHECK(reloaded_read == first);
+    BOOST_CHECK(reloaded.GetMasternodeOperatorKey(second.GetPublicKey(), reloaded_read));
+    BOOST_CHECK(reloaded_read == second);
+}
+
+BOOST_FIXTURE_TEST_CASE(walletdb_masternode_operator_key_derive_locked, DerivingWalletTestingSetup)
+{
+    SetupHDWallet(m_wallet, DASHSYNC_MNEMONIC);
+    BOOST_REQUIRE(m_wallet.EncryptWallet("passphrase"));
+    BOOST_REQUIRE(m_wallet.IsLocked());
+
+    // The wallet still knows it could derive, it just cannot reach the seed while locked, so
+    // the caller is told to unlock instead of being pushed onto the random-key path
+    BOOST_CHECK(m_wallet.CanDeriveMasternodeOperatorKey());
+    SecureVector seed;
+    BOOST_CHECK(!m_wallet.GetHDSeed(seed));
+    CBLSSecretKey locked;
+    BOOST_CHECK(!m_wallet.DeriveMasternodeOperatorKey(/*index=*/0, locked));
+    uint32_t index{std::numeric_limits<uint32_t>::max()};
+    BOOST_CHECK(!m_wallet.DeriveNextMasternodeOperatorKey(locked, index));
+    BOOST_CHECK_EQUAL(CountRecords(m_wallet, DBKeys::MASTERNODE_OPERATOR_INDEX), 0U);
+
+    BOOST_REQUIRE(m_wallet.Unlock("passphrase"));
+    BOOST_CHECK(m_wallet.DeriveNextMasternodeOperatorKey(locked, index));
+    BOOST_CHECK_EQUAL(index, 0U);
+    // Encryption must not have disturbed the seed, so the vector still holds
+    BOOST_CHECK_EQUAL(HexStr(locked.ToByteVector(/*specificLegacyScheme=*/false)), DASHSYNC_OPERATOR_SECRET);
+}
+
+//! A wallet without an HD seed cannot derive, and must keep the stored-random-key path
+BOOST_AUTO_TEST_CASE(walletdb_masternode_operator_key_no_seed)
+{
+    BOOST_CHECK(!m_wallet.CanDeriveMasternodeOperatorKey());
+    BOOST_CHECK(m_wallet.CanStoreMasternodeOperatorKey());
+    SecureVector seed;
+    BOOST_CHECK(!m_wallet.GetHDSeed(seed));
+    CBLSSecretKey secret;
+    uint32_t index{std::numeric_limits<uint32_t>::max()};
+    BOOST_CHECK(!m_wallet.DeriveNextMasternodeOperatorKey(secret, index));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3838,6 +3838,47 @@ static CBLSSecretKey MasternodeOperatorSecretKey(const CKeyingMaterial& secret)
     return CBLSSecretKey{Span<const unsigned char>{secret.data(), secret.size()}};
 }
 
+//! Levels of the masternode operator key derivation path, m/9'/coin'/3'/3'/index.
+//! This mirrors DSAuthenticationKeysDerivationPath's provider operator path in DashSync, so
+//! that a recovery phrase produces the same operator keys in Dash Core and in the mobile
+//! wallets. Only the leaf index is not hardened, again matching DashSync.
+constexpr uint32_t BIP32_HARDENED{0x80000000};
+constexpr uint32_t MASTERNODE_PROVIDER_FEATURE{3};
+constexpr uint32_t MASTERNODE_OPERATOR_SUBFEATURE{3};
+
+//! DashSync uses coin type 5 on mainnet and 1 on every other network, including devnets and
+//! regtest. Deriving with the same split is what keeps the two wallets compatible; the BIP44
+//! registered testnet coin type would give different keys.
+static uint32_t MasternodeOperatorCoinType()
+{
+    return Params().NetworkIDString() == CBaseChainParams::MAIN ? 5 : 1;
+}
+
+//! The BLS master key comes from the BIP39 seed through the Chia "BLS HD seed" construction,
+//! and every level uses the legacy child derivation. DashSync derives this way regardless of
+//! which BLS scheme is active on the network, so this must not follow the scheme either.
+static bool DeriveMasternodeOperatorSecret(const SecureVector& seed, uint32_t coin_type, uint32_t index,
+                                           CBLSSecretKey& secret)
+{
+    if (seed.empty() || index >= BIP32_HARDENED) return false;
+
+    try {
+        const auto master{bls::ExtendedPrivateKey::FromSeed(bls::Bytes{seed.data(), seed.size()})};
+        const auto derived{master.PrivateChild(BIP32_HARDENED | BIP32_PURPOSE_FEATURE, /*fLegacy=*/true)
+                               .PrivateChild(BIP32_HARDENED | coin_type, /*fLegacy=*/true)
+                               .PrivateChild(BIP32_HARDENED | MASTERNODE_PROVIDER_FEATURE, /*fLegacy=*/true)
+                               .PrivateChild(BIP32_HARDENED | MASTERNODE_OPERATOR_SUBFEATURE, /*fLegacy=*/true)
+                               .PrivateChild(index, /*fLegacy=*/true)};
+        auto secret_bytes{derived.GetPrivateKey().SerializeToArray()};
+        secret = CBLSSecretKey{Span<const unsigned char>{secret_bytes.data(), secret_bytes.size()}};
+        memory_cleanse(secret_bytes.data(), secret_bytes.size());
+        return secret.IsValid();
+    } catch (const std::exception& e) {
+        LogPrintf("%s: BLS derivation failed: %s\n", __func__, e.what());
+        return false;
+    }
+}
+
 bool CWallet::LoadMasternodeOperatorKey(const std::vector<unsigned char>& pubkey, const CKeyingMaterial& secret)
 {
     AssertLockHeld(cs_wallet);
@@ -3862,6 +3903,20 @@ bool CWallet::LoadCryptedMasternodeOperatorKey(const std::vector<unsigned char>&
     return true;
 }
 
+bool CWallet::LoadMasternodeOperatorIndex(const std::vector<unsigned char>& pubkey, uint32_t index)
+{
+    AssertLockHeld(cs_wallet);
+    CBLSPublicKey pk;
+    pk.SetBytes(pubkey, /*specificLegacyScheme=*/false);
+    if (!pk.IsValid() || index >= BIP32_HARDENED) {
+        // Whether the index really derives this public key can only be checked once the
+        // wallet is unlocked, see GetMasternodeOperatorKey()
+        return false;
+    }
+    m_mn_operator_indexes[pubkey] = index;
+    return true;
+}
+
 bool CWallet::AddMasternodeOperatorKey(const CBLSSecretKey& secret)
 {
     if (!CanStoreMasternodeOperatorKey() || !secret.IsValid()) return false;
@@ -3871,7 +3926,8 @@ bool CWallet::AddMasternodeOperatorKey(const CBLSSecretKey& secret)
     const std::vector<unsigned char> pubkey_bytes{MasternodeOperatorPubKeyBytes(pubkey)};
 
     LOCK(cs_wallet);
-    if (m_mn_operator_keys.count(pubkey_bytes) > 0 || m_mn_operator_crypted_keys.count(pubkey_bytes) > 0) {
+    if (m_mn_operator_keys.count(pubkey_bytes) > 0 || m_mn_operator_crypted_keys.count(pubkey_bytes) > 0 ||
+        m_mn_operator_indexes.count(pubkey_bytes) > 0) {
         return true;
     }
 
@@ -3900,12 +3956,23 @@ bool CWallet::AddMasternodeOperatorKey(const CBLSSecretKey& secret)
     return true;
 }
 
-bool CWallet::GetMasternodeOperatorKey(const CBLSPublicKey& pubkey, CBLSSecretKey& secret) const
+bool CWallet::GetMasternodeOperatorKey(const CBLSPublicKey& pubkey, CBLSSecretKey& secret, std::string* path) const
 {
     if (!pubkey.IsValid()) return false;
     const std::vector<unsigned char> pubkey_bytes{MasternodeOperatorPubKeyBytes(pubkey)};
+    if (path != nullptr) path->clear();
 
     LOCK(cs_wallet);
+    if (const auto it{m_mn_operator_indexes.find(pubkey_bytes)}; it != m_mn_operator_indexes.end()) {
+        // Nothing is stored for a derived key, the seed and the recorded index reproduce it
+        CBLSSecretKey derived;
+        if (!DeriveMasternodeOperatorKey(it->second, derived)) return false;
+        if (MasternodeOperatorPubKeyBytes(derived.GetPublicKey()) != pubkey_bytes) return false;
+        secret = derived;
+        if (path != nullptr) *path = GetMasternodeOperatorKeyPath(it->second);
+        return true;
+    }
+
     if (const auto it{m_mn_operator_keys.find(pubkey_bytes)}; it != m_mn_operator_keys.end()) {
         secret = MasternodeOperatorSecretKey(it->second);
         return secret.IsValid();
@@ -3932,12 +3999,103 @@ bool CWallet::HaveMasternodeOperatorKey(const CBLSPublicKey& pubkey) const
     const std::vector<unsigned char> pubkey_bytes{MasternodeOperatorPubKeyBytes(pubkey)};
 
     LOCK(cs_wallet);
-    return m_mn_operator_keys.count(pubkey_bytes) > 0 || m_mn_operator_crypted_keys.count(pubkey_bytes) > 0;
+    return m_mn_operator_keys.count(pubkey_bytes) > 0 || m_mn_operator_crypted_keys.count(pubkey_bytes) > 0 ||
+           m_mn_operator_indexes.count(pubkey_bytes) > 0;
+}
+
+std::vector<std::vector<unsigned char>> CWallet::ListMasternodeOperatorKeys() const
+{
+    LOCK(cs_wallet);
+    std::set<std::vector<unsigned char>> pubkeys;
+    for (const auto& entry : m_mn_operator_keys) pubkeys.insert(entry.first);
+    for (const auto& entry : m_mn_operator_crypted_keys) pubkeys.insert(entry.first);
+    for (const auto& entry : m_mn_operator_indexes) pubkeys.insert(entry.first);
+    return {pubkeys.begin(), pubkeys.end()};
 }
 
 bool CWallet::CanStoreMasternodeOperatorKey() const
 {
     return !IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS);
+}
+
+bool CWallet::GetHDSeed(SecureVector& seed) const
+{
+    LOCK(cs_wallet);
+    SecureVector found;
+    for (const auto& spk_man_pair : m_spk_managers) {
+        SecureVector spk_man_seed;
+        if (!spk_man_pair.second->GetBIP39Seed(spk_man_seed)) continue;
+        if (found.empty()) {
+            found = std::move(spk_man_seed);
+        } else if (found != spk_man_seed) {
+            // A wallet holding several mnemonics has no single seed to derive from
+            WalletLogPrintf("%s: wallet has more than one HD seed\n", __func__);
+            return false;
+        }
+    }
+    if (found.empty()) return false;
+
+    seed = std::move(found);
+    return true;
+}
+
+bool CWallet::HasHDSeed() const
+{
+    LOCK(cs_wallet);
+    return std::any_of(m_spk_managers.begin(), m_spk_managers.end(),
+                       [](const auto& spk_man_pair) { return spk_man_pair.second->HasBIP39Seed(); });
+}
+
+bool CWallet::CanDeriveMasternodeOperatorKey() const
+{
+    if (IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS) || IsWalletFlagSet(WALLET_FLAG_EXTERNAL_SIGNER)) {
+        return false;
+    }
+    return HasHDSeed();
+}
+
+bool CWallet::DeriveMasternodeOperatorKey(uint32_t index, CBLSSecretKey& secret) const
+{
+    SecureVector seed;
+    if (!GetHDSeed(seed)) return false;
+
+    const bool derived{DeriveMasternodeOperatorSecret(seed, MasternodeOperatorCoinType(), index, secret)};
+    memory_cleanse(seed.data(), seed.size());
+    return derived;
+}
+
+bool CWallet::DeriveNextMasternodeOperatorKey(CBLSSecretKey& secret, uint32_t& index_out)
+{
+    if (!CanDeriveMasternodeOperatorKey()) return false;
+
+    LOCK(cs_wallet);
+    // Hand out the lowest unused index so that a wallet recovered from its mnemonic walks the
+    // same path in the same order and finds the keys it handed out before
+    std::set<uint32_t> used;
+    for (const auto& entry : m_mn_operator_indexes) used.insert(entry.second);
+    uint32_t index{0};
+    while (used.count(index) > 0) ++index;
+
+    CBLSSecretKey derived;
+    if (!DeriveMasternodeOperatorKey(index, derived)) return false;
+    const CBLSPublicKey pubkey{derived.GetPublicKey()};
+    if (!pubkey.IsValid()) return false;
+    const std::vector<unsigned char> pubkey_bytes{MasternodeOperatorPubKeyBytes(pubkey)};
+
+    WalletBatch batch(GetDatabase());
+    if (!batch.WriteMasternodeOperatorIndex(pubkey_bytes, index)) return false;
+    m_mn_operator_indexes[pubkey_bytes] = index;
+
+    secret = derived;
+    index_out = index;
+    return true;
+}
+
+std::string CWallet::GetMasternodeOperatorKeyPath(uint32_t index) const
+{
+    return strprintf("m/%d'/%d'/%d'/%d'/%d", static_cast<uint32_t>(BIP32_PURPOSE_FEATURE),
+                     MasternodeOperatorCoinType(), MASTERNODE_PROVIDER_FEATURE,
+                     MASTERNODE_OPERATOR_SUBFEATURE, index);
 }
 
 bool CWallet::EncryptMasternodeOperatorKeys(const CKeyingMaterial& master_key, WalletBatch& batch)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -7,12 +7,14 @@
 #include <wallet/wallet.h>
 
 #include <blockfilter.h>
+#include <bls/bls.h>
 #include <chain.h>
 #include <chainparams.h>
 #include <consensus/amount.h>
 #include <consensus/consensus.h>
 #include <crypto/common.h>
 #include <external_signer.h>
+#include <hash.h>
 #include <interfaces/chain.h>
 #include <interfaces/wallet.h>
 #include <key.h>
@@ -850,6 +852,18 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
                 // die and let the user reload the unencrypted wallet.
                 assert(false);
             }
+        }
+
+        // Masternode operator keys are stored by this wallet but not owned by any
+        // ScriptPubKeyMan, so they have to be re-encrypted explicitly. Leaving them behind
+        // would keep them in plaintext in the database for the lifetime of the wallet.
+        if (!EncryptMasternodeOperatorKeys(_vMasterKey, *encrypted_batch)) {
+            encrypted_batch->TxnAbort();
+            delete encrypted_batch;
+            encrypted_batch = nullptr;
+            // We now probably have half of our keys encrypted in memory, and half not...
+            // die and let the user reload the unencrypted wallet.
+            assert(false);
         }
 
 
@@ -3809,6 +3823,138 @@ std::vector<const Governance::Object*> CWallet::GetGovernanceObjects()
         vecObjects.push_back(&obj.second);
     }
     return vecObjects;
+}
+
+//! Serialization used for the operator public key both as database key and as encryption IV.
+//! The basic scheme is picked explicitly because the record has to survive a scheme activation.
+static std::vector<unsigned char> MasternodeOperatorPubKeyBytes(const CBLSPublicKey& pubkey)
+{
+    return pubkey.ToByteVector(/*specificLegacyScheme=*/false);
+}
+
+static CBLSSecretKey MasternodeOperatorSecretKey(const CKeyingMaterial& secret)
+{
+    if (secret.size() != CBLSSecretKey::SerSize) return CBLSSecretKey{};
+    return CBLSSecretKey{Span<const unsigned char>{secret.data(), secret.size()}};
+}
+
+bool CWallet::LoadMasternodeOperatorKey(const std::vector<unsigned char>& pubkey, const CKeyingMaterial& secret)
+{
+    AssertLockHeld(cs_wallet);
+    const CBLSSecretKey sk{MasternodeOperatorSecretKey(secret)};
+    if (!sk.IsValid() || MasternodeOperatorPubKeyBytes(sk.GetPublicKey()) != pubkey) {
+        return false;
+    }
+    m_mn_operator_keys[pubkey] = secret;
+    return true;
+}
+
+bool CWallet::LoadCryptedMasternodeOperatorKey(const std::vector<unsigned char>& pubkey, const std::vector<unsigned char>& crypted_secret)
+{
+    AssertLockHeld(cs_wallet);
+    CBLSPublicKey pk;
+    pk.SetBytes(pubkey, /*specificLegacyScheme=*/false);
+    if (!pk.IsValid() || crypted_secret.empty()) {
+        // The secret itself can only be checked once the wallet is unlocked, see GetMasternodeOperatorKey()
+        return false;
+    }
+    m_mn_operator_crypted_keys[pubkey] = crypted_secret;
+    return true;
+}
+
+bool CWallet::AddMasternodeOperatorKey(const CBLSSecretKey& secret)
+{
+    if (!CanStoreMasternodeOperatorKey() || !secret.IsValid()) return false;
+
+    const CBLSPublicKey pubkey{secret.GetPublicKey()};
+    if (!pubkey.IsValid()) return false;
+    const std::vector<unsigned char> pubkey_bytes{MasternodeOperatorPubKeyBytes(pubkey)};
+
+    LOCK(cs_wallet);
+    if (m_mn_operator_keys.count(pubkey_bytes) > 0 || m_mn_operator_crypted_keys.count(pubkey_bytes) > 0) {
+        return true;
+    }
+
+    auto secret_bytes{secret.ToBytes(/*specificLegacyScheme=*/false)};
+    const CKeyingMaterial secret_material(secret_bytes.begin(), secret_bytes.end());
+    memory_cleanse(secret_bytes.data(), secret_bytes.size());
+
+    WalletBatch batch(GetDatabase());
+    if (!HasEncryptionKeys()) {
+        if (!batch.WriteMasternodeOperatorKey(pubkey_bytes, secret_material)) return false;
+        m_mn_operator_keys[pubkey_bytes] = secret_material;
+        return true;
+    }
+
+    // An encrypted wallet only ever holds the ciphertext, so it has to be unlocked to store a key
+    if (IsLocked(/*fForMixing=*/true)) return false;
+
+    std::vector<unsigned char> crypted_secret;
+    if (!WithEncryptionKey([&](const CKeyingMaterial& encryption_key) {
+            return EncryptSecret(encryption_key, secret_material, Hash(pubkey_bytes), crypted_secret);
+        })) {
+        return false;
+    }
+    if (!batch.WriteCryptedMasternodeOperatorKey(pubkey_bytes, crypted_secret)) return false;
+    m_mn_operator_crypted_keys[pubkey_bytes] = crypted_secret;
+    return true;
+}
+
+bool CWallet::GetMasternodeOperatorKey(const CBLSPublicKey& pubkey, CBLSSecretKey& secret) const
+{
+    if (!pubkey.IsValid()) return false;
+    const std::vector<unsigned char> pubkey_bytes{MasternodeOperatorPubKeyBytes(pubkey)};
+
+    LOCK(cs_wallet);
+    if (const auto it{m_mn_operator_keys.find(pubkey_bytes)}; it != m_mn_operator_keys.end()) {
+        secret = MasternodeOperatorSecretKey(it->second);
+        return secret.IsValid();
+    }
+
+    const auto it{m_mn_operator_crypted_keys.find(pubkey_bytes)};
+    if (it == m_mn_operator_crypted_keys.end()) return false;
+    // Handing out a plaintext secret needs a full unlock, not a mixing-only one
+    if (IsLocked()) return false;
+
+    CKeyingMaterial secret_material;
+    if (!WithEncryptionKey([&](const CKeyingMaterial& encryption_key) {
+            return DecryptSecret(encryption_key, it->second, Hash(pubkey_bytes), secret_material);
+        })) {
+        return false;
+    }
+    secret = MasternodeOperatorSecretKey(secret_material);
+    return secret.IsValid();
+}
+
+bool CWallet::HaveMasternodeOperatorKey(const CBLSPublicKey& pubkey) const
+{
+    if (!pubkey.IsValid()) return false;
+    const std::vector<unsigned char> pubkey_bytes{MasternodeOperatorPubKeyBytes(pubkey)};
+
+    LOCK(cs_wallet);
+    return m_mn_operator_keys.count(pubkey_bytes) > 0 || m_mn_operator_crypted_keys.count(pubkey_bytes) > 0;
+}
+
+bool CWallet::CanStoreMasternodeOperatorKey() const
+{
+    return !IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS);
+}
+
+bool CWallet::EncryptMasternodeOperatorKeys(const CKeyingMaterial& master_key, WalletBatch& batch)
+{
+    AssertLockHeld(cs_wallet);
+    for (const auto& [pubkey_bytes, secret] : m_mn_operator_keys) {
+        std::vector<unsigned char> crypted_secret;
+        if (!EncryptSecret(master_key, secret, Hash(pubkey_bytes), crypted_secret)) {
+            return false;
+        }
+        if (!batch.WriteCryptedMasternodeOperatorKey(pubkey_bytes, crypted_secret)) {
+            return false;
+        }
+        m_mn_operator_crypted_keys[pubkey_bytes] = crypted_secret;
+    }
+    m_mn_operator_keys.clear();
+    return true;
 }
 
 CKeyPool::CKeyPool()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -14,7 +14,6 @@
 #include <consensus/consensus.h>
 #include <crypto/common.h>
 #include <external_signer.h>
-#include <hash.h>
 #include <interfaces/chain.h>
 #include <interfaces/wallet.h>
 #include <key.h>
@@ -853,19 +852,6 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
                 assert(false);
             }
         }
-
-        // Masternode operator keys are stored by this wallet but not owned by any
-        // ScriptPubKeyMan, so they have to be re-encrypted explicitly. Leaving them behind
-        // would keep them in plaintext in the database for the lifetime of the wallet.
-        if (!EncryptMasternodeOperatorKeys(_vMasterKey, *encrypted_batch)) {
-            encrypted_batch->TxnAbort();
-            delete encrypted_batch;
-            encrypted_batch = nullptr;
-            // We now probably have half of our keys encrypted in memory, and half not...
-            // die and let the user reload the unencrypted wallet.
-            assert(false);
-        }
-
 
         // Encryption was introduced in version 0.4.0
         SetMinVersion(FEATURE_WALLETCRYPT, encrypted_batch);
@@ -3825,17 +3811,12 @@ std::vector<const Governance::Object*> CWallet::GetGovernanceObjects()
     return vecObjects;
 }
 
-//! Serialization used for the operator public key both as database key and as encryption IV.
-//! The basic scheme is picked explicitly because the record has to survive a scheme activation.
+//! Serialization used for the operator public key as a database key and when comparing against the
+//! operator keys registered on chain. The basic scheme is picked explicitly because the record has
+//! to survive a scheme activation.
 static std::vector<unsigned char> MasternodeOperatorPubKeyBytes(const CBLSPublicKey& pubkey)
 {
     return pubkey.ToByteVector(/*specificLegacyScheme=*/false);
-}
-
-static CBLSSecretKey MasternodeOperatorSecretKey(const CKeyingMaterial& secret)
-{
-    if (secret.size() != CBLSSecretKey::SerSize) return CBLSSecretKey{};
-    return CBLSSecretKey{Span<const unsigned char>{secret.data(), secret.size()}};
 }
 
 //! Levels of the masternode operator key derivation path, m/9'/coin'/3'/3'/index.
@@ -3846,6 +3827,16 @@ constexpr uint32_t BIP32_HARDENED{0x80000000};
 constexpr uint32_t MASTERNODE_PROVIDER_FEATURE{3};
 constexpr uint32_t MASTERNODE_OPERATOR_SUBFEATURE{3};
 
+//! How many indexes of the operator path this wallet walks. A wallet restored from its recovery
+//! phrase alone holds no record of the keys it handed out, so re-deriving the path is the only way
+//! back to them: without this walk, restoring the phrase would not restore the operator keys of the
+//! masternodes the wallet registered. The same bound applies when handing out a new index, so that
+//! no key is ever handed out that the walk could not find again. One index costs a child derivation
+//! plus the public key it is compared against, measured at about a tenth of a millisecond, so a
+//! full walk stays in the tens of milliseconds: short enough for a GUI action, and far more
+//! masternodes than one wallet is expected to operate.
+constexpr uint32_t MASTERNODE_OPERATOR_KEY_LIMIT{500};
+
 //! DashSync uses coin type 5 on mainnet and 1 on every other network, including devnets and
 //! regtest. Deriving with the same split is what keeps the two wallets compatible; the BIP44
 //! registered testnet coin type would give different keys.
@@ -3854,24 +3845,37 @@ static uint32_t MasternodeOperatorCoinType()
     return Params().NetworkIDString() == CBaseChainParams::MAIN ? 5 : 1;
 }
 
-//! The BLS master key comes from the BIP39 seed through the Chia "BLS HD seed" construction,
-//! and every level uses the legacy child derivation. DashSync derives this way regardless of
-//! which BLS scheme is active on the network, so this must not follow the scheme either.
+//! The account level of the operator path, m/9'/coin'/3'/3'. The BLS master key comes from the
+//! BIP39 seed through the Chia "BLS HD seed" construction, and every level uses the legacy child
+//! derivation. DashSync derives this way regardless of which BLS scheme is active on the network,
+//! so this must not follow the scheme either. Deriving the account on its own is what lets a walk
+//! over many indexes pay for one child derivation per index instead of five.
+static bls::ExtendedPrivateKey DeriveMasternodeOperatorAccount(const SecureVector& seed, uint32_t coin_type)
+{
+    return bls::ExtendedPrivateKey::FromSeed(bls::Bytes{seed.data(), seed.size()})
+        .PrivateChild(BIP32_HARDENED | BIP32_PURPOSE_FEATURE, /*fLegacy=*/true)
+        .PrivateChild(BIP32_HARDENED | coin_type, /*fLegacy=*/true)
+        .PrivateChild(BIP32_HARDENED | MASTERNODE_PROVIDER_FEATURE, /*fLegacy=*/true)
+        .PrivateChild(BIP32_HARDENED | MASTERNODE_OPERATOR_SUBFEATURE, /*fLegacy=*/true);
+}
+
+//! The leaf level of the operator path. Its index is the only one that is not hardened, again
+//! matching DashSync.
+static CBLSSecretKey DeriveMasternodeOperatorLeaf(const bls::ExtendedPrivateKey& account, uint32_t index)
+{
+    auto secret_bytes{account.PrivateChild(index, /*fLegacy=*/true).GetPrivateKey().SerializeToArray()};
+    CBLSSecretKey secret{Span<const unsigned char>{secret_bytes.data(), secret_bytes.size()}};
+    memory_cleanse(secret_bytes.data(), secret_bytes.size());
+    return secret;
+}
+
 static bool DeriveMasternodeOperatorSecret(const SecureVector& seed, uint32_t coin_type, uint32_t index,
                                            CBLSSecretKey& secret)
 {
     if (seed.empty() || index >= BIP32_HARDENED) return false;
 
     try {
-        const auto master{bls::ExtendedPrivateKey::FromSeed(bls::Bytes{seed.data(), seed.size()})};
-        const auto derived{master.PrivateChild(BIP32_HARDENED | BIP32_PURPOSE_FEATURE, /*fLegacy=*/true)
-                               .PrivateChild(BIP32_HARDENED | coin_type, /*fLegacy=*/true)
-                               .PrivateChild(BIP32_HARDENED | MASTERNODE_PROVIDER_FEATURE, /*fLegacy=*/true)
-                               .PrivateChild(BIP32_HARDENED | MASTERNODE_OPERATOR_SUBFEATURE, /*fLegacy=*/true)
-                               .PrivateChild(index, /*fLegacy=*/true)};
-        auto secret_bytes{derived.GetPrivateKey().SerializeToArray()};
-        secret = CBLSSecretKey{Span<const unsigned char>{secret_bytes.data(), secret_bytes.size()}};
-        memory_cleanse(secret_bytes.data(), secret_bytes.size());
+        secret = DeriveMasternodeOperatorLeaf(DeriveMasternodeOperatorAccount(seed, coin_type), index);
         return secret.IsValid();
     } catch (const std::exception& e) {
         LogPrintf("%s: BLS derivation failed: %s\n", __func__, e.what());
@@ -3879,28 +3883,28 @@ static bool DeriveMasternodeOperatorSecret(const SecureVector& seed, uint32_t co
     }
 }
 
-bool CWallet::LoadMasternodeOperatorKey(const std::vector<unsigned char>& pubkey, const CKeyingMaterial& secret)
+//! Derive the operator secrets at indexes 0 to count - 1 in turn, handing each index and the secret
+//! it derives to `visit` and stopping as soon as `visit` returns false. Returns false when the
+//! derivation itself failed, which the callers report as "unlock the wallet".
+static bool WalkMasternodeOperatorSecrets(const SecureVector& seed, uint32_t coin_type, uint32_t count,
+                                          const std::function<bool(uint32_t, const CBLSSecretKey&)>& visit)
 {
-    AssertLockHeld(cs_wallet);
-    const CBLSSecretKey sk{MasternodeOperatorSecretKey(secret)};
-    if (!sk.IsValid() || MasternodeOperatorPubKeyBytes(sk.GetPublicKey()) != pubkey) {
-        return false;
-    }
-    m_mn_operator_keys[pubkey] = secret;
-    return true;
-}
+    if (seed.empty()) return false;
+    // The leaf index is not hardened, so the walk must stay below the hardened range
+    count = std::min(count, BIP32_HARDENED);
 
-bool CWallet::LoadCryptedMasternodeOperatorKey(const std::vector<unsigned char>& pubkey, const std::vector<unsigned char>& crypted_secret)
-{
-    AssertLockHeld(cs_wallet);
-    CBLSPublicKey pk;
-    pk.SetBytes(pubkey, /*specificLegacyScheme=*/false);
-    if (!pk.IsValid() || crypted_secret.empty()) {
-        // The secret itself can only be checked once the wallet is unlocked, see GetMasternodeOperatorKey()
+    try {
+        const bls::ExtendedPrivateKey account{DeriveMasternodeOperatorAccount(seed, coin_type)};
+        for (uint32_t index{0}; index < count; ++index) {
+            const CBLSSecretKey secret{DeriveMasternodeOperatorLeaf(account, index)};
+            if (!secret.IsValid()) return false;
+            if (!visit(index, secret)) break;
+        }
+        return true;
+    } catch (const std::exception& e) {
+        LogPrintf("%s: BLS derivation failed: %s\n", __func__, e.what());
         return false;
     }
-    m_mn_operator_crypted_keys[pubkey] = crypted_secret;
-    return true;
 }
 
 bool CWallet::LoadMasternodeOperatorIndex(const std::vector<unsigned char>& pubkey, uint32_t index)
@@ -3917,50 +3921,11 @@ bool CWallet::LoadMasternodeOperatorIndex(const std::vector<unsigned char>& pubk
     return true;
 }
 
-bool CWallet::AddMasternodeOperatorKey(const CBLSSecretKey& secret)
+bool CWallet::GetMasternodeOperatorKey(const CBLSPublicKey& pubkey, CBLSSecretKey& secret, std::string* path)
 {
-    if (!CanStoreMasternodeOperatorKey() || !secret.IsValid()) return false;
-
-    const CBLSPublicKey pubkey{secret.GetPublicKey()};
-    if (!pubkey.IsValid()) return false;
-    const std::vector<unsigned char> pubkey_bytes{MasternodeOperatorPubKeyBytes(pubkey)};
-
-    LOCK(cs_wallet);
-    if (m_mn_operator_keys.count(pubkey_bytes) > 0 || m_mn_operator_crypted_keys.count(pubkey_bytes) > 0 ||
-        m_mn_operator_indexes.count(pubkey_bytes) > 0) {
-        return true;
-    }
-
-    auto secret_bytes{secret.ToBytes(/*specificLegacyScheme=*/false)};
-    const CKeyingMaterial secret_material(secret_bytes.begin(), secret_bytes.end());
-    memory_cleanse(secret_bytes.data(), secret_bytes.size());
-
-    WalletBatch batch(GetDatabase());
-    if (!HasEncryptionKeys()) {
-        if (!batch.WriteMasternodeOperatorKey(pubkey_bytes, secret_material)) return false;
-        m_mn_operator_keys[pubkey_bytes] = secret_material;
-        return true;
-    }
-
-    // An encrypted wallet only ever holds the ciphertext, so it has to be unlocked to store a key
-    if (IsLocked(/*fForMixing=*/true)) return false;
-
-    std::vector<unsigned char> crypted_secret;
-    if (!WithEncryptionKey([&](const CKeyingMaterial& encryption_key) {
-            return EncryptSecret(encryption_key, secret_material, Hash(pubkey_bytes), crypted_secret);
-        })) {
-        return false;
-    }
-    if (!batch.WriteCryptedMasternodeOperatorKey(pubkey_bytes, crypted_secret)) return false;
-    m_mn_operator_crypted_keys[pubkey_bytes] = crypted_secret;
-    return true;
-}
-
-bool CWallet::GetMasternodeOperatorKey(const CBLSPublicKey& pubkey, CBLSSecretKey& secret, std::string* path) const
-{
-    if (!pubkey.IsValid()) return false;
-    const std::vector<unsigned char> pubkey_bytes{MasternodeOperatorPubKeyBytes(pubkey)};
     if (path != nullptr) path->clear();
+    if (!pubkey.IsValid() || !CanDeriveMasternodeOperatorKey()) return false;
+    const std::vector<unsigned char> pubkey_bytes{MasternodeOperatorPubKeyBytes(pubkey)};
 
     LOCK(cs_wallet);
     if (const auto it{m_mn_operator_indexes.find(pubkey_bytes)}; it != m_mn_operator_indexes.end()) {
@@ -3973,49 +3938,46 @@ bool CWallet::GetMasternodeOperatorKey(const CBLSPublicKey& pubkey, CBLSSecretKe
         return true;
     }
 
-    if (const auto it{m_mn_operator_keys.find(pubkey_bytes)}; it != m_mn_operator_keys.end()) {
-        secret = MasternodeOperatorSecretKey(it->second);
-        return secret.IsValid();
+    // No record points at this key. The wallet may have been restored from its recovery phrase,
+    // which brings back the seed but not the indexes the wallet handed out, so walk the path to
+    // find the index this key came from.
+    SecureVector seed;
+    if (!GetHDSeed(seed)) return false;
+
+    CBLSSecretKey found;
+    uint32_t found_index{0};
+    const bool walked{WalkMasternodeOperatorSecrets(
+        seed, MasternodeOperatorCoinType(), MASTERNODE_OPERATOR_KEY_LIMIT,
+        [&](uint32_t index, const CBLSSecretKey& candidate) {
+            if (MasternodeOperatorPubKeyBytes(candidate.GetPublicKey()) != pubkey_bytes) return true;
+            found = candidate;
+            found_index = index;
+            return false;
+        })};
+    memory_cleanse(seed.data(), seed.size());
+    if (!walked || !found.IsValid()) return false;
+
+    // Record the index so that the next lookup of this key does not walk the path again. Failing
+    // to write it costs nothing but that speedup, so the key is still handed out.
+    WalletBatch batch(GetDatabase());
+    if (batch.WriteMasternodeOperatorIndex(pubkey_bytes, found_index)) {
+        m_mn_operator_indexes[pubkey_bytes] = found_index;
     }
 
-    const auto it{m_mn_operator_crypted_keys.find(pubkey_bytes)};
-    if (it == m_mn_operator_crypted_keys.end()) return false;
-    // Handing out a plaintext secret needs a full unlock, not a mixing-only one
-    if (IsLocked()) return false;
-
-    CKeyingMaterial secret_material;
-    if (!WithEncryptionKey([&](const CKeyingMaterial& encryption_key) {
-            return DecryptSecret(encryption_key, it->second, Hash(pubkey_bytes), secret_material);
-        })) {
-        return false;
-    }
-    secret = MasternodeOperatorSecretKey(secret_material);
-    return secret.IsValid();
+    secret = found;
+    if (path != nullptr) *path = GetMasternodeOperatorKeyPath(found_index);
+    return true;
 }
 
 bool CWallet::HaveMasternodeOperatorKey(const CBLSPublicKey& pubkey) const
 {
     if (!pubkey.IsValid()) return false;
-    const std::vector<unsigned char> pubkey_bytes{MasternodeOperatorPubKeyBytes(pubkey)};
 
     LOCK(cs_wallet);
-    return m_mn_operator_keys.count(pubkey_bytes) > 0 || m_mn_operator_crypted_keys.count(pubkey_bytes) > 0 ||
-           m_mn_operator_indexes.count(pubkey_bytes) > 0;
-}
-
-std::vector<std::vector<unsigned char>> CWallet::ListMasternodeOperatorKeys() const
-{
-    LOCK(cs_wallet);
-    std::set<std::vector<unsigned char>> pubkeys;
-    for (const auto& entry : m_mn_operator_keys) pubkeys.insert(entry.first);
-    for (const auto& entry : m_mn_operator_crypted_keys) pubkeys.insert(entry.first);
-    for (const auto& entry : m_mn_operator_indexes) pubkeys.insert(entry.first);
-    return {pubkeys.begin(), pubkeys.end()};
-}
-
-bool CWallet::CanStoreMasternodeOperatorKey() const
-{
-    return !IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS);
+    if (m_mn_operator_indexes.count(MasternodeOperatorPubKeyBytes(pubkey)) > 0) return true;
+    // Without a record the question can only be answered by deriving, which a locked wallet cannot
+    // do, so answer optimistically: GetMasternodeOperatorKey() is the one that reports precisely
+    return CanDeriveMasternodeOperatorKey();
 }
 
 bool CWallet::GetHDSeed(SecureVector& seed) const
@@ -4064,30 +4026,44 @@ bool CWallet::DeriveMasternodeOperatorKey(uint32_t index, CBLSSecretKey& secret)
     return derived;
 }
 
-bool CWallet::DeriveNextMasternodeOperatorKey(CBLSSecretKey& secret, uint32_t& index_out)
+bool CWallet::DeriveNextMasternodeOperatorKey(const std::vector<std::vector<unsigned char>>& in_use,
+                                              CBLSSecretKey& secret, uint32_t& index_out)
 {
     if (!CanDeriveMasternodeOperatorKey()) return false;
 
     LOCK(cs_wallet);
-    // Hand out the lowest unused index so that a wallet recovered from its mnemonic walks the
-    // same path in the same order and finds the keys it handed out before
-    std::set<uint32_t> used;
-    for (const auto& entry : m_mn_operator_indexes) used.insert(entry.second);
-    uint32_t index{0};
-    while (used.count(index) > 0) ++index;
+    SecureVector seed;
+    if (!GetHDSeed(seed)) return false;
 
-    CBLSSecretKey derived;
-    if (!DeriveMasternodeOperatorKey(index, derived)) return false;
-    const CBLSPublicKey pubkey{derived.GetPublicKey()};
-    if (!pubkey.IsValid()) return false;
-    const std::vector<unsigned char> pubkey_bytes{MasternodeOperatorPubKeyBytes(pubkey)};
+    // Hand out the lowest index whose key neither this wallet has handed out nor any masternode is
+    // using. Skipping the keys in use is what keeps two masternodes apart after a recovery from the
+    // mnemonic alone: the restored wallet has no records left, so on-chain registrations are the
+    // only trace of the indexes it handed out before.
+    std::set<std::vector<unsigned char>> taken{in_use.begin(), in_use.end()};
+    for (const auto& [pubkey_bytes, index] : m_mn_operator_indexes) taken.insert(pubkey_bytes);
+
+    CBLSSecretKey found;
+    uint32_t found_index{0};
+    std::vector<unsigned char> found_pubkey;
+    const bool walked{WalkMasternodeOperatorSecrets(
+        seed, MasternodeOperatorCoinType(), MASTERNODE_OPERATOR_KEY_LIMIT,
+        [&](uint32_t index, const CBLSSecretKey& candidate) {
+            std::vector<unsigned char> candidate_pubkey{MasternodeOperatorPubKeyBytes(candidate.GetPublicKey())};
+            if (taken.count(candidate_pubkey) > 0) return true;
+            found = candidate;
+            found_index = index;
+            found_pubkey = std::move(candidate_pubkey);
+            return false;
+        })};
+    memory_cleanse(seed.data(), seed.size());
+    if (!walked || !found.IsValid()) return false;
 
     WalletBatch batch(GetDatabase());
-    if (!batch.WriteMasternodeOperatorIndex(pubkey_bytes, index)) return false;
-    m_mn_operator_indexes[pubkey_bytes] = index;
+    if (!batch.WriteMasternodeOperatorIndex(found_pubkey, found_index)) return false;
+    m_mn_operator_indexes[found_pubkey] = found_index;
 
-    secret = derived;
-    index_out = index;
+    secret = found;
+    index_out = found_index;
     return true;
 }
 
@@ -4096,23 +4072,6 @@ std::string CWallet::GetMasternodeOperatorKeyPath(uint32_t index) const
     return strprintf("m/%d'/%d'/%d'/%d'/%d", static_cast<uint32_t>(BIP32_PURPOSE_FEATURE),
                      MasternodeOperatorCoinType(), MASTERNODE_PROVIDER_FEATURE,
                      MASTERNODE_OPERATOR_SUBFEATURE, index);
-}
-
-bool CWallet::EncryptMasternodeOperatorKeys(const CKeyingMaterial& master_key, WalletBatch& batch)
-{
-    AssertLockHeld(cs_wallet);
-    for (const auto& [pubkey_bytes, secret] : m_mn_operator_keys) {
-        std::vector<unsigned char> crypted_secret;
-        if (!EncryptSecret(master_key, secret, Hash(pubkey_bytes), crypted_secret)) {
-            return false;
-        }
-        if (!batch.WriteCryptedMasternodeOperatorKey(pubkey_bytes, crypted_secret)) {
-            return false;
-        }
-        m_mn_operator_crypted_keys[pubkey_bytes] = crypted_secret;
-    }
-    m_mn_operator_keys.clear();
-    return true;
 }
 
 CKeyPool::CKeyPool()

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -49,6 +49,8 @@
 
 #include <boost/signals2/signal.hpp>
 
+class CBLSPublicKey;
+class CBLSSecretKey;
 class CKey;
 class CScript;
 class CTxDSIn;
@@ -424,6 +426,18 @@ private:
 
     //! Whether the CoinJoin client is mixing with this wallet
     std::atomic<bool> m_mixing{false};
+
+    /** Masternode operator BLS secret keys stored in this wallet, keyed by the serialized
+     *  (basic scheme) public key. Plaintext secrets are only held for a wallet without
+     *  encryption keys, an encrypted wallet holds the ciphertext and decrypts on use.
+     */
+    std::map<std::vector<unsigned char>, CKeyingMaterial> m_mn_operator_keys GUARDED_BY(cs_wallet);
+    std::map<std::vector<unsigned char>, std::vector<unsigned char>> m_mn_operator_crypted_keys GUARDED_BY(cs_wallet);
+
+    /** Re-encrypt the operator keys stored while this wallet was still unencrypted. Only used
+     *  by EncryptWallet(), which supplies the freshly created master key.
+     */
+    bool EncryptMasternodeOperatorKeys(const CKeyingMaterial& master_key, WalletBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /** Height of last block processed is used by wallet to know depth of transactions
      * without relying on Chain interface beyond asynchronous updates. For safety, we
@@ -996,6 +1010,24 @@ public:
     bool WriteGovernanceObject(const Governance::Object& obj) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     /** Returns a vector containing pointers to the governance objects in m_gobjects */
     std::vector<const Governance::Object*> GetGovernanceObjects() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+
+    /** Load a plaintext masternode operator secret key from the wallet database. Returns false
+     *  if the record does not describe a usable key, in which case it is dropped. */
+    bool LoadMasternodeOperatorKey(const std::vector<unsigned char>& pubkey, const CKeyingMaterial& secret) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    /** Load an encrypted masternode operator secret key from the wallet database. The ciphertext
+     *  can only be checked once the wallet is unlocked, so this only validates the public key. */
+    bool LoadCryptedMasternodeOperatorKey(const std::vector<unsigned char>& pubkey, const std::vector<unsigned char>& crypted_secret) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+
+    /** Store a masternode operator secret key, keyed by its public key, so that it is covered by
+     *  wallet backups. An encrypted wallet stores the secret encrypted and must be unlocked. */
+    bool AddMasternodeOperatorKey(const CBLSSecretKey& secret);
+    /** Retrieve a stored masternode operator secret key. Decrypts on demand, so an encrypted
+     *  wallet must be unlocked. */
+    bool GetMasternodeOperatorKey(const CBLSPublicKey& pubkey, CBLSSecretKey& secret) const;
+    /** Whether an operator secret key for the given public key is stored in this wallet. */
+    bool HaveMasternodeOperatorKey(const CBLSPublicKey& pubkey) const;
+    /** Whether this wallet can store operator secret keys at all. */
+    bool CanStoreMasternodeOperatorKey() const;
 
     /**
      * Blocks until the wallet state is up-to-date to /at least/ the current

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -427,24 +427,12 @@ private:
     //! Whether the CoinJoin client is mixing with this wallet
     std::atomic<bool> m_mixing{false};
 
-    /** Masternode operator BLS secret keys stored in this wallet, keyed by the serialized
-     *  (basic scheme) public key. Plaintext secrets are only held for a wallet without
-     *  encryption keys, an encrypted wallet holds the ciphertext and decrypts on use.
-     */
-    std::map<std::vector<unsigned char>, CKeyingMaterial> m_mn_operator_keys GUARDED_BY(cs_wallet);
-    std::map<std::vector<unsigned char>, std::vector<unsigned char>> m_mn_operator_crypted_keys GUARDED_BY(cs_wallet);
-
-    /** Masternode operator BLS keys derived from this wallet's HD seed, mapping the same
-     *  serialized public key to the derivation index it came from. No secret is kept: the
+    /** Masternode operator BLS keys derived from this wallet's HD seed, mapping the serialized
+     *  (basic scheme) public key to the derivation index it came from. No secret is kept: the
      *  seed plus the index reproduce it, which is also what makes these keys survive a
      *  recovery from the mnemonic alone.
      */
     std::map<std::vector<unsigned char>, uint32_t> m_mn_operator_indexes GUARDED_BY(cs_wallet);
-
-    /** Re-encrypt the operator keys stored while this wallet was still unencrypted. Only used
-     *  by EncryptWallet(), which supplies the freshly created master key.
-     */
-    bool EncryptMasternodeOperatorKeys(const CKeyingMaterial& master_key, WalletBatch& batch) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /** Height of last block processed is used by wallet to know depth of transactions
      * without relying on Chain interface beyond asynchronous updates. For safety, we
@@ -1018,33 +1006,22 @@ public:
     /** Returns a vector containing pointers to the governance objects in m_gobjects */
     std::vector<const Governance::Object*> GetGovernanceObjects() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
-    /** Load a plaintext masternode operator secret key from the wallet database. Returns false
-     *  if the record does not describe a usable key, in which case it is dropped. */
-    bool LoadMasternodeOperatorKey(const std::vector<unsigned char>& pubkey, const CKeyingMaterial& secret) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
-    /** Load an encrypted masternode operator secret key from the wallet database. The ciphertext
-     *  can only be checked once the wallet is unlocked, so this only validates the public key. */
-    bool LoadCryptedMasternodeOperatorKey(const std::vector<unsigned char>& pubkey, const std::vector<unsigned char>& crypted_secret) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     /** Load the derivation index of a masternode operator key derived from this wallet's HD
      *  seed. The recorded key itself can only be checked once the wallet is unlocked, so this
      *  only validates the public key. */
     bool LoadMasternodeOperatorIndex(const std::vector<unsigned char>& pubkey, uint32_t index) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
-    /** Store a masternode operator secret key, keyed by its public key, so that it is covered by
-     *  wallet backups. An encrypted wallet stores the secret encrypted and must be unlocked. */
-    bool AddMasternodeOperatorKey(const CBLSSecretKey& secret);
-    /** Retrieve a masternode operator secret key this wallet holds, whether it was derived from
-     *  the HD seed or stored outright. Derives or decrypts on demand, so an encrypted wallet
-     *  must be unlocked. */
-    //! Fetch an operator secret this wallet holds. When `path` is given it is filled with the
-    //! derivation path for a key derived from the HD seed, and left empty for a stored one.
+    /** Fetch the operator secret behind the given public key, either from the recorded derivation
+     *  index or, when no record points at it, by walking a bounded range of indexes so that a
+     *  wallet restored from its recovery phrase alone still finds the keys of the masternodes it
+     *  registered. A key found by walking is recorded, so the next lookup is immediate. When
+     *  `path` is given it comes back holding the derivation path. Requires an unlocked wallet. */
     bool GetMasternodeOperatorKey(const CBLSPublicKey& pubkey, CBLSSecretKey& secret,
-                                  std::string* path = nullptr) const;
-    /** Whether an operator secret key for the given public key is held by this wallet. */
+                                  std::string* path = nullptr);
+    /** Whether this wallet can produce the operator secret behind the given public key. Cheap and
+     *  unlock-free, so it answers optimistically for a wallet that can derive but holds no record
+     *  of this key: only GetMasternodeOperatorKey() can tell for sure. */
     bool HaveMasternodeOperatorKey(const CBLSPublicKey& pubkey) const;
-    /** Public keys of every operator key this wallet holds, derived and stored alike. */
-    std::vector<std::vector<unsigned char>> ListMasternodeOperatorKeys() const;
-    /** Whether this wallet can store operator secret keys at all. */
-    bool CanStoreMasternodeOperatorKey() const;
 
     /** The BIP39 seed shared by this wallet's ScriptPubKeyMans. Fails for a locked wallet, one
      *  without private keys, and one built from more than one mnemonic, which has no single
@@ -1052,15 +1029,20 @@ public:
     bool GetHDSeed(SecureVector& seed) const;
     /** Whether GetHDSeed() can succeed once this wallet is unlocked. */
     bool HasHDSeed() const;
-    /** Whether operator keys can be derived from this wallet's HD seed, as opposed to being
-     *  generated at random and stored. Does not require an unlocked wallet. */
+    /** Whether operator keys can be derived from this wallet's HD seed. Does not require an
+     *  unlocked wallet. */
     bool CanDeriveMasternodeOperatorKey() const;
     /** Derive the operator key at the given index off this wallet's HD seed. Requires an
      *  unlocked wallet. */
     bool DeriveMasternodeOperatorKey(uint32_t index, CBLSSecretKey& secret) const;
-    /** Derive the lowest operator key index this wallet has not handed out yet, record the
-     *  index so the key can be found again, and return both. Requires an unlocked wallet. */
-    bool DeriveNextMasternodeOperatorKey(CBLSSecretKey& secret, uint32_t& index_out);
+    /** Derive the lowest operator key index that neither this wallet has handed out nor any
+     *  masternode in `in_use` occupies, record the index so the key can be found again, and
+     *  return both. `in_use` holds the serialized (basic scheme) operator public keys registered
+     *  on chain, which is what keeps a wallet restored from its recovery phrase, and therefore
+     *  holding no records, from handing out a key one of its masternodes already uses. Requires
+     *  an unlocked wallet. */
+    bool DeriveNextMasternodeOperatorKey(const std::vector<std::vector<unsigned char>>& in_use,
+                                         CBLSSecretKey& secret, uint32_t& index_out);
     /** Human readable derivation path of the operator key at the given index. */
     std::string GetMasternodeOperatorKeyPath(uint32_t index) const;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -434,6 +434,13 @@ private:
     std::map<std::vector<unsigned char>, CKeyingMaterial> m_mn_operator_keys GUARDED_BY(cs_wallet);
     std::map<std::vector<unsigned char>, std::vector<unsigned char>> m_mn_operator_crypted_keys GUARDED_BY(cs_wallet);
 
+    /** Masternode operator BLS keys derived from this wallet's HD seed, mapping the same
+     *  serialized public key to the derivation index it came from. No secret is kept: the
+     *  seed plus the index reproduce it, which is also what makes these keys survive a
+     *  recovery from the mnemonic alone.
+     */
+    std::map<std::vector<unsigned char>, uint32_t> m_mn_operator_indexes GUARDED_BY(cs_wallet);
+
     /** Re-encrypt the operator keys stored while this wallet was still unencrypted. Only used
      *  by EncryptWallet(), which supplies the freshly created master key.
      */
@@ -1017,17 +1024,45 @@ public:
     /** Load an encrypted masternode operator secret key from the wallet database. The ciphertext
      *  can only be checked once the wallet is unlocked, so this only validates the public key. */
     bool LoadCryptedMasternodeOperatorKey(const std::vector<unsigned char>& pubkey, const std::vector<unsigned char>& crypted_secret) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    /** Load the derivation index of a masternode operator key derived from this wallet's HD
+     *  seed. The recorded key itself can only be checked once the wallet is unlocked, so this
+     *  only validates the public key. */
+    bool LoadMasternodeOperatorIndex(const std::vector<unsigned char>& pubkey, uint32_t index) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /** Store a masternode operator secret key, keyed by its public key, so that it is covered by
      *  wallet backups. An encrypted wallet stores the secret encrypted and must be unlocked. */
     bool AddMasternodeOperatorKey(const CBLSSecretKey& secret);
-    /** Retrieve a stored masternode operator secret key. Decrypts on demand, so an encrypted
-     *  wallet must be unlocked. */
-    bool GetMasternodeOperatorKey(const CBLSPublicKey& pubkey, CBLSSecretKey& secret) const;
-    /** Whether an operator secret key for the given public key is stored in this wallet. */
+    /** Retrieve a masternode operator secret key this wallet holds, whether it was derived from
+     *  the HD seed or stored outright. Derives or decrypts on demand, so an encrypted wallet
+     *  must be unlocked. */
+    //! Fetch an operator secret this wallet holds. When `path` is given it is filled with the
+    //! derivation path for a key derived from the HD seed, and left empty for a stored one.
+    bool GetMasternodeOperatorKey(const CBLSPublicKey& pubkey, CBLSSecretKey& secret,
+                                  std::string* path = nullptr) const;
+    /** Whether an operator secret key for the given public key is held by this wallet. */
     bool HaveMasternodeOperatorKey(const CBLSPublicKey& pubkey) const;
+    /** Public keys of every operator key this wallet holds, derived and stored alike. */
+    std::vector<std::vector<unsigned char>> ListMasternodeOperatorKeys() const;
     /** Whether this wallet can store operator secret keys at all. */
     bool CanStoreMasternodeOperatorKey() const;
+
+    /** The BIP39 seed shared by this wallet's ScriptPubKeyMans. Fails for a locked wallet, one
+     *  without private keys, and one built from more than one mnemonic, which has no single
+     *  seed to derive from. */
+    bool GetHDSeed(SecureVector& seed) const;
+    /** Whether GetHDSeed() can succeed once this wallet is unlocked. */
+    bool HasHDSeed() const;
+    /** Whether operator keys can be derived from this wallet's HD seed, as opposed to being
+     *  generated at random and stored. Does not require an unlocked wallet. */
+    bool CanDeriveMasternodeOperatorKey() const;
+    /** Derive the operator key at the given index off this wallet's HD seed. Requires an
+     *  unlocked wallet. */
+    bool DeriveMasternodeOperatorKey(uint32_t index, CBLSSecretKey& secret) const;
+    /** Derive the lowest operator key index this wallet has not handed out yet, record the
+     *  index so the key can be found again, and return both. Requires an unlocked wallet. */
+    bool DeriveNextMasternodeOperatorKey(CBLSSecretKey& secret, uint32_t& index_out);
+    /** Human readable derivation path of the operator key at the given index. */
+    std::string GetMasternodeOperatorKeyPath(uint32_t index) const;
 
     /**
      * Blocks until the wallet state is up-to-date to /at least/ the current

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -38,6 +38,7 @@ const std::string BESTBLOCK_NOMERKLE{"bestblock_nomerkle"};
 const std::string BESTBLOCK{"bestblock"};
 const std::string CRYPTED_KEY{"ckey"};
 const std::string CRYPTED_HDCHAIN{"chdchain"};
+const std::string CRYPTED_MASTERNODE_OPERATOR_KEY{"mnopckey"};
 const std::string COINJOIN_PENDING_OBS{"cj_pending_obs"};
 const std::string COINJOIN_SALT{"cj_salt"};
 const std::string CSCRIPT{"cscript"};
@@ -51,6 +52,7 @@ const std::string KEYMETA{"keymeta"};
 const std::string KEY{"key"};
 const std::string LOCKED_UTXO{"lockedutxo"};
 const std::string MASTER_KEY{"mkey"};
+const std::string MASTERNODE_OPERATOR_KEY{"mnopkey"};
 const std::string MINVERSION{"minversion"};
 const std::string NAME{"name"};
 const std::string OLD_KEY{"wkey"};
@@ -242,6 +244,20 @@ bool WalletBatch::WriteCoinJoinPendingObs(const std::map<COutPoint, int64_t>& pe
     return WriteIC(DBKeys::COINJOIN_PENDING_OBS, pending_obs);
 }
 
+bool WalletBatch::WriteMasternodeOperatorKey(const std::vector<unsigned char>& pubkey, const CKeyingMaterial& secret)
+{
+    return WriteIC(std::make_pair(DBKeys::MASTERNODE_OPERATOR_KEY, pubkey), secret);
+}
+
+bool WalletBatch::WriteCryptedMasternodeOperatorKey(const std::vector<unsigned char>& pubkey, const std::vector<unsigned char>& crypted_secret)
+{
+    if (!WriteIC(std::make_pair(DBKeys::CRYPTED_MASTERNODE_OPERATOR_KEY, pubkey), crypted_secret)) {
+        return false;
+    }
+    EraseIC(std::make_pair(DBKeys::MASTERNODE_OPERATOR_KEY, pubkey));
+    return true;
+}
+
 bool WalletBatch::WriteGovernanceObject(const Governance::Object& obj)
 {
     return WriteIC(std::make_pair(DBKeys::G_OBJECT, obj.GetHash()), obj, false);
@@ -355,6 +371,8 @@ public:
     std::map<std::pair<uint256, CKeyID>, std::pair<CPubKey, std::vector<unsigned char>>> m_descriptor_crypt_keys;
     std::map<std::pair<uint256, CKeyID>, std::pair<SecureString, SecureString>> mnemonics;
     std::map<std::pair<uint256, CKeyID>, std::pair<std::vector<unsigned char>, std::vector<unsigned char>>> crypted_mnemonics;
+    std::map<std::vector<unsigned char>, CKeyingMaterial> m_mn_operator_keys;
+    std::map<std::vector<unsigned char>, std::vector<unsigned char>> m_mn_operator_crypted_keys;
     bool tx_corrupt{false};
 
     CWalletScanState() = default;
@@ -787,6 +805,18 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
                 wss.crypted_mnemonics.insert(std::make_pair(std::make_pair(desc_id, pubkey.GetID()), std::make_pair(mnemonic, mnemonic_passphrase)));
             }
 
+        } else if (strType == DBKeys::MASTERNODE_OPERATOR_KEY) {
+            std::vector<unsigned char> pubkey;
+            ssKey >> pubkey;
+            CKeyingMaterial secret;
+            ssValue >> secret;
+            wss.m_mn_operator_keys[pubkey] = secret;
+        } else if (strType == DBKeys::CRYPTED_MASTERNODE_OPERATOR_KEY) {
+            std::vector<unsigned char> pubkey;
+            ssKey >> pubkey;
+            std::vector<unsigned char> crypted_secret;
+            ssValue >> crypted_secret;
+            wss.m_mn_operator_crypted_keys[pubkey] = crypted_secret;
         } else if (strType == DBKeys::LOCKED_UTXO) {
             uint256 hash;
             uint32_t n;
@@ -967,6 +997,21 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
             ((DescriptorScriptPubKeyMan*)spk_man)->AddCryptedKey(desc_key_pair.first.second, desc_key_pair.second.first, desc_key_pair.second.second, {}, {});
         } else {
             ((DescriptorScriptPubKeyMan*)spk_man)->AddCryptedKey(desc_key_pair.first.second, desc_key_pair.second.first, desc_key_pair.second.second, it->second.first, it->second.second);
+        }
+    }
+
+    // Set the masternode operator keys. Losing one of these costs a masternode re-registration
+    // and no funds, so a record that cannot be loaded is skipped instead of failing the load.
+    for (const auto& [pubkey, crypted_secret] : wss.m_mn_operator_crypted_keys) {
+        if (!pwallet->LoadCryptedMasternodeOperatorKey(pubkey, crypted_secret)) {
+            pwallet->WalletLogPrintf("Ignoring unusable encrypted masternode operator key record\n");
+        }
+    }
+    for (const auto& [pubkey, secret] : wss.m_mn_operator_keys) {
+        // The encrypted record supersedes a plaintext one left behind by an interrupted encryption
+        if (wss.m_mn_operator_crypted_keys.count(pubkey) > 0) continue;
+        if (!pwallet->LoadMasternodeOperatorKey(pubkey, secret)) {
+            pwallet->WalletLogPrintf("Ignoring unusable masternode operator key record\n");
         }
     }
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -52,6 +52,7 @@ const std::string KEYMETA{"keymeta"};
 const std::string KEY{"key"};
 const std::string LOCKED_UTXO{"lockedutxo"};
 const std::string MASTER_KEY{"mkey"};
+const std::string MASTERNODE_OPERATOR_INDEX{"mnopidx"};
 const std::string MASTERNODE_OPERATOR_KEY{"mnopkey"};
 const std::string MINVERSION{"minversion"};
 const std::string NAME{"name"};
@@ -258,6 +259,11 @@ bool WalletBatch::WriteCryptedMasternodeOperatorKey(const std::vector<unsigned c
     return true;
 }
 
+bool WalletBatch::WriteMasternodeOperatorIndex(const std::vector<unsigned char>& pubkey, uint32_t index)
+{
+    return WriteIC(std::make_pair(DBKeys::MASTERNODE_OPERATOR_INDEX, pubkey), index);
+}
+
 bool WalletBatch::WriteGovernanceObject(const Governance::Object& obj)
 {
     return WriteIC(std::make_pair(DBKeys::G_OBJECT, obj.GetHash()), obj, false);
@@ -373,6 +379,7 @@ public:
     std::map<std::pair<uint256, CKeyID>, std::pair<std::vector<unsigned char>, std::vector<unsigned char>>> crypted_mnemonics;
     std::map<std::vector<unsigned char>, CKeyingMaterial> m_mn_operator_keys;
     std::map<std::vector<unsigned char>, std::vector<unsigned char>> m_mn_operator_crypted_keys;
+    std::map<std::vector<unsigned char>, uint32_t> m_mn_operator_indexes;
     bool tx_corrupt{false};
 
     CWalletScanState() = default;
@@ -817,6 +824,12 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             std::vector<unsigned char> crypted_secret;
             ssValue >> crypted_secret;
             wss.m_mn_operator_crypted_keys[pubkey] = crypted_secret;
+        } else if (strType == DBKeys::MASTERNODE_OPERATOR_INDEX) {
+            std::vector<unsigned char> pubkey;
+            ssKey >> pubkey;
+            uint32_t index;
+            ssValue >> index;
+            wss.m_mn_operator_indexes[pubkey] = index;
         } else if (strType == DBKeys::LOCKED_UTXO) {
             uint256 hash;
             uint32_t n;
@@ -1012,6 +1025,11 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
         if (wss.m_mn_operator_crypted_keys.count(pubkey) > 0) continue;
         if (!pwallet->LoadMasternodeOperatorKey(pubkey, secret)) {
             pwallet->WalletLogPrintf("Ignoring unusable masternode operator key record\n");
+        }
+    }
+    for (const auto& [pubkey, index] : wss.m_mn_operator_indexes) {
+        if (!pwallet->LoadMasternodeOperatorIndex(pubkey, index)) {
+            pwallet->WalletLogPrintf("Ignoring unusable derived masternode operator key record\n");
         }
     }
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -38,7 +38,6 @@ const std::string BESTBLOCK_NOMERKLE{"bestblock_nomerkle"};
 const std::string BESTBLOCK{"bestblock"};
 const std::string CRYPTED_KEY{"ckey"};
 const std::string CRYPTED_HDCHAIN{"chdchain"};
-const std::string CRYPTED_MASTERNODE_OPERATOR_KEY{"mnopckey"};
 const std::string COINJOIN_PENDING_OBS{"cj_pending_obs"};
 const std::string COINJOIN_SALT{"cj_salt"};
 const std::string CSCRIPT{"cscript"};
@@ -53,7 +52,6 @@ const std::string KEY{"key"};
 const std::string LOCKED_UTXO{"lockedutxo"};
 const std::string MASTER_KEY{"mkey"};
 const std::string MASTERNODE_OPERATOR_INDEX{"mnopidx"};
-const std::string MASTERNODE_OPERATOR_KEY{"mnopkey"};
 const std::string MINVERSION{"minversion"};
 const std::string NAME{"name"};
 const std::string OLD_KEY{"wkey"};
@@ -245,20 +243,6 @@ bool WalletBatch::WriteCoinJoinPendingObs(const std::map<COutPoint, int64_t>& pe
     return WriteIC(DBKeys::COINJOIN_PENDING_OBS, pending_obs);
 }
 
-bool WalletBatch::WriteMasternodeOperatorKey(const std::vector<unsigned char>& pubkey, const CKeyingMaterial& secret)
-{
-    return WriteIC(std::make_pair(DBKeys::MASTERNODE_OPERATOR_KEY, pubkey), secret);
-}
-
-bool WalletBatch::WriteCryptedMasternodeOperatorKey(const std::vector<unsigned char>& pubkey, const std::vector<unsigned char>& crypted_secret)
-{
-    if (!WriteIC(std::make_pair(DBKeys::CRYPTED_MASTERNODE_OPERATOR_KEY, pubkey), crypted_secret)) {
-        return false;
-    }
-    EraseIC(std::make_pair(DBKeys::MASTERNODE_OPERATOR_KEY, pubkey));
-    return true;
-}
-
 bool WalletBatch::WriteMasternodeOperatorIndex(const std::vector<unsigned char>& pubkey, uint32_t index)
 {
     return WriteIC(std::make_pair(DBKeys::MASTERNODE_OPERATOR_INDEX, pubkey), index);
@@ -377,8 +361,6 @@ public:
     std::map<std::pair<uint256, CKeyID>, std::pair<CPubKey, std::vector<unsigned char>>> m_descriptor_crypt_keys;
     std::map<std::pair<uint256, CKeyID>, std::pair<SecureString, SecureString>> mnemonics;
     std::map<std::pair<uint256, CKeyID>, std::pair<std::vector<unsigned char>, std::vector<unsigned char>>> crypted_mnemonics;
-    std::map<std::vector<unsigned char>, CKeyingMaterial> m_mn_operator_keys;
-    std::map<std::vector<unsigned char>, std::vector<unsigned char>> m_mn_operator_crypted_keys;
     std::map<std::vector<unsigned char>, uint32_t> m_mn_operator_indexes;
     bool tx_corrupt{false};
 
@@ -812,18 +794,6 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
                 wss.crypted_mnemonics.insert(std::make_pair(std::make_pair(desc_id, pubkey.GetID()), std::make_pair(mnemonic, mnemonic_passphrase)));
             }
 
-        } else if (strType == DBKeys::MASTERNODE_OPERATOR_KEY) {
-            std::vector<unsigned char> pubkey;
-            ssKey >> pubkey;
-            CKeyingMaterial secret;
-            ssValue >> secret;
-            wss.m_mn_operator_keys[pubkey] = secret;
-        } else if (strType == DBKeys::CRYPTED_MASTERNODE_OPERATOR_KEY) {
-            std::vector<unsigned char> pubkey;
-            ssKey >> pubkey;
-            std::vector<unsigned char> crypted_secret;
-            ssValue >> crypted_secret;
-            wss.m_mn_operator_crypted_keys[pubkey] = crypted_secret;
         } else if (strType == DBKeys::MASTERNODE_OPERATOR_INDEX) {
             std::vector<unsigned char> pubkey;
             ssKey >> pubkey;
@@ -1015,18 +985,6 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
 
     // Set the masternode operator keys. Losing one of these costs a masternode re-registration
     // and no funds, so a record that cannot be loaded is skipped instead of failing the load.
-    for (const auto& [pubkey, crypted_secret] : wss.m_mn_operator_crypted_keys) {
-        if (!pwallet->LoadCryptedMasternodeOperatorKey(pubkey, crypted_secret)) {
-            pwallet->WalletLogPrintf("Ignoring unusable encrypted masternode operator key record\n");
-        }
-    }
-    for (const auto& [pubkey, secret] : wss.m_mn_operator_keys) {
-        // The encrypted record supersedes a plaintext one left behind by an interrupted encryption
-        if (wss.m_mn_operator_crypted_keys.count(pubkey) > 0) continue;
-        if (!pwallet->LoadMasternodeOperatorKey(pubkey, secret)) {
-            pwallet->WalletLogPrintf("Ignoring unusable masternode operator key record\n");
-        }
-    }
     for (const auto& [pubkey, index] : wss.m_mn_operator_indexes) {
         if (!pwallet->LoadMasternodeOperatorIndex(pubkey, index)) {
             pwallet->WalletLogPrintf("Ignoring unusable derived masternode operator key record\n");

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -8,7 +8,6 @@
 
 #include <script/sign.h>
 #include <script/standard.h>
-#include <wallet/crypter.h>
 #include <wallet/db.h>
 #include <wallet/walletutil.h>
 #include <key.h>
@@ -70,7 +69,6 @@ extern const std::string BESTBLOCK;
 extern const std::string BESTBLOCK_NOMERKLE;
 extern const std::string CRYPTED_HDCHAIN;
 extern const std::string CRYPTED_KEY;
-extern const std::string CRYPTED_MASTERNODE_OPERATOR_KEY;
 extern const std::string COINJOIN_PENDING_OBS;
 extern const std::string COINJOIN_SALT;
 extern const std::string CSCRIPT;
@@ -85,7 +83,6 @@ extern const std::string KEYMETA;
 extern const std::string LOCKED_UTXO;
 extern const std::string MASTER_KEY;
 extern const std::string MASTERNODE_OPERATOR_INDEX;
-extern const std::string MASTERNODE_OPERATOR_KEY;
 extern const std::string MINVERSION;
 extern const std::string NAME;
 extern const std::string OLD_KEY;
@@ -230,15 +227,10 @@ public:
     bool ReadCoinJoinPendingObs(std::map<COutPoint, int64_t>& pending_obs);
     bool WriteCoinJoinPendingObs(const std::map<COutPoint, int64_t>& pending_obs);
 
-    /** Masternode operator BLS secret keys, keyed by the serialized (basic scheme) public key
-     *  so that keys for several masternodes can coexist in one wallet. Writing the encrypted
-     *  record removes the plaintext one for the same public key. */
-    bool WriteMasternodeOperatorKey(const std::vector<unsigned char>& pubkey, const CKeyingMaterial& secret);
-    bool WriteCryptedMasternodeOperatorKey(const std::vector<unsigned char>& pubkey, const std::vector<unsigned char>& crypted_secret);
-
-    /** Derivation index of a masternode operator key derived from this wallet's HD seed, keyed
-     *  by the same serialized public key. The secret is never written for these: the seed and
-     *  this index reproduce it, and a wallet backup already covers the seed. */
+    /** Derivation index of a masternode operator key derived from this wallet's HD seed, keyed by
+     *  the serialized (basic scheme) public key, so that the keys of several masternodes can
+     *  coexist in one wallet. The secret is never written: the seed and this index reproduce it,
+     *  and a wallet backup already covers the seed. */
     bool WriteMasternodeOperatorIndex(const std::vector<unsigned char>& pubkey, uint32_t index);
 
     /** Write a CGovernanceObject to the database */

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -8,6 +8,7 @@
 
 #include <script/sign.h>
 #include <script/standard.h>
+#include <wallet/crypter.h>
 #include <wallet/db.h>
 #include <wallet/walletutil.h>
 #include <key.h>
@@ -69,6 +70,7 @@ extern const std::string BESTBLOCK;
 extern const std::string BESTBLOCK_NOMERKLE;
 extern const std::string CRYPTED_HDCHAIN;
 extern const std::string CRYPTED_KEY;
+extern const std::string CRYPTED_MASTERNODE_OPERATOR_KEY;
 extern const std::string COINJOIN_PENDING_OBS;
 extern const std::string COINJOIN_SALT;
 extern const std::string CSCRIPT;
@@ -82,6 +84,7 @@ extern const std::string KEY;
 extern const std::string KEYMETA;
 extern const std::string LOCKED_UTXO;
 extern const std::string MASTER_KEY;
+extern const std::string MASTERNODE_OPERATOR_KEY;
 extern const std::string MINVERSION;
 extern const std::string NAME;
 extern const std::string OLD_KEY;
@@ -225,6 +228,12 @@ public:
     bool HasCoinJoinPendingObs();
     bool ReadCoinJoinPendingObs(std::map<COutPoint, int64_t>& pending_obs);
     bool WriteCoinJoinPendingObs(const std::map<COutPoint, int64_t>& pending_obs);
+
+    /** Masternode operator BLS secret keys, keyed by the serialized (basic scheme) public key
+     *  so that keys for several masternodes can coexist in one wallet. Writing the encrypted
+     *  record removes the plaintext one for the same public key. */
+    bool WriteMasternodeOperatorKey(const std::vector<unsigned char>& pubkey, const CKeyingMaterial& secret);
+    bool WriteCryptedMasternodeOperatorKey(const std::vector<unsigned char>& pubkey, const std::vector<unsigned char>& crypted_secret);
 
     /** Write a CGovernanceObject to the database */
     bool WriteGovernanceObject(const Governance::Object& obj);

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -84,6 +84,7 @@ extern const std::string KEY;
 extern const std::string KEYMETA;
 extern const std::string LOCKED_UTXO;
 extern const std::string MASTER_KEY;
+extern const std::string MASTERNODE_OPERATOR_INDEX;
 extern const std::string MASTERNODE_OPERATOR_KEY;
 extern const std::string MINVERSION;
 extern const std::string NAME;
@@ -234,6 +235,11 @@ public:
      *  record removes the plaintext one for the same public key. */
     bool WriteMasternodeOperatorKey(const std::vector<unsigned char>& pubkey, const CKeyingMaterial& secret);
     bool WriteCryptedMasternodeOperatorKey(const std::vector<unsigned char>& pubkey, const std::vector<unsigned char>& crypted_secret);
+
+    /** Derivation index of a masternode operator key derived from this wallet's HD seed, keyed
+     *  by the same serialized public key. The secret is never written for these: the seed and
+     *  this index reproduce it, and a wallet backup already covers the seed. */
+    bool WriteMasternodeOperatorIndex(const std::vector<unsigned char>& pubkey, uint32_t index);
 
     /** Write a CGovernanceObject to the database */
     bool WriteGovernanceObject(const Governance::Object& obj);


### PR DESCRIPTION
## Issue being fixed or feature implemented

dash-qt has never had an action-oriented masternode UI — the legacy "start alias" GUI was removed with the legacy masternode code (#2600), and today's Masternodes tab is a read-only list. Meanwhile #7437 adds shared (multi-party) masternodes, whose multi-step, multi-wallet RPC flows (`register_shared_prepare` → `shared_sign` → `shared_combine` → funding signatures → broadcast) are impractical to drive by hand from the debug console for the non-expert participants they are designed for.

**Stacked on #7437.** This PR's base is the #7437 branch, so it shows only the 14 GUI commits; it will be retargeted to `develop` once #7437 merges.

## What was done?

GUI for creating and maintaining masternodes, evonodes and shared masternodes, stacked on #7437:

- **Recognition** (`interfaces` + list): `MnEntry` exposes the shared state (share table, penalty terms); the masternode list gets a "Shared" type, type filter, share-aware text search and owned-row attribution via share owner keys (`keyIDOwner` is null for shared MNs); the details dialog shows the share table with per-share amounts/addresses, "(you)" markers, penalty terms and the early-period countdown.
- **`ProTxSender`**: worker-thread bridge that drives the wallet-side protx RPC handlers in-process with named arguments (`executeRpc` is synchronous and takes wallet/validation locks, so it stays off the GUI thread) and translates consensus reject strings into actionable messages. The write path deliberately reuses the RPC layer as its contract instead of extracting #7437's file-static tx-assembly helpers into typed interfaces — that refactor would enlarge the base PR's review surface and conflict with every #7437 push while it is still under review; typed `interfaces::Wallet` protx virtuals are the intended follow-up once #7437 merges.
- **Registration wizard** for regular masternodes and evonodes with all three collateral paths: fund from wallet (`register_fund`), existing exact-denomination UTXO (`register`), and external/hardware-held collateral (`register_prepare` → out-of-band message signing → `register_submit`). Generates owner/voting addresses and the operator BLS keypair (or accepts a hosting provider's public key); the operator secret is shown exactly once behind a type-back confirmation with the matching `masternodeblsprivkey` dash.conf line.
- **Maintenance dialogs**: Update Service (incl. evonode platform fields; mandatory fee source for shared MNs), Update Registrar (never offered for shared MNs; PoSe-ban warning on operator change), Revoke (reason dropdown, de-dramatized copy).
- **Shared masternode creation** as a resumable session dialog (not a wizard — the flow is asynchronous and multi-wallet): a JSON session envelope passes between participants; the share-table editor mirrors `IsShareListTriviallyValid` live; funding uses a chip model (each participant contributes one output of exactly their share; the coordinator adds the fee input and takes the only change) so the final transaction is verifiable at a glance; **every imported signature is verified natively at import time** against the recomputed consent hash, so signing a stale draft is caught immediately with who must re-sign, instead of surfacing as `bad-protx-shares-sig` at broadcast; contributed coins are locked in the wallet and the session is declared dead if a funding input gets spent.
- **Shared maintenance/dissolution**: per-share reward-address change; unanimous operator/voting rotation (pinned to the prepare wallet whose fee inputs the transaction spends); dissolution with a live payout preview mirroring the consensus split math, an explicit early-penalty acceptance, and a **standby pair** generator — one transaction broadcastable immediately (pays the penalty forever, since the penalty is baked into the outputs at build time) and one penalty-free transaction valid from the early-period boundary — with the Dissolve menu entry warning until both are saved.
- Unit tests for the session engine (validation mirror, envelope round-trip, payout preview vs consensus math, import-time signature verification incl. stale-signature rejection).

Shared-MN entry points are gated on v24 activation at the tip (`Node::isV24Active()`), with explanatory tooltips pre-activation.

## How Has This Been Tested?

- Built on macOS (arm64, Qt 5.15); `test_dash-qt` passes incl. the new `MnShareSessionTests`.
- Driven manually against a regtest datadir produced by `feature_masternode_shares.py` with v24 active and a live 3-share shared masternode; screenshots below.
- `lint-qt-translation`, `lint-include-guards`, `lint-format-strings`, `lint-whitespace`, `lint-circular-dependencies` all clean.

## Breaking Changes

None. GUI-only on top of #7437; no RPC or consensus changes.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have assigned this pull request to a milestone
